### PR TITLE
Release 1.2 — Research Dataset Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > **A production-oriented quantitative research platform for acquiring and persisting real-world market data, built with C#/.NET and an AI-assisted engineering workflow.**
 
 [![Release](https://img.shields.io/badge/release-1.1-blue)](https://github.com/samuel-santos-engineer/AIQuantTradingResearch/milestones)
-[![Tests](<https://img.shields.io/badge/tests-145%20passing-brightgreen>)](https://github.com/samuel-santos-engineer/AIQuantTradingResearch/tree/main/tests)
+[![Tests](<https://img.shields.io/badge/tests-171%20passing-brightgreen>)](https://github.com/samuel-santos-engineer/AIQuantTradingResearch/tree/main/tests)
 [![Architecture Tests](<https://img.shields.io/badge/architecture%20tests-13%20passing-brightgreen>)](https://github.com/samuel-santos-engineer/AIQuantTradingResearch/tree/main/tests/AIQuantTradingResearch.Architecture.Tests)
 [![.NET](https://img.shields.io/badge/.NET-C%23-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
@@ -14,7 +14,7 @@ AIQuantTradingResearch is an open-source engineering project for building a quan
 
 The project is intentionally broader than a collection of trading algorithms or ML experiments. It demonstrates how market-data capabilities can be designed as a maintainable software platform while creating a foundation for later quantitative analytics, AI/ML research, observability, resilience, and cloud-native operation.
 
-**Current completed milestone:** **Release 1.1 — Market Data Persistence Foundation**
+**Current in-progress milestone:** **Release 1.2 — Research Dataset Foundation**
 
 [What Works Today](#what-works-today) · [Architecture](#architecture) · [Run &amp; Verify](#run--verify) · [Engineering Evidence](#engineering-evidence) · [Roadmap](#engineering-capability-journey) · [Engineering Handbook](#engineering-handbook)
 
@@ -55,11 +55,26 @@ The current implementation can:
 - Compose acquisition and persistence through an externally configured Worker execution root.
 - Validate architectural boundaries with executable architecture tests.
 
-### Release 1.1 quality baseline
+### Release 1.2 current foundation
+
+Release 1.2 builds on Release 1.1 historical observations. It materializes one
+exact-target, `[from,to)` research dataset definition into immutable SQLite
+snapshot/catalog evidence. Definitions are ordered by semantic instant; empty
+selection is valid; original offsets and decimal values are preserved. The
+`aiq-dataset-identity-v1` scheme uses deterministic SHA-256-backed identities
+for the definition, research dataset, source state, and snapshot; the snapshot
+identity is also the immutable dataset version. Re-running equivalent evidence
+is recognized without overwrite, while conflicts remain explicit.
+
+The Worker has one externally configured bounded dataset execution using
+`Persistence:DatabasePath`, `Dataset:Target`, `Dataset:From`, and `Dataset:To`.
+It is not a scheduler, refresh loop, or Release 1.3 pipeline.
+
+### Release 1.2 quality baseline
 
 | Evidence                                    |      Current baseline |
 | ------------------------------------------- | --------------------: |
-| Permanent automated tests                   | **145 passing** |
+| Permanent automated tests                   | **171 passing** |
 | Architecture tests                          |  **13 passing** |
 | Build warnings                              |           **0** |
 | Build errors                                |           **0** |

--- a/docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md
+++ b/docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md
@@ -1,0 +1,415 @@
+# Dataset Identity, Version, and Provenance Semantics
+
+**Status:** Accepted for Release 1.2 WP03
+
+**Scope:** Research Dataset Foundation
+
+**Technology boundary:** Provider-, storage-, and implementation-independent
+
+## Purpose and authority
+
+This document converts the accepted
+`RESEARCH_DATASET_DEFINITION.md` model into deterministic identity, version,
+provenance, and lineage semantics. It specifies meaning and normative identity
+inputs without defining Application contracts, catalog objects, physical
+storage, or executable hashing code.
+
+Release 1.1 accepted historical observations remain the source authority.
+Release 1.2 does not change their exact-target identity, absolute-instant
+identity, original-offset fidelity, exact decimal fidelity, immutable-history
+behavior, or ascending retrieval semantics.
+
+## Vocabulary
+
+### Dataset Definition Identity
+
+The deterministic semantic identity of one declarative dataset definition. It
+changes exactly when the definition's meaning changes and is independent of
+materialization or source-history state.
+
+### Research Dataset Identity
+
+The stable logical identity of the research dataset family defined by one
+dataset definition. It remains stable across distinguishable snapshots of that
+definition. It is a separately typed identity derived from the same definition
+semantics and is not an alias for a mutable "latest" snapshot.
+
+### Source State
+
+The exact ordered sequence of accepted Release 1.1 observations selected by a
+dataset definition at materialization. The empty ordered sequence is a valid
+source state.
+
+### Source-State Identity
+
+The deterministic semantic identity of a relevant source state, including its
+exact target and ordered observation content.
+
+### Dataset Snapshot Identity
+
+The deterministic identity of one immutable semantic materialization result,
+derived from its definition identity and source-state identity under an
+explicit identity scheme.
+
+### Dataset Version
+
+The immutable semantic version of a research dataset snapshot. In Release 1.2,
+the authoritative version is the snapshot's deterministic identity, not a
+timestamp or mutable sequence number.
+
+### Semantic Identity
+
+Identity determined only by the meaning of an artifact under an explicit
+identity scheme, excluding incidental execution or storage facts.
+
+### Semantic Equivalence
+
+Equality of all normative semantic inputs for the relevant identity layer
+under the same identity scheme.
+
+### Provenance
+
+Evidence explaining the authoritative definition and relevant accepted source
+state from which a snapshot was materialized.
+
+### Lineage
+
+The derivation relationship connecting a snapshot to one definition, one
+relevant source state, and the zero or more accepted observations composing
+that state.
+
+### Canonical Semantic Representation
+
+The unambiguous, culture-independent, versioned representation of normative
+semantic values used as digest input. It is not a storage serialization.
+
+### Digest / Fingerprint
+
+A content-derived cryptographic digest used as compact deterministic identity
+evidence. It is not authentication, authorization, encryption, or proof that
+collisions are mathematically impossible.
+
+### Algorithm/Representation Version
+
+The explicit identity-scheme identifier that fixes the canonicalization rules,
+type domain, digest algorithm, and textual interpretation for an identity.
+
+## Identity layers
+
+| Layer | Stable across | Changes when | Normative basis |
+| --- | --- | --- | --- |
+| Dataset Definition Identity | Repeated use of an equivalent definition | Any definition semantic changes | Exact target, `[from, to)` instants, inclusion/order rules, parameters, definition-model version |
+| Research Dataset Identity | All snapshots of one equivalent definition | The dataset definition changes | Separately typed digest over definition semantics |
+| Source-State Identity | Equivalent relevant accepted history | Selected target, membership, order, instant, offset, or decimal value changes | Exact target plus ordered selected observations |
+| Dataset Snapshot Identity / Version | Equivalent re-materializations | Definition identity or source-state identity changes | Typed digest over definition and source-state identities |
+
+Identity types are not interchangeable even when they use the same digest
+algorithm. Type-specific domain separators prevent a definition, logical
+dataset, source state, and snapshot from sharing an identity accidentally.
+
+## Definition and logical dataset identity
+
+Two definitions are semantically equivalent only when all these facts match:
+
+1. exact target using ordinal, case-sensitive target semantics;
+2. lower and upper boundary semantic instants;
+3. inclusive-lower/exclusive-upper `[from, to)` interpretation;
+4. strict ascending semantic-instant ordering rule;
+5. every authorized deterministic definition parameter; and
+6. the definition semantic-model version.
+
+Boundary identity uses the absolute semantic instant. Different display offsets
+that denote the same boundary instant do not change selection meaning and do
+not create a different definition. Source-observation offsets remain distinct
+normative content as required below.
+
+The Dataset Definition Identity and Research Dataset Identity are separately
+typed deterministic fingerprints over the same definition semantics. The
+logical Research Dataset Identity groups immutable snapshot versions without
+creating mutable latest-state semantics.
+
+Creation or execution time, display formatting, JSON ordering or whitespace,
+machine/process identity, file or database paths, connection strings, culture,
+and local timezone do not participate.
+
+## Source-state identity
+
+The relevant source state is the exact sequence selected by the definition,
+strictly ordered by ascending absolute semantic instant. Its identity covers:
+
+- the exact target;
+- the explicit observation count; and
+- for every ordered observation:
+  - absolute semantic instant;
+  - original offset representation; and
+  - exact positive decimal price value.
+
+Target and count make the source state independently interpretable. Count also
+distinguishes structural boundaries in the ordered sequence. The empty state is
+encoded with the exact target and an explicit zero count, so it has a stable,
+unambiguous identity.
+
+SQLite row identifiers, insertion order, natural database order, database file
+location, provider DTO identity, provider response order, and execution time
+are excluded.
+
+## Snapshot identity and dataset version
+
+Snapshot identity is derived from:
+
+1. the explicit snapshot identity-scheme version;
+2. the Dataset Definition Identity; and
+3. the Source-State Identity.
+
+The ordered content need not be duplicated in snapshot digest input because it
+is already committed by the source-state identity. Stored or returned snapshot
+content must nevertheless agree with both identities; disagreement is an
+integrity conflict.
+
+The resulting Dataset Snapshot Identity is also the authoritative Release 1.2
+Dataset Version within the logical Research Dataset Identity. Dataset versions
+are therefore immutable semantic/content-derived versions. A catalog may later
+display a human-friendly sequence or creation timestamp, but neither is an
+authoritative version and neither affects identity.
+
+Equivalent re-materialization creates a new operational execution event but
+resolves to the same logical dataset identity, source-state identity, snapshot
+identity, and dataset version. It does not create new semantic research
+evidence solely because it ran again.
+
+## Relevant and irrelevant change semantics
+
+The following changes produce a distinguishable source state and snapshot when
+they affect the selected interval:
+
+- an observation is added inside `[from, to)`;
+- selected membership or deterministic order changes;
+- a selected observation's decimal value differs in a legitimately distinct
+  authoritative source state; or
+- a selected observation's original offset representation differs.
+
+The following do not change the snapshot identity:
+
+- an observation is added outside `[from, to)`;
+- history for another target changes;
+- insertion or physical row order changes while semantic order does not;
+- a database file moves or a connection string changes;
+- execution time, duration, machine, or process changes; or
+- equivalent boundary display offsets denote the same semantic instants.
+
+A definition-semantic change always creates a distinguishable Definition
+Identity, Research Dataset Identity, and Snapshot Identity. Existing identities
+are never reassigned and old snapshots are never overwritten.
+
+## Canonical semantic representation
+
+Release 1.2 selects a normative, versioned canonical semantic representation
+as the input to deterministic fingerprints. It is independent of database,
+provider, JSON, and platform-native binary layouts.
+
+### Identity scheme
+
+The initial scheme is named `aiq-dataset-identity-v1`. Every carried identity
+must retain its scheme name. The scheme fixes SHA-256 and the following
+canonicalization rules.
+
+### Encoding rules
+
+- Values are encoded as UTF-8 bytes without a byte-order mark.
+- Each identity structure begins with its exact ASCII type-domain tag and
+  scheme name.
+- Fields occur only in the normative order defined below.
+- Every variable-length byte value is preceded by its non-negative decimal byte
+  length and a colon; structures also carry explicit field and sequence counts.
+- Integers use invariant base-10 ASCII with no leading zero except zero itself.
+- Enumeration/rule values use fixed lowercase ASCII tokens defined by the
+  scheme.
+- No locale-sensitive formatting, insignificant whitespace, property ordering,
+  provider JSON, or platform-native binary layout participates.
+
+### Value canonicalization
+
+- **Target:** exact UTF-8 value; no trimming, case folding, normalization, or
+  symbol rewriting.
+- **Boundary semantic instant:** signed UTC ticks in invariant base-10 form;
+  its display offset is excluded because the boundary denotes an instant.
+- **Source observation instant:** signed UTC ticks plus signed offset minutes;
+  both are required to preserve absolute instant and original offset.
+- **Decimal price:** sign, base-10 coefficient, and scale after removing
+  redundant trailing coefficient zeros; numerically equal decimal values have
+  one representation. Scientific notation and floating-point conversion are
+  prohibited.
+- **Sequence:** explicit count followed by observations in strict ascending
+  semantic-instant order. An empty sequence is count zero with no elements.
+
+### Normative field order
+
+- `definition`: scheme, target, lower UTC ticks, upper UTC ticks,
+  `lower-inclusive`, `upper-exclusive`, `instant-ascending`, parameter count,
+  then parameters in scheme-defined ordinal key order.
+- `research-dataset`: scheme, canonical definition fields.
+- `source-state`: scheme, target, observation count, then each observation's
+  UTC ticks, offset minutes, and normalized decimal components.
+- `snapshot`: scheme, typed Definition Identity, typed Source-State Identity.
+
+WP03 defines these canonical semantic bytes because deterministic content
+identity requires an unambiguous input. It does not define physical storage or
+Application type shapes.
+
+## Digest and textual identity decision
+
+SHA-256 is selected because it is a standard, non-secret cryptographic hash
+available in the .NET platform without an added package and operates fully
+offline. Random identifiers, GUIDs, sequences, and timestamps cannot recognize
+equivalent semantic content. Carrying raw canonical content as identity is
+deterministic but unnecessarily large and awkward for later contracts and
+catalog lookup.
+
+The normative textual fingerprint is lowercase hexadecimal with exactly 64
+characters. A complete identity is interpreted only with its identity type and
+scheme, conceptually:
+
+```text
+<identity-type>:aiq-dataset-identity-v1:sha256:<64-lowercase-hex>
+```
+
+The digest is compact identity evidence, not a signature, credential, or
+security boundary.
+
+## Scheme evolution and collision semantics
+
+Identity scheme, representation version, and digest algorithm are explicit.
+Snapshots retain their original scheme permanently. A future scheme never
+reinterprets an old identifier. Cross-scheme equivalence, if needed, requires
+comparison of preserved semantics or separately authorized migration; WP03
+does not define a migration framework.
+
+Under one scheme, equal fingerprints are expected to represent semantically
+equivalent content. If preserved metadata or content contradicts an equal
+fingerprint, the condition is an integrity conflict. Implementations must fail
+deterministically, preserve both bodies of evidence, and never overwrite or
+silently alias materially different definitions, source states, or snapshots.
+WP11 owns concrete validation and failure mapping.
+
+## Provenance semantics
+
+For every snapshot it must be possible to know:
+
+- its Research Dataset Identity, Dataset Definition Identity, Source-State
+  Identity, Snapshot Identity, and Dataset Version;
+- the exact definition semantics, target, and `[from, to)` boundaries;
+- source authority: accepted Release 1.1 historical observations;
+- the selected observation count;
+- the ordered semantic content or sufficient preserved evidence to reconstruct
+  and verify the Source-State Identity;
+- the identity scheme, canonicalization version, and digest algorithm; and
+- that the materialized content agrees with its semantic identities.
+
+Execution timestamp, duration, host, process, diagnostic correlation, and
+storage location may later be audit metadata. They are not semantic provenance
+inputs and never affect identity or version.
+
+## Lineage semantics
+
+Each snapshot derives from exactly one dataset definition and exactly one
+relevant source state. That source state consists of zero or more accepted
+Release 1.1 observations selected by the definition. The definition and source
+state together fully explain the semantic snapshot.
+
+An empty snapshot retains lineage to its definition and to an explicitly empty
+source state with a deterministic Source-State Identity. Lineage does not
+require one physical record per observation; WP06 through WP09 may choose a
+lossless representation without weakening this relationship.
+
+## Identity and immutability invariants
+
+1. Same semantic definition under the same scheme yields the same Definition
+   Identity and Research Dataset Identity.
+2. Same exact target and relevant ordered source content under the same scheme
+   yields the same Source-State Identity.
+3. Same Definition Identity and Source-State Identity under the same scheme
+   yields the same Snapshot Identity and Dataset Version.
+4. Operational metadata changes alone never change semantic identity.
+5. A relevant source semantic change yields distinguishable source-state and
+   snapshot identities.
+6. A definition semantic change yields distinguishable definition, logical
+   dataset, and snapshot identities.
+7. An accepted snapshot identity is immutable and is never reassigned to
+   different semantic content.
+8. New versions never overwrite old snapshots.
+9. A valid empty materialization has deterministic identities and version.
+10. Persisted or returned content that contradicts its identities is an
+    integrity conflict, never an overwrite opportunity.
+
+## Metadata and catalog boundary
+
+WP06 must make these facts catalog-visible: Research Dataset Identity, Dataset
+Definition Identity, Snapshot Identity/Dataset Version, Source-State Identity,
+identity scheme, target, selection boundaries, observation count, source
+authority, and provenance/lineage relationships.
+
+WP03 does not define catalog records, indexes, lookup APIs, pagination, query
+behavior, storage layout, or lifecycle presentation metadata.
+
+## Application and physical-storage boundaries
+
+WP04 must provide provider- and storage-independent Application values capable
+of carrying the four typed identities, scheme information, exact definition
+semantics, immutable snapshot/version semantics, required provenance, lineage,
+coverage/count, and valid empty snapshot results. Its contracts must preserve
+the equivalence and distinguishability invariants above without exposing
+SQLite, provider, filesystem, or generated database identifiers.
+
+WP05 owns materialization orchestration. WP06 owns catalog metadata objects.
+WP07 owns lossless physical representation but not identity meaning. WP08 owns
+immutable snapshot persistence. WP09 owns catalog persistence and lookup. WP10
+owns integration consistency. WP11 owns validation/failure mapping. WP12 owns a
+bounded execution path. WP13/WP14 own permanent tests.
+
+No table, column, SQLite type, index, foreign key, DDL, migration, or file path
+is specified here.
+
+## Alternatives and decisions
+
+| Decision | Alternatives | Selected option and rationale | Deferred implementation |
+| --- | --- | --- | --- |
+| Identity source | Random/GUID/sequential; semantic | Deterministic semantic identity recognizes equivalent offline materializations | Computing values: WP05 or owning later implementation |
+| Identity layers | Conflate definition and snapshot; separate | Separate logical definition/dataset, source-state, and snapshot identities because definitions survive source evolution | Application shapes: WP04 |
+| Version | Sequence; execution timestamp; content-derived | Snapshot fingerprint is the authoritative immutable semantic version | Optional display sequence: WP06 |
+| Source-state basis | Physical rows; semantic observations | Exact ordered observation content preserves provider/storage independence | Persistence: WP07/WP08 |
+| Equivalent rerun | New semantic version; same version | Same semantic identity/version; only operational event differs | Idempotent behavior: WP08/WP10 |
+| Operational metadata | Include; exclude | Excluded because it does not change research meaning | Audit metadata: later bounded ownership |
+| Canonicalization | Implicit; explicit versioned | Explicit scheme prevents locale/platform ambiguity and supports evolution | Executable encoder: later owning implementation |
+| Identity representation | Raw semantic key; SHA-256 digest | Typed versioned SHA-256 is compact, deterministic, offline, and package-free | Concrete value types: WP04 |
+
+## WP04 handoff
+
+WP04 receives these settled requirements:
+
+- four distinct typed concepts: Dataset Definition Identity, Research Dataset
+  Identity, Source-State Identity, and Dataset Snapshot Identity;
+- Dataset Version is the immutable Snapshot Identity within one logical
+  Research Dataset Identity;
+- equivalent definition and source state produce the same semantic identities
+  and version, including an explicitly empty source state;
+- any semantic definition or relevant selected-source change produces a
+  distinguishable snapshot identity;
+- identity values carry type, scheme, algorithm, and lowercase digest text;
+- provenance carries enough definition/source evidence to explain and verify a
+  snapshot;
+- lineage relates one snapshot to one definition and one source state of zero
+  or more accepted observations;
+- original observation offset and decimal fidelity remain normative;
+- operational metadata is excluded from semantic identity; and
+- identities are provider-, storage-, and machine-independent and immutable.
+
+WP04 owns interface and value-type shapes, not these semantics. Later work
+packages retain their boundaries: WP05 orchestration, WP06 catalog model, WP07
+physical schema, WP08 snapshot persistence, WP09 catalog persistence/lookup,
+WP10 integration, WP11 validation, WP12 composition, and WP13/WP14 tests.
+
+## Release 1.3 exclusion
+
+These semantics do not authorize scheduled refresh, continuous ingestion,
+event-driven re-materialization, pipeline graphs, background monitoring,
+feature generation, or Release 1.3 orchestration.

--- a/docs/architecture/data/RESEARCH_DATASET_DEFINITION.md
+++ b/docs/architecture/data/RESEARCH_DATASET_DEFINITION.md
@@ -1,0 +1,338 @@
+# Research Dataset Definition and Reproducibility Model
+
+**Status:** Accepted for Release 1.2 WP02
+
+**Scope:** Research Dataset Foundation
+
+**Technology boundary:** Provider-, storage-, and implementation-independent
+
+## Purpose
+
+This document defines the semantic foundation for Release 1.2 research
+datasets. It reuses the accepted Release 1.1 historical-observation truth and
+settles what a dataset, definition, materialization, and snapshot mean before
+later work packages choose identifiers, contracts, catalog models, or physical
+storage.
+
+## Authoritative source foundation
+
+Release 1.1 persisted `PriceObservation` values are the authoritative source
+material for Release 1.2 datasets. Each source observation belongs to one exact
+target and carries:
+
+- a semantic instant represented by `DateTimeOffset`, including its original
+  offset representation;
+- a positive `decimal` price with exact decimal fidelity; and
+- an identity defined by exact target plus absolute semantic instant.
+
+Source history is immutable and append-oriented. An exact repeat is
+idempotent; a different price or offset representation for an existing target
+and semantic instant is a conflict. Retrieval returns observations in strictly
+ascending semantic-instant order and may succeed with an empty result.
+
+Provider DTOs, HTTP payloads, database rows, row identifiers, insertion order,
+and natural database order are not dataset source truth. Dataset
+materialization neither rewrites nor repairs accepted source history.
+
+## Vocabulary
+
+### Research Dataset
+
+A research-owned, deterministic materialization of explicitly selected,
+accepted historical market observations together with the semantic metadata
+needed to explain how the materialization was produced. It is a durable
+research artifact, not a live query, provider response, mutable working set, or
+implicit view of "latest" data.
+
+### Dataset Definition
+
+The declarative semantic intent that determines a dataset: one exact target,
+explicit time-selection boundaries, their inclusion rules, deterministic
+ordering, and any explicitly authorized deterministic selection parameters.
+Release 1.2 introduces no transformation, enrichment, feature, label, missing-
+value repair, or provider-specific rule into this definition.
+
+### Dataset Materialization
+
+The deterministic resolution of a valid dataset definition against a fixed,
+authoritative state of accepted source observations. The term also describes
+the semantic result of that resolution before a physical representation is
+chosen.
+
+### Dataset Snapshot
+
+The durable, immutable representation of one successful dataset
+materialization. A snapshot preserves research evidence even if source history
+later changes. WP08 owns its persistence mechanics.
+
+### Source Observation
+
+An accepted Release 1.1 historical `PriceObservation` associated with its exact
+target. It is normalized platform data, not provider transport data.
+
+### Selection Boundary
+
+An explicit semantic-instant limit used to select source observations. Release
+1.2 uses an inclusive lower bound and an exclusive upper bound: `[from, to)`.
+
+### Determinism
+
+The property that fixed semantic inputs produce the same ordered semantic
+content and semantic metadata, without influence from execution environment or
+incidental ordering.
+
+### Reproducibility
+
+The ability to materialize semantically equivalent dataset content and
+explanatory semantic metadata when given the same dataset definition and the
+same authoritative source-observation state relevant to that definition.
+
+### Equivalent Materialization
+
+Two successful materializations are equivalent when their definition
+semantics, relevant source-state semantics, ordered observations, and semantic
+metadata are equal as defined below. Operational execution facts do not affect
+equivalence.
+
+### Dataset Metadata
+
+Descriptive semantic information required to understand a materialization,
+including its target, selection coverage, ordering rule, content cardinality,
+and the definition and source-state facts needed for explanation.
+
+### Provenance
+
+Evidence identifying the authoritative dataset definition and accepted source-
+observation state from which a materialization arose. WP03 owns its detailed
+semantics and representation.
+
+### Lineage
+
+The relationship from a materialized dataset to the exact selected source
+observations and semantic inputs that contributed to it. WP03 owns its detailed
+semantics and representation.
+
+### Catalog
+
+The discoverable record or index of materialized datasets and their metadata;
+it describes assets and does not define or contain their observation content.
+WP06 owns the catalog model and WP09 owns persistence and lookup.
+
+## Dataset definition model
+
+A Release 1.2 dataset definition has these semantic inputs:
+
+| Input | Requirement |
+| --- | --- |
+| Target | Exactly one non-ambiguous target, matched using the accepted exact target semantics |
+| Lower boundary | Required semantic instant; inclusive |
+| Upper boundary | Required semantic instant; exclusive and strictly later than the lower boundary |
+| Ordering | Strictly ascending by source observation semantic instant |
+| Parameters | Only deterministic parameters explicitly authorized by Release 1.2; none are added by WP02 |
+
+Both time boundaries are required. Unbounded sides and implicit wall-clock
+values are excluded because they would leave the selected source state
+ambiguous. Multiple targets are outside the Release 1.2 minimum slice; a
+separate single-target definition is required for each target.
+
+The selection includes precisely the accepted observations for the exact target
+whose semantic instants satisfy `lower <= instant < upper`. Selection never
+depends on insertion order, provider order, database row order, locale, or the
+time at which materialization runs.
+
+## Materialization and snapshot model
+
+Materialization evaluates a definition against a fixed view of the relevant
+accepted source history, selects matching observations, and orders them by
+semantic instant. It performs no acquisition, normalization, correction,
+aggregation, enrichment, feature engineering, or imputation.
+
+A successful selection containing zero observations is a valid empty
+materialization. This preserves Release 1.1 successful-empty retrieval
+semantics and distinguishes "no matching accepted observations" from an invalid
+definition or operational failure.
+
+Once accepted, the resulting snapshot is immutable. It may not be overwritten
+or amended. Re-materialization may recognize an equivalent result, but must not
+rewrite existing research evidence. A materially different result remains a
+distinct snapshot; older snapshots remain valid historical evidence.
+
+## Reproducibility model
+
+Given the same authoritative dataset definition and the same authoritative
+source-observation state relevant to that definition, materialization must
+produce semantically equivalent ordered content and explanatory semantic
+metadata independent of:
+
+- execution time or wall-clock `now`;
+- process identity, machine identity, machine path, or connection string;
+- random values;
+- provider response order or provider current state;
+- database natural row-return order or insertion order;
+- unordered collection enumeration;
+- locale or current culture;
+- local machine timezone or implicit timezone conversion;
+- floating-point conversion; and
+- environment-specific operational configuration.
+
+Source `DateTimeOffset` values and their original offsets are preserved without
+conversion or truncation. Source decimal values remain decimal and are
+preserved without binary floating-point conversion or rounding.
+
+### Input classification
+
+| Candidate input | Classification |
+| --- | --- |
+| Dataset definition and its explicit parameters | Required semantic input |
+| Exact target | Required semantic input |
+| Inclusive lower and exclusive upper boundaries | Required semantic input |
+| Relevant accepted source observations | Required semantic input |
+| Observation semantic instants and original offsets | Required semantic input |
+| Observation decimal values | Required semantic input |
+| Strict ascending semantic-instant ordering rule | Required semantic input |
+| Explicit deterministic filters or transformations | Deferred; none are authorized by WP02 |
+| Content count and actual selected coverage | Explanatory semantic metadata |
+| Definition/source-state provenance and lineage | Required to be knowable; detailed representation deferred to WP03 |
+| Execution timestamp and duration | Operational metadata only |
+| Process/machine identity, path, row ID, or connection string | Operational metadata only; excluded from semantics |
+| Provider DTO, HTTP details, and provider ordering | Out of scope and excluded from semantics |
+| Canonical bytes, identifier, version, or digest | Deferred to WP03 |
+
+Operational metadata may be recorded later for diagnostics, but must be kept
+separate from semantic content and must not determine semantic identity or
+equivalence.
+
+## Ordering and semantic content
+
+The canonical semantic content is the selected single-target observation
+sequence in strictly ascending absolute semantic-instant order. Each element
+preserves the exact instant, original offset representation, and decimal price
+from source truth. No duplicate target-plus-semantic-instant identities may be
+introduced. Physical record order and serialization are not authoritative.
+
+Because the Release 1.2 slice is single-target, no cross-target ordering rule is
+needed. Multi-target composition is not implied and remains outside this model.
+
+## Equivalent materialization semantics
+
+Two materializations are semantically equivalent only when all of these are
+equal:
+
+1. the complete dataset-definition semantics, including exact target,
+   boundaries, inclusion rules, ordering, and authorized parameters;
+2. the relevant authoritative source-state semantics;
+3. the ordered sequence of source observation identities;
+4. each observation's exact semantic instant, original offset, and decimal
+   value; and
+5. explanatory semantic metadata derived from those inputs and outputs.
+
+Execution timestamp, duration, process or machine identity, machine paths,
+connection strings, diagnostic correlation values, physical row identifiers,
+and storage layout are excluded from semantic equivalence.
+
+WP03 must choose how equivalence and distinction are represented. WP02 does not
+select canonical bytes, identifier shapes, version shapes, serialization, or a
+digest algorithm.
+
+## Source-history change model
+
+The dataset definition is stable independently of source-history state. A
+materialization resolves that definition against the authoritative source state
+available to that materialization. The resulting snapshot permanently records
+the semantic result and must remain explainable from provenance and lineage.
+
+If accepted source history later gains observations relevant to the same
+definition, a later materialization may be materially different. It must not
+replace the earlier snapshot. If the relevant source state and definition are
+semantically unchanged, a later materialization is equivalent even when its
+operational execution metadata differs.
+
+Release 1.1 conflict rules prohibit silently changing an accepted observation.
+If a future governed correction mechanism creates a changed authoritative
+source state, both the old and new materializations must remain distinguishable
+and the older snapshot must remain immutable research evidence.
+
+## Metadata, provenance, lineage, and catalog boundary
+
+For every materialization it must be possible to know:
+
+- the complete dataset-definition semantics;
+- the exact target and requested selection interval;
+- the actual selected coverage, including an explicit empty result;
+- the deterministic ordering rule and observation count;
+- the exact selected source identities and their preserved values;
+- the authoritative source-state facts needed to reproduce the result;
+- whether a later materialization is equivalent or materially different; and
+- the relationship between the snapshot, its definition, and its sources.
+
+WP03 defines identity, version, provenance, and lineage semantics and chooses
+their representations. WP06 defines catalog metadata objects. WP07 and WP08 own
+physical schema and snapshot persistence. WP09 owns catalog persistence and
+lookup. These later work packages may represent this required knowledge but may
+not weaken it.
+
+## Validation and failure concept boundary
+
+These concepts are distinct:
+
+- **Invalid definition:** target or boundaries are ambiguous, missing, or
+  unsupported; lower is not earlier than upper; or an input is inherently
+  non-deterministic.
+- **Valid empty materialization:** the definition is valid and source access
+  succeeds, but no accepted observations satisfy the selection.
+- **Source-data semantic failure:** required source fidelity or uniqueness
+  cannot be established without altering source truth.
+- **Operational materialization failure:** an execution dependency prevents a
+  result from being produced.
+
+WP02 creates no public failure types. WP11 owns validation and failure mapping.
+
+## Decisions and alternatives
+
+| Decision | Alternatives considered | Selected option and rationale | Consequence / deferred work |
+| --- | --- | --- | --- |
+| Dataset form | Live query; durable artifact | Durable materialization because research evidence must survive source evolution | Persistence mechanics deferred to WP08 |
+| Mutability | Mutable working set; immutable snapshot | Immutable snapshot to preserve reproducibility and auditability | Re-materialization cannot overwrite evidence |
+| Source inputs | Implicit current state; fixed relevant source state | Fixed semantic inputs avoid time-dependent results | WP03 represents source-state provenance |
+| Equivalence | Include execution metadata; semantic inputs/content only | Exclude operational metadata because machines and execution times must not alter meaning | Operational facts remain diagnostic only |
+| Re-materialization | Overwrite; preserve snapshots | Preserve historical snapshots to explain prior research | WP03 distinguishes materially different results |
+| Empty selection | Invalid; valid empty | Valid empty, consistent with Release 1.1 retrieval and deterministic selection | Empty is distinct from failure |
+| Source truth | Provider transport; accepted platform observations | Accepted Release 1.1 observations preserve provider independence and validated fidelity | Provider data remains outside dataset semantics |
+| Time boundaries | Unbounded/implicit; explicit closed interval; explicit half-open interval | Required `[from, to)` interval is deterministic and composes without boundary overlap | Concrete contract representation deferred to WP04 |
+| Target scope | Multiple targets; one exact target | Single target is the minimum authorized slice and avoids speculative cross-target semantics | Future expansion requires separate authority |
+
+## Release 1.3 exclusions
+
+This model does not authorize continuous ingestion, scheduled refresh,
+event-driven re-materialization, automatic recomputation, stream processing,
+pipeline DAG orchestration, background monitoring, production scheduling, or
+pipeline retry/resilience. Release 1.2 WP12 may later demonstrate one bounded
+execution path; it does not establish pipeline infrastructure.
+
+## WP03 handoff
+
+WP03 receives these settled semantic requirements:
+
+- the dataset definition, a materialization, and its immutable snapshot require
+  distinguishable identity concepts;
+- equivalence is determined by definition semantics, relevant source-state
+  semantics, ordered observations, preserved offset/decimal fidelity, and
+  semantic metadata;
+- any material change to the definition or relevant source state must remain
+  distinguishable;
+- provenance must explain the authoritative definition and source state;
+- lineage must relate the snapshot to its exact selected source observations;
+- accepted snapshots and prior research evidence remain immutable; and
+- operational metadata must not affect semantic identity.
+
+WP03 must leave representations provider- and storage-independent. It owns the
+identifier and version shapes, digest/hash choice if any, canonical
+serialization if any, provenance encoding, and lineage identifier encoding.
+Physical persistence remains deferred to WP07+.
+
+## Acceptance statement
+
+This model defines a small, deterministic Release 1.2 research dataset without
+changing Release 1.1 observation truth. It settles semantic meaning while
+deliberately leaving representation, contracts, catalog structures, storage,
+execution, and pipelines to their owning work packages.

--- a/docs/architecture/design/MODULE_INTERACTIONS.md
+++ b/docs/architecture/design/MODULE_INTERACTIONS.md
@@ -77,6 +77,20 @@ Release 1.1 adds a separate persistence interaction after successful acquisition
 
 ```text
 Worker -> IObservationSource -> normalized PriceObservation values
+
+## Release 1.2 Dataset Materialization
+
+Release 1.2 reuses accepted Release 1.1 historical observations rather than
+provider transport as dataset source truth. The Worker provides one explicit
+`DatasetDefinition` (`Dataset:Target`, `Dataset:From`, `Dataset:To`) to the
+Application integration seam. Application selects exact-target observations in
+the `[from,to)` interval, orders by semantic instant, constructs deterministic
+identity/version/provenance/lineage evidence, and asks Infrastructure to persist
+an immutable SQLite schema-v2 snapshot and register the same evidence for exact
+Snapshot Identity lookup. `NewlyAccepted`, equivalent existing evidence,
+integrity conflict, unavailable storage, and invalid persisted evidence retain
+their existing result meanings. This is a one-shot bounded action: no polling,
+scheduling, refresh, retries, or pipeline orchestration is implemented.
       -> IPersistHistoricalObservationsUseCase
       -> IHistoricalObservationStore
       -> SqliteHistoricalObservationStore -> historical_observations

--- a/docs/architecture/implementation/DEPENDENCY_INJECTION.md
+++ b/docs/architecture/implementation/DEPENDENCY_INJECTION.md
@@ -87,14 +87,14 @@ Centralized composition improves predictability and maintainability.
 
 ---
 
-# Implemented Release 1.0 Composition
+# Implemented Release 1.2 Composition
 
 `AIQuantTradingResearch.Worker` is the current composition root. Its one-shot execution lifecycle is:
 
 ```text
 Create generic host builder
         ↓
-Read TwelveData:ApiKey
+Read TwelveData:ApiKey, Persistence:DatabasePath, and Dataset inputs
         ↓
 AddApplication()
         ↓
@@ -102,16 +102,16 @@ AddInfrastructure(TwelveDataConfiguration)
         ↓
 Build host
         ↓
-Resolve IResearchUseCase
+Resolve IDatasetMaterializationIntegrationUseCase
         ↓
-Execute AAPL / 3 once
+Execute one exact-target DatasetDefinition once
         ↓
-Surface ResearchOutcome and exit
+Surface newly accepted, equivalent existing, or existing failure and exit
 ```
 
-`AddApplication` registers `IResearchUseCase` and `IPersistHistoricalObservationsUseCase` to their internal implementations with transient lifetimes. The configured `AddInfrastructure` overload registers the provider graph plus singleton `SqliteStorageConfiguration`, singleton `ISqliteConnectionFactory`, and transient `IHistoricalObservationStore`. The Worker resolves the bounded persistence coordinator through DI and does not construct provider or storage implementations manually.
+`AddApplication` registers the research/persistence use cases plus the transient dataset materialization and bounded integration use cases. The configured `AddInfrastructure` overload preserves the provider graph, singleton `SqliteStorageConfiguration`, singleton `ISqliteConnectionFactory`, and transient historical store; it also registers transient SQLite dataset snapshot-store and catalog implementations. The Worker resolves the bounded integration seam through DI and does not construct provider or storage implementations manually.
 
-`TwelveData:ApiKey` and `Persistence:DatabasePath` are mandatory external configuration. Worker reports deterministic configuration failures and exits non-zero when either is absent. Authentication remains header-based, and credentials are not committed or placed in request URLs. SQLite connections are operation-owned and resolution alone creates no database. No hosted/background service, runtime provider selection, streaming, or fallback framework is part of Release 1.1 composition.
+`TwelveData:ApiKey`, `Persistence:DatabasePath`, `Dataset:Target`, `Dataset:From`, and `Dataset:To` are mandatory external configuration. Worker reports deterministic configuration failures and exits non-zero when required values are absent or invalid. Authentication remains header-based, and credentials are not committed or placed in request URLs. SQLite connections are operation-owned and resolution alone creates no database. No hosted/background service, runtime provider selection, streaming, scheduler, retry framework, or Release 1.3 pipeline is implemented.
 
 ---
 

--- a/docs/architecture/implementation/TESTING_STRATEGY.md
+++ b/docs/architecture/implementation/TESTING_STRATEGY.md
@@ -210,7 +210,7 @@ Deterministic testing supports reproducible engineering outcomes.
 
 Testing projects should mirror architectural responsibilities.
 
-Current Release 1.1 organization:
+Current Release 1.2 organization:
 
 ```text
 tests/
@@ -222,11 +222,11 @@ tests/
 
 The implemented test responsibilities are:
 
-The current verified Release 1.1 baseline is 11 Domain, 42 Application, 79 Infrastructure, and 13 Architecture tests: 145 permanent tests in total.
+The current verified Release 1.2 baseline is 11 Domain, 60 Application, 87 Infrastructure, and 13 Architecture tests: 171 permanent tests in total.
 
 * **Domain.Tests** verifies price and series invariants plus deterministic mean behavior.
-* **Application.Tests** verifies `ResearchUseCase` plus provider-independent persistence contracts and use-case behavior with test-owned fakes and no concrete Infrastructure dependency.
-* **Infrastructure.Tests** verifies Twelve Data transport/normalization and the real isolated file-backed SQLite schema, bootstrap, mapping, persistence, retrieval, failure mapping, and DI composition. The suite is offline, deterministic, credential-free, and provider-call-free.
+* **Application.Tests** verifies provider-independent research/persistence behavior plus deterministic dataset definitions, identities, materialization, immutable catalog evidence, integration outcomes, and failure propagation using test-owned fakes and no concrete Infrastructure dependency.
+* **Infrastructure.Tests** verifies Twelve Data transport/normalization and the real isolated file-backed SQLite schema v2, v1-to-v2 preservation, dataset mapping, immutable snapshot/catalog evidence, retrieval, atomicity, failure mapping, and DI composition. The suite is offline, deterministic, credential-free, and provider-call-free.
 * **Architecture.Tests** verifies structural dependency, ownership, visibility, provider confinement, HTTP confinement, and acyclicity boundaries.
 
 The executable forbidden edges are:

--- a/docs/roadmap/release-1.2/RELEASE_1.2_EXECUTION_PLAN.md
+++ b/docs/roadmap/release-1.2/RELEASE_1.2_EXECUTION_PLAN.md
@@ -1,0 +1,644 @@
+# Release 1.2 Execution Plan
+
+## 1. Release Identity
+
+**Release:** 1.2\
+**Phase:** Phase 3\
+**Title:** Research Dataset Foundation
+
+Authoritative milestone title:
+
+``` text
+Phase 3 - Release 1.2: Research Dataset Foundation
+```
+
+Release 1.2 begins only after `RELEASE 1.1 CLOSED`. The accepted Release
+1.1 merged-main state is the predecessor platform baseline. Legacy
+milestone `#43 — Phase 3 - Release 1.2: Storage` is historical only and
+must remain closed and empty.
+
+## 2. Release Objective
+
+Transform the durable historical-observation foundation established by
+Release 1.1 into deterministic, versioned, reproducible, and
+discoverable research datasets with provider-independent metadata,
+provenance, lineage, coverage, immutable snapshot semantics, and a
+minimal catalog boundary.
+
+``` text
+Release 1.0: Acquire
+→ Release 1.1: Persist
+→ Release 1.2: Dataset
+→ Release 1.3: Pipeline
+→ Release 1.4: Features
+```
+
+Release 1.2 proves a reusable research-data asset. It does not implement
+the general pipeline engine.
+
+## 3. Accepted Predecessor Baseline
+
+WP01 must reconcile the formally accepted Release 1.1 closure baseline:
+
+``` text
+Release 1.1 terminal = RELEASE 1.1 CLOSED
+PR #120 = MERGED
+Milestone #52 = CLOSED
+Issues #103–#118 = 16/16 Closed / Done
+Permanent tests = 145/145
+Architecture.Tests = 13/13
+Build warnings/errors = 0/0
+Canonical verification = PASS
+Active Release 1.2 planning = 0
+```
+
+If repository truth has legitimately advanced since closure, WP01
+records the current accepted baseline rather than forcing historical
+counts, provided no unauthorized Release 1.2 implementation exists.
+
+## 4. Architectural Invariants
+
+``` text
+Domain         → none
+Application    → Domain
+Infrastructure → Application
+Worker         → Application, Infrastructure
+```
+
+-   Domain remains independent of SQLite, SQL, ORM, provider transport,
+    filesystem mechanics, catalog storage, and operational
+    configuration.
+-   Application owns provider/storage-independent dataset contracts,
+    materialization orchestration, catalog abstractions, and approved
+    result/failure vocabulary.
+-   Infrastructure owns physical dataset/catalog representation, SQLite
+    mechanics, durable persistence, mapping, queries, and concrete
+    failure handling.
+-   Worker remains a bounded composition/execution boundary.
+-   Release 1.1 historical-observation persistence/retrieval is reused,
+    not redesigned without evidence.
+-   Dataset identity/version/provenance/lineage must not depend on
+    physical row identifiers.
+-   No new production project is authorized by default.
+-   Production cycles remain zero.
+-   Release 1.3 pipeline responsibilities must not leak into Release
+    1.2.
+
+## 5. In Scope
+
+Release 1.2 includes repository preflight; dataset/reproducibility
+definition; dataset identity/version/provenance/lineage/coverage
+semantics; deterministic observation selection; Application
+dataset/materialization/catalog contracts; materialization use case;
+minimal catalog model; SQLite physical dataset/catalog model; durable
+immutable snapshot persistence; catalog registration/lookup;
+materialization integration; bounded failure mapping; DI/configuration;
+one bounded production execution; permanent Domain/Application and
+Infrastructure tests; architecture/documentation alignment; technical
+acceptance; governed integration; human merge; and post-merge closure.
+
+## 6. Explicitly Out of Scope
+
+No streaming/WebSockets, event buses, generalized ingestion pipelines,
+pipeline orchestration, DAG/workflow engine, scheduler, pipeline
+monitoring, generalized validation/transformation/enrichment stages,
+feature generation, technical indicators, ML feature store, backtesting,
+strategy/portfolio/trading execution, generalized caching, data lake,
+cloud database/object storage, TimescaleDB/PostgreSQL migration,
+distributed storage, retention automation, generalized migration
+platform, semantic/AI catalog search, notebooks, UI/API product surface,
+AI/ML, MLOps, plugin framework, Release 1.3 implementation, or Release
+1.4 implementation.
+
+## 7. Design Principles
+
+1.  Semantics before storage mechanics.
+2.  Equivalent accepted inputs plus equivalent materialization
+    definition produce deterministic logical dataset identity/content.
+3.  Accepted snapshots are immutable.
+4.  Versioning is semantic, never an accidental database row ID.
+5.  Provenance/lineage is bounded to what is needed for reproducibility.
+6.  Cataloging is minimal deterministic registration/lookup, not
+    generalized search.
+7.  Release 1.1 persistence/retrieval is reused.
+8.  Domain/Application remain storage independent.
+9.  Canonical tests are offline and deterministic.
+10. A bounded materialization use case must not become a pipeline
+    runtime.
+11. Implement the smallest credible vertical slice.
+12. WP16 acceptance, merge, and post-merge closure remain distinct
+    gates.
+
+## 8. Authoritative Work-Package Sequence
+
+Exactly sixteen work packages:
+
+``` text
+WP01 — Release & Repository Preflight
+WP02 — Research Dataset Definition & Reproducibility Model
+WP03 — Dataset Identity, Version & Provenance Semantics
+WP04 — Application Dataset Contracts
+WP05 — Dataset Materialization Use Case
+WP06 — Dataset Metadata & Catalog Model
+WP07 — Dataset Physical Storage Model
+WP08 — Dataset Snapshot Persistence
+WP09 — Dataset Catalog Persistence & Lookup
+WP10 — Dataset Materialization Integration
+WP11 — Dataset Validation & Failure Mapping
+WP12 — Dependency Registration & Bounded Dataset Execution
+WP13 — Domain & Application Dataset Tests
+WP14 — Infrastructure & Dataset Tests
+WP15 — Architecture & Documentation Alignment
+WP16 — Full Validation, Integration & Acceptance
+```
+
+No WP17+ implementation package is authorized.
+
+## 9. Authoritative Dependency Graph
+
+  WP     Depends On
+  ------ ------------------------------------
+  WP01   Release 1.1 CLOSED
+  WP02   WP01
+  WP03   WP02
+  WP04   WP03
+  WP05   WP04
+  WP06   WP03, WP04
+  WP07   WP05, WP06
+  WP08   WP07
+  WP09   WP08
+  WP10   WP05, WP08, WP09
+  WP11   WP10
+  WP12   WP11
+  WP13   WP03, WP04, WP05, WP06
+  WP14   WP07, WP08, WP09, WP10, WP11, WP12
+  WP15   WP13, WP14
+  WP16   WP15
+
+GitHub issue dependencies must match exactly. Missing or artificial
+edges are planning drift.
+
+## 10. WP01 --- Release & Repository Preflight
+
+**Objective:** establish the exact Release 1.2 starting state.
+
+Verify Release 1.1 closure; PR #120 merged; local `main` synchronized;
+milestone #52 terminal; legacy #43 closed/empty; canonical
+verification/test baseline; production graph; Release 1.1 persistence
+surfaces; existing dataset/catalog concepts; no unauthorized 1.2
+implementation; no 1.3 leakage.
+
+**Mutation:** governance/report artifacts only if the file manifest and
+WP01 prompt authorize them.
+
+**Prohibited:** production/test code, contracts, schema, packages, DI,
+Worker behavior, Git transport, WP02 implementation.
+
+**Exit:** baseline reconciled with zero unexplained implementation
+drift.
+
+## 11. WP02 --- Research Dataset Definition & Reproducibility Model
+
+**Objective:** define a Release 1.2 research dataset and reproducibility
+before contracts/storage.
+
+Decide dataset vs observation series; snapshot meaning; source-selection
+boundary; deterministic materialization definition; reproducibility
+rule; minimum metadata; provenance/lineage; coverage; immutability;
+logical identity vs snapshot/version identity; and the boundary with
+Release 1.3.
+
+Produce at least one evidence-backed data-architecture
+decision/definition artifact.
+
+**Prohibited:** source/test implementation, contracts, SQLite, packages,
+DI, Worker, WP03+ implementation.
+
+**Exit:** one coherent model is precise enough for later WPs.
+
+## 12. WP03 --- Dataset Identity, Version & Provenance Semantics
+
+**Objective:** define provider/storage-independent identity,
+snapshot/version, provenance, lineage, coverage, determinism,
+immutability, and empty-selection semantics.
+
+WP03 must determine whether Domain changes are necessary. Domain delta
+`0` is valid and preferred when existing values suffice.
+
+**Prohibited:** SQLite, physical records, Infrastructure, DI, Worker,
+tests, pipeline runtime, feature engineering.
+
+**Exit:** all later semantic decisions are explicit and technology
+independent.
+
+## 13. WP04 --- Application Dataset Contracts
+
+**Objective:** create the minimum provider/storage-independent
+Application seam.
+
+Contracts may include dataset definition/request, snapshot/descriptor,
+identity/version, provenance/lineage/coverage, materialization
+result/failure, snapshot store abstraction, catalog registration/lookup
+abstraction, and deterministic lookup criteria.
+
+Application must not expose SQLite/SQL/ORM, filesystem paths,
+database-generated semantic IDs, storage exceptions, provider DTOs, or
+pipeline types.
+
+**Exit:** minimal technology-independent contract surface exists.
+
+## 14. WP05 --- Dataset Materialization Use Case
+
+**Objective:** deterministically turn a materialization request plus
+persisted historical observations into a provider/storage-independent
+dataset snapshot candidate.
+
+``` text
+request
+→ historical retrieval
+→ deterministic selection/materialization
+→ snapshot/descriptor candidate
+→ explicit result
+```
+
+Reuse Release 1.1 retrieval and preserve observation fidelity.
+
+**Prohibited:** physical storage, catalog persistence, Worker,
+scheduler/DAG, feature generation.
+
+**Exit:** deterministic Application materialization works without
+storage leakage.
+
+## 15. WP06 --- Dataset Metadata & Catalog Model
+
+**Objective:** define the minimum catalogable metadata model.
+
+Reconcile logical identity, snapshot/version, target/instrument
+coverage, temporal coverage, bounded count/coverage, provenance,
+lineage/materialization-definition reference, and only necessary
+lifecycle metadata.
+
+The catalog is not semantic search, a marketplace, enterprise metadata
+platform, AI discovery, or generalized indexing framework.
+
+**Exit:** a minimal discoverable descriptor is compatible with
+WP03--WP05.
+
+## 16. WP07 --- Dataset Physical Storage Model
+
+**Objective:** define the minimum Infrastructure-owned durable
+dataset/catalog representation.
+
+Reuse Release 1.1 SQLite by default. Any schema evolution must preserve
+`historical_observations`, existing data, clean-checkout bootstrap, and
+avoid a generalized migration framework.
+
+Physical records/SQLite remain Infrastructure-only.
+
+**Exit:** durable model represents accepted semantics without changing
+Release 1.1 observation meaning.
+
+## 17. WP08 --- Dataset Snapshot Persistence
+
+**Objective:** implement durable immutable snapshot persistence.
+
+Persist identity/descriptor, preserve
+version/provenance/lineage/coverage fidelity, implement approved
+idempotency/conflict behavior, prevent silent overwrite, preserve
+atomicity, and survive component reconstruction.
+
+**Prohibited:** cache/pipeline/feature/catalog-search frameworks or new
+storage engine.
+
+**Exit:** snapshots are durably and immutably stored.
+
+## 18. WP09 --- Dataset Catalog Persistence & Lookup
+
+**Objective:** implement durable minimal catalog registration and
+deterministic lookup.
+
+Preserve metadata/provenance/lineage/coverage fidelity and approved
+empty/not-found behavior.
+
+**Prohibited:** semantic/full-text/AI search, ranking, generalized
+indexing, pipelines.
+
+**Exit:** catalog descriptors can be registered and retrieved
+deterministically.
+
+## 19. WP10 --- Dataset Materialization Integration
+
+**Objective:** integrate materialization, snapshot persistence, and
+catalog registration.
+
+``` text
+request
+→ historical retrieval
+→ deterministic materialization
+→ durable snapshot
+→ catalog registration
+→ provider-independent result
+```
+
+Define an explicit consistency/atomicity boundary and prevent partial
+accepted state.
+
+**Prohibited:** scheduler, background queue, pipeline runtime,
+transformation/enrichment framework, feature generation.
+
+**Exit:** full dataset-foundation use case works through approved
+abstractions.
+
+## 20. WP11 --- Dataset Validation & Failure Mapping
+
+**Objective:** map concrete dataset/catalog storage conditions into
+approved provider-independent failures.
+
+Cover unavailable storage, incompatible schema, malformed persisted
+metadata, identity/content conflict, invalid lineage/coverage
+representation, corruption, and partial-state prevention. Do not swallow
+programming defects or invent a generalized data-quality/retry
+framework.
+
+**Exit:** failure behavior is deterministic and storage-independent at
+the Application boundary.
+
+## 21. WP12 --- Dependency Registration & Bounded Dataset Execution
+
+**Objective:** wire the dataset graph into the existing composition
+model and prove one bounded production path.
+
+Allowed:
+
+``` text
+one explicit materialization
+→ retrieve persisted observations
+→ materialize
+→ persist snapshot
+→ register catalog
+→ report result
+```
+
+Not allowed: scheduler, continuous loop, DAG/workflow engine, background
+orchestration, generic stage framework, feature pipeline.
+
+**Exit:** the real composition root executes the vertical slice while
+Release 1.3 remains absent.
+
+## 22. WP13 --- Domain & Application Dataset Tests
+
+Permanently prove technology-independent semantics/contracts/use cases:
+identity/version, reproducibility, provenance/lineage, coverage, empty
+selection, request validation, deterministic materialization,
+observation fidelity, result/failure propagation, catalog contracts, and
+separation from provider/SQLite/pipeline mechanics.
+
+Domain test delta may be `0` if WP03 changes no Domain behavior.
+
+Tests are offline and deterministic.
+
+## 23. WP14 --- Infrastructure & Dataset Tests
+
+Permanently prove SQLite schema evolution and Release 1.1 preservation;
+snapshot mapping/persistence; idempotency/conflict; immutability;
+atomicity; catalog registration/lookup;
+metadata/provenance/lineage/coverage fidelity; materialization
+integration; failure mapping; DI/configuration; reconstruction
+durability; and database cleanup.
+
+All tests are isolated/offline and leave zero repository database
+residue.
+
+## 24. WP15 --- Architecture & Documentation Alignment
+
+Align executable architecture rules and current-state documentation with
+accepted implementation. Reconcile data platform
+vision/lifecycle/catalog/storage/pipeline docs plus
+solution/design/DI/testing/project-structure/README where repository
+truth requires.
+
+Documentation must clearly show:
+
+``` text
+historical observations
+→ reproducible research dataset snapshot
+→ cataloged reusable asset
+→ future Release 1.3 pipelines
+→ future Release 1.4 features
+```
+
+No production/package/project/build/script changes.
+
+## 25. WP16 --- Full Validation, Integration & Acceptance
+
+Reconcile the exact candidate and validate restore, format, build, all
+tests, architecture tests, canonical verification, whitespace,
+docs/links, security/package state, dataset reproducibility,
+immutability, catalog behavior, Release 1.1 regression, Release 1.3
+leakage=0, temporary residue=0, and fresh-checkout reproducibility.
+
+The separately authored WP16 authority may grant exact integration
+branch/stage/commit/push/PR mutations after candidate reconciliation.
+WP16 must not merge or self-approve.
+
+If an earlier-WP defect is found, return `BLOCKED` and request a narrow
+correction.
+
+## 26. Reproducibility Contract
+
+``` text
+same accepted historical observation set
++ same materialization definition
++ same dataset semantics
+= same logical dataset content/identity outcome
+```
+
+Reproducibility must not depend on row insertion order, SQLite-generated
+IDs, machine paths, locale, timezone, network availability, developer
+state, or untracked files.
+
+## 27. Dataset Immutability Contract
+
+Accepted snapshot content is immutable. Equivalent rematerialization
+follows the approved idempotency rule. Changed source
+selection/definition produces an explicit new or conflicting semantic
+outcome. Infrastructure must not invent update-in-place behavior.
+
+## 28. Provenance / Lineage Boundary
+
+Release 1.2 must be able to explain what logical dataset/snapshot this
+is, what source target/coverage contributed, what materialization
+definition produced it, what historical-observation boundary it derives
+from, and whether it can be reproduced.
+
+No enterprise lineage graph/ontology/cross-system metadata platform is
+required.
+
+## 29. Catalog Boundary
+
+The catalog describes/references dataset assets and supports
+deterministic registration/lookup. It does not replace Release 1.1
+historical storage. No generalized search technology is selected without
+separate evidence/authority.
+
+## 30. Release 1.1 Regression Contract
+
+Preserve exact target identity, timestamp/offset/decimal fidelity,
+immutable historical observations, duplicate idempotency, deterministic
+conflict, atomic writes, ascending retrieval, successful empty
+retrieval, failure behavior, `Persistence:DatabasePath`, operation-owned
+connections, provider/storage independence, and bounded Worker
+composition.
+
+Any public Release 1.1 contract evolution must be explicitly
+proven/governed by WP03/WP04 or treated as a blocker.
+
+## 31. Release 1.3 Protection
+
+Release 1.2 must not introduce abstractions primarily for arbitrary
+stage composition, stage graphs, scheduling, recurring execution,
+pipeline lifecycle/monitoring, generalized
+validation/transformation/enrichment stages, or feature-generation
+orchestration.
+
+## 32. Security / Data Safety
+
+No real credentials, secret-bearing connection strings, production
+market-data fixtures without authority, committed SQLite/WAL/SHM/journal
+files, personal machine paths, destructive historical-data reset, silent
+dataset overwrite, or secret-bearing catalog metadata.
+
+## 33. Working-Tree Discipline
+
+Until WP16 explicitly owns integration: no commits, pushes,
+implementation PRs, branch proliferation, or destructive reset/stash. No
+staging unless a WP authority explicitly requires it. Preserve
+cumulative accepted work. Unexpected mutations are blockers.
+
+## 34. GitHub Planning Model
+
+Before WP01, planning must represent one new authoritative milestone
+titled `Phase 3 - Release 1.2: Research Dataset Foundation`, exactly 16
+WP issues, the exact dependency graph, no WP17+, existing labels/Project
+conventions, Project Release=`1.2` reconciliation if required, legacy
+#43 closed/empty, and no Release 1.3 implementation.
+
+Project #2 field truth must be inspected, not assumed.
+
+## 35. Standard Issue Body Contract
+
+``` text
+Objective
+Scope
+Dependencies
+Deliverables
+Validation Evidence
+Exit Criteria
+Out of Scope
+Authority
+```
+
+## 36. Required Governance Before WP01
+
+``` text
+docs/roadmap/release-1.2/RELEASE_1.2_EXECUTION_PLAN.md
+docs/roadmap/release-1.2/RELEASE_1.2_FILE_MANIFEST.md
+docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt.md
+docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt-chat.md
+```
+
+Standard `-chat` companions are exactly five lines. WP01 prompt
+artifacts are created only after GitHub planning is accepted.
+
+## 37. Validation Rules
+
+Every implementation WP must classify Git state, verify
+predecessors/issue lifecycle, run relevant baseline and targeted
+validation, run canonical verification before completion, pass
+`git diff --check`, prove unexpected paths=0, remove temporary residue,
+report package/reference/test deltas, and preserve later-WP scope.
+
+## 38. Temporary Probe Policy
+
+Temporary probes must be minimal, offline unless explicitly authorized
+otherwise, uncommitted, removed before completion, residue-free, and
+never substitute for required WP13/WP14 permanent tests.
+
+## 39. Package / Project Policy
+
+Default:
+
+``` text
+new production packages = 0
+new production projects = 0
+new project references = 0
+```
+
+Expected references remain Application→Domain,
+Infrastructure→Application, Worker→Application+Infrastructure. Any
+package addition requires explicit evidence and authority.
+
+## 40. Candidate Accounting
+
+Do not hardcode the final candidate count. At WP16 derive the accepted
+governance + WP01--WP15 artifacts + explicitly in-band WP16 artifacts,
+then freeze candidate `N`. Later lifecycle authorities must state
+whether their files are in-band or out-of-band.
+
+## 41. Integration / Merge Gate
+
+Under explicit authority WP16 may create one governed integration
+branch/commit/push/review-ready PR. No self-approval, auto-merge, merge,
+force-push, or history rewrite.
+
+## 42. Post-Merge Closure
+
+A separate closure authority must prove the accepted candidate on
+`main`, local/remote synchronization, canonical validation,
+fresh-checkout reproducibility, all WP issues Closed/Done, authoritative
+milestone with zero open issues then closed, clean working tree, and
+Release 1.3 not started.
+
+Only then:
+
+``` text
+RELEASE 1.2 CLOSED
+```
+
+## 43. Release-Level Exit Criteria
+
+Technical acceptance requires deterministic
+identity/version/reproducibility; explicit provenance/lineage/coverage;
+storage-independent contracts; deterministic materialization; durable
+immutable snapshots; explicit equivalent-rerun behavior; durable catalog
+registration; deterministic lookup; fidelity; Release 1.1 regression
+PASS; SQLite confined to Infrastructure; Domain/Application SQLite
+leakage=0; pipeline/feature implementation=0; permanent/architecture
+tests PASS; canonical verification PASS; documentation aligned;
+residue=0; fresh checkout PASS; candidate reconciled; review-ready PR
+under authority.
+
+## 44. Authority Transition
+
+``` text
+Release 1.2 Definition
+→ Execution Plan + File Manifest
+→ GitHub Planning
+→ WP01 ... WP16
+→ RELEASE 1.2 ACCEPTED
+→ Human Review / Merge
+→ Post-Merge Closure
+→ RELEASE 1.2 CLOSED
+→ Release 1.3 governance may be separately authorized
+```
+
+## 45. Final Governance Decision
+
+This plan defines exactly one capability:
+`Phase 3 - Release 1.2: Research Dataset Foundation`.
+
+It authorizes preparation of Release 1.2 GitHub planning and, only after
+that planning is accepted, WP01--WP16 execution under separately
+authored prompts. It does not itself mutate GitHub planning, implement
+Release 1.2, authorize early Git transport, authorize merge, or
+authorize Release 1.3 implementation.

--- a/docs/roadmap/release-1.2/RELEASE_1.2_FILE_MANIFEST.md
+++ b/docs/roadmap/release-1.2/RELEASE_1.2_FILE_MANIFEST.md
@@ -1,0 +1,859 @@
+# Release 1.2 File Manifest
+
+## 1. Purpose
+
+This manifest defines authoritative file-ownership and mutation
+boundaries for:
+
+``` text
+Phase 3 - Release 1.2: Research Dataset Foundation
+```
+
+It prevents uncontrolled file scope while allowing concrete
+implementation filenames to emerge from evidence-backed design. The
+execution plan is authoritative for behavior/sequencing; this manifest
+is authoritative for artifact classes, allowed mutation surfaces, and
+prohibited file categories.
+
+## 2. Manifest Principles
+
+1.  Do not invent implementation filenames before the owning WP
+    establishes design.
+2.  Modify only surfaces owned here or by a later narrow
+    unblock/reconciliation authority.
+3.  Existing files may evolve only when their responsibility
+    legitimately evolves under the owning WP.
+4.  New files remain inside the owning layer/module/documentation
+    surface.
+5.  Application owns provider/storage-independent
+    dataset/materialization/catalog contracts and orchestration.
+6.  Infrastructure owns SQLite physical dataset/catalog representation
+    and persistence mechanics.
+7.  Release 1.1 historical-observation behavior is preserved unless an
+    owning WP explicitly proves compatible evolution.
+8.  Domain changes are allowed only if WP03 proves genuinely
+    Domain-owned dataset semantics are necessary.
+9.  Worker changes are owned only by WP12 bounded composition/execution.
+10. Permanent test changes belong to WP13/WP14; architecture-test
+    changes belong to WP15.
+11. Governance prompts belong under `docs/roadmap/release-1.2/prompts/`.
+12. No Release 1.3 implementation artifact is authorized.
+13. Final candidate counts are derived after reconciliation, never
+    hardcoded now.
+14. Temporary SQLite/probe/generated artifacts never silently become
+    candidate files.
+15. Legacy milestone #43 is historical GitHub state and does not
+    authorize obsolete repository naming.
+
+## 3. Authoritative Governance Paths
+
+``` text
+docs/roadmap/release-1.2/
+    RELEASE_1.2_EXECUTION_PLAN.md
+    RELEASE_1.2_FILE_MANIFEST.md
+    prompts/
+```
+
+Standard WP prompt naming:
+
+``` text
+NN-<work-package-slug>-codex-prompt.md
+NN-<work-package-slug>-codex-prompt-chat.md
+```
+
+Lifecycle prompt naming:
+
+``` text
+release-1.2-<lifecycle-step>-codex-prompt.md
+release-1.2-<lifecycle-step>-codex-prompt-chat.md
+```
+
+Every standard `-chat` companion is exactly five lines unless explicit
+later authority changes the convention.
+
+## 4. Required Pre-Implementation Governance
+
+Before WP01:
+
+``` text
+docs/roadmap/release-1.2/RELEASE_1.2_EXECUTION_PLAN.md
+docs/roadmap/release-1.2/RELEASE_1.2_FILE_MANIFEST.md
+docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt.md
+docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt-chat.md
+```
+
+WP01 prompt artifacts are created only after GitHub planning is
+accepted.
+
+# 5. WP01 --- Release & Repository Preflight
+
+**Prompt pair**
+
+``` text
+01-release-repository-preflight-codex-prompt.md
+01-release-repository-preflight-codex-prompt-chat.md
+```
+
+under the Release 1.2 prompt root.
+
+**Authorized mutation:** normally governance/report artifacts only.
+
+**Prohibited unless narrow unblock:** `src/**`, `tests/**`,
+package/build/solution files, `eng/**`, `.github/**`.
+
+# 6. WP02 --- Research Dataset Definition & Reproducibility Model
+
+**Prompt pair**
+
+``` text
+02-research-dataset-definition-reproducibility-model-codex-prompt.md
+02-research-dataset-definition-reproducibility-model-codex-prompt-chat.md
+```
+
+**Authorized surface**
+
+``` text
+docs/architecture/data/**
+```
+
+Prefer existing data-architecture authorities where natural. A dedicated
+definition/decision artifact may be created under that folder. Concrete
+filename(s) are evidence-driven.
+
+**Prohibited:** `src/**`, `tests/**`,
+packages/projects/solution/build/scripts/GitHub config. WP02 is
+definition/decision-only.
+
+# 7. WP03 --- Dataset Identity, Version & Provenance Semantics
+
+**Prompt pair**
+
+``` text
+03-dataset-identity-version-provenance-semantics-codex-prompt.md
+03-dataset-identity-version-provenance-semantics-codex-prompt-chat.md
+```
+
+**Primary expected production outcome:** Domain delta may be `0`.
+
+If required:
+
+``` text
+src/AIQuantTradingResearch.Domain/**
+```
+
+may change only for provider/storage-independent dataset
+identity/version/provenance/lineage/coverage semantics.
+
+Narrow semantic documentation under `docs/architecture/data/**` may be
+updated only when explicitly authorized.
+
+**Prohibited:** Infrastructure physical types, SQLite/schema, Worker,
+packages/projects, tests, pipeline/feature types. Application contracts
+remain WP04-owned.
+
+# 8. WP04 --- Application Dataset Contracts
+
+**Prompt pair**
+
+``` text
+04-application-dataset-contracts-codex-prompt.md
+04-application-dataset-contracts-codex-prompt-chat.md
+```
+
+**Authorized production surface**
+
+``` text
+src/AIQuantTradingResearch.Application/**
+```
+
+Allowed classes: dataset definition/request; snapshot/descriptor;
+identity/version supporting values where Domain does not own them;
+provenance/lineage/coverage; materialization result/failure;
+snapshot-store abstraction; catalog registration/lookup abstraction;
+minimal supporting Application values.
+
+**Prohibited:** Infrastructure/Worker, SQLite/SQL/ORM/filesystem types
+in public contracts, provider DTOs, pipeline runtime types, tests, new
+packages.
+
+# 9. WP05 --- Dataset Materialization Use Case
+
+**Prompt pair**
+
+``` text
+05-dataset-materialization-use-case-codex-prompt.md
+05-dataset-materialization-use-case-codex-prompt-chat.md
+```
+
+**Authorized**
+
+``` text
+src/AIQuantTradingResearch.Application/**
+```
+
+for deterministic materialization orchestration, request validation,
+Release 1.1 historical retrieval reuse, and snapshot-candidate
+construction.
+
+**Prohibited:** Infrastructure, Worker, SQLite/schema, catalog
+persistence, permanent tests, packages/projects, scheduler/DAG, feature
+generation.
+
+# 10. WP06 --- Dataset Metadata & Catalog Model
+
+**Prompt pair**
+
+``` text
+06-dataset-metadata-catalog-model-codex-prompt.md
+06-dataset-metadata-catalog-model-codex-prompt-chat.md
+```
+
+**Authorized primary surface**
+
+``` text
+src/AIQuantTradingResearch.Application/**
+```
+
+Narrow `docs/architecture/data/**` refinement is allowed when explicitly
+authorized. Domain may change only as a compile-level continuation of
+WP03's already accepted Domain semantic decision.
+
+Allowed classes: catalogable descriptor values/contracts; coverage;
+provenance/lineage; deterministic lookup criteria; minimal catalog-model
+refinements.
+
+**Prohibited:** Infrastructure persistence, SQLite, Worker, tests,
+semantic/AI/full-text search platform, generalized indexing, pipeline
+types.
+
+# 11. WP07 --- Dataset Physical Storage Model
+
+**Prompt pair**
+
+``` text
+07-dataset-physical-storage-model-codex-prompt.md
+07-dataset-physical-storage-model-codex-prompt-chat.md
+```
+
+**Authorized**
+
+``` text
+src/AIQuantTradingResearch.Infrastructure/**
+```
+
+Allowed classes: snapshot records; catalog records; mappings; schema
+representation/version evolution; SQLite constraints/indexes required by
+approved lookup semantics.
+
+Existing Release 1.1 SQLite bootstrap/schema files may change only to
+add Release 1.2 schema while preserving `historical_observations`
+behavior/data.
+
+Default production package delta is `0`. Additional packages require
+exact separate authority unless the WP07 prompt explicitly grants them
+after evidence.
+
+**Prohibited:** Domain physical records, Application SQLite types,
+Worker, permanent tests, new storage engine, generalized migration
+framework, destructive Release 1.1 reset.
+
+# 12. WP08 --- Dataset Snapshot Persistence
+
+**Prompt pair**
+
+``` text
+08-dataset-snapshot-persistence-codex-prompt.md
+08-dataset-snapshot-persistence-codex-prompt-chat.md
+```
+
+**Authorized**
+
+``` text
+src/AIQuantTradingResearch.Infrastructure/**
+```
+
+for snapshot persistence, immutable writes, identity/version
+enforcement, idempotency/conflict behavior, transactions/atomicity, and
+mapping.
+
+**Prohibited:** Application redesign, Worker, Domain, permanent tests,
+new packages unless separately authorized, catalog-search framework,
+pipeline behavior.
+
+# 13. WP09 --- Dataset Catalog Persistence & Lookup
+
+**Prompt pair**
+
+``` text
+09-dataset-catalog-persistence-lookup-codex-prompt.md
+09-dataset-catalog-persistence-lookup-codex-prompt-chat.md
+```
+
+**Authorized**
+
+``` text
+src/AIQuantTradingResearch.Infrastructure/**
+```
+
+for catalog registration, deterministic lookup, record mapping,
+metadata/provenance/lineage/coverage reconstruction, and minimal
+approved indexes.
+
+**Prohibited:** Application storage knowledge, Worker, Domain, permanent
+tests, semantic/AI search, ranking/recommendation, generalized indexing
+platform, pipeline behavior.
+
+# 14. WP10 --- Dataset Materialization Integration
+
+**Prompt pair**
+
+``` text
+10-dataset-materialization-integration-codex-prompt.md
+10-dataset-materialization-integration-codex-prompt-chat.md
+```
+
+**Authorized primary surfaces**
+
+``` text
+src/AIQuantTradingResearch.Application/**
+src/AIQuantTradingResearch.Infrastructure/**
+```
+
+The WP10 authority must enumerate which layer/file responsibilities
+require mutation before changing them.
+
+Allowed: Application orchestration over approved abstractions;
+Infrastructure consistency/transaction mechanics; no-partial-state
+behavior; deterministic rerun semantics.
+
+**Prohibited:** Worker, Domain redesign, permanent tests,
+packages/projects, scheduler/background queue/pipeline runtime/feature
+generation.
+
+# 15. WP11 --- Dataset Validation & Failure Mapping
+
+**Prompt pair**
+
+``` text
+11-dataset-validation-failure-mapping-codex-prompt.md
+11-dataset-validation-failure-mapping-codex-prompt-chat.md
+```
+
+**Authorized**
+
+``` text
+src/AIQuantTradingResearch.Infrastructure/**
+```
+
+Minimal Application changes only when an already-approved WP04 contract
+requires compile-level reconciliation and the WP11 prompt names the
+exact surface.
+
+Allowed: SQLite failure classification; malformed dataset/catalog record
+handling; incompatible schema; identity/content conflict preservation;
+partial-state validation; approved failure mapping.
+
+**Prohibited:** Worker, Domain, permanent tests, unrelated exception
+handling, retry framework, generalized data-quality pipeline.
+
+# 16. WP12 --- Dependency Registration & Bounded Dataset Execution
+
+**Prompt pair**
+
+``` text
+12-dependency-registration-bounded-dataset-execution-codex-prompt.md
+12-dependency-registration-bounded-dataset-execution-codex-prompt-chat.md
+```
+
+**Authorized surfaces**
+
+``` text
+src/AIQuantTradingResearch.Application/**
+src/AIQuantTradingResearch.Infrastructure/**
+src/AIQuantTradingResearch.Worker/**
+```
+
+Only minimal composition changes justified by current repository
+conventions: service registration, snapshot/catalog implementation
+registration, configuration handoff, one bounded Worker materialization
+invocation, and result reporting.
+
+Existing configuration files may change only when explicitly named by
+the WP12 authority.
+
+**Prohibited:** new project/reference/package unless separately
+authorized, CLI/service/API redesign, scheduler, continuous loop,
+background framework, pipeline DAG/runtime, feature pipeline.
+
+# 17. WP13 --- Domain & Application Dataset Tests
+
+**Prompt pair**
+
+``` text
+13-domain-application-dataset-tests-codex-prompt.md
+13-domain-application-dataset-tests-codex-prompt-chat.md
+```
+
+**Authorized test surface**
+
+``` text
+tests/AIQuantTradingResearch.Domain.Tests/**
+tests/AIQuantTradingResearch.Application.Tests/**
+```
+
+No production visibility/reference/package change is automatically
+authorized. If needed, stop for narrow testability authority.
+
+**Prohibited:** Infrastructure tests, production behavior changes,
+SQLite/database use in Application tests unless separately authorized,
+provider/network calls.
+
+# 18. WP14 --- Infrastructure & Dataset Tests
+
+**Prompt pair**
+
+``` text
+14-infrastructure-dataset-tests-codex-prompt.md
+14-infrastructure-dataset-tests-codex-prompt-chat.md
+```
+
+**Authorized**
+
+``` text
+tests/AIQuantTradingResearch.Infrastructure.Tests/**
+```
+
+Potential test-only dependency surface, only when explicitly authorized:
+
+``` text
+Directory.Packages.props
+tests/AIQuantTradingResearch.Infrastructure.Tests/AIQuantTradingResearch.Infrastructure.Tests.csproj
+```
+
+Temporary databases must be isolated, cleaned, ignored/outside tracked
+state, and leave zero WAL/SHM/journal residue.
+
+**Prohibited:** production behavior changes.
+
+# 19. WP15 --- Architecture & Documentation Alignment
+
+**Prompt pair**
+
+``` text
+15-architecture-documentation-alignment-codex-prompt.md
+15-architecture-documentation-alignment-codex-prompt-chat.md
+```
+
+**Authorized architecture-test surface**
+
+``` text
+tests/AIQuantTradingResearch.Architecture.Tests/**
+```
+
+only for accepted Release 1.2 boundaries not already executable.
+
+**Potential current-state documentation surface, after exact
+reconciliation**
+
+``` text
+README.md
+docs/architecture/data/DATA_PLATFORM_VISION.md
+docs/architecture/data/DATA_LIFECYCLE.md
+docs/architecture/data/DATA_CATALOG.md
+docs/architecture/data/DATA_STORAGE_ARCHITECTURE.md
+docs/architecture/data/DATA_PIPELINE_ARCHITECTURE.md
+docs/architecture/solution/SOLUTION_ARCHITECTURE.md
+docs/architecture/solution/DEPENDENCY_RULES.md
+docs/architecture/solution/BOUNDARY_DEFINITIONS.md
+docs/architecture/design/MODULE_INTERACTIONS.md
+docs/architecture/design/PUBLIC_CONTRACTS.md
+docs/architecture/implementation/DEPENDENCY_INJECTION.md
+docs/architecture/implementation/TESTING_STRATEGY.md
+docs/architecture/implementation/PROJECT_STRUCTURE.md
+```
+
+Only existing documents materially requiring alignment may change.
+
+New dataset architecture documents may be created only under
+`docs/architecture/data/` or another established architecture subfolder
+proven more consistent by the WP15 authority. Exact files must be
+enumerated before mutation.
+
+**Prohibited:** production code/packages/project
+references/solution/build/scripts/workflows and Release 1.3
+implementation.
+
+# 20. WP16 --- Full Validation, Integration & Acceptance
+
+**Prompt pair**
+
+``` text
+16-full-validation-integration-acceptance-codex-prompt.md
+16-full-validation-integration-acceptance-codex-prompt-chat.md
+```
+
+WP16 is primarily validation/integration. Before candidate freeze,
+expected correction delta is zero for
+production/tests/docs/packages/projects. Earlier-WP defects cause
+`BLOCKED` and narrow corrective authority.
+
+Only the separately authored WP16 authority may grant staging of the
+exact candidate, one integration branch, governed commit strategy, push
+without force, and one review-ready PR. It must not grant
+merge/self-approval.
+
+Temporary validation artifacts must be uncommitted and removed.
+
+# 21. Lifecycle Governance After WP16
+
+After `RELEASE 1.2 ACCEPTED`, lifecycle governance may be created under
+the Release 1.2 prompt root.
+
+Expected closure pair:
+
+``` text
+release-1.2-post-merge-closure-codex-prompt.md
+release-1.2-post-merge-closure-codex-prompt-chat.md
+```
+
+A separate integration pair is allowed only if the eventual WP16
+authority does not own integration transport. Do not create duplicate
+authorities for one lifecycle transition.
+
+Unblock/reconciliation prompts are created only for actual blockers.
+
+# 22. Integration Candidate Accounting
+
+Never predefine final candidate file count.
+
+At integration:
+
+``` text
+accepted Release 1.2 governance
++ accepted WP01–WP15 implementation/test/docs
++ explicitly in-band WP16 artifacts
+= reconciled candidate N
+```
+
+Freeze `N`. Later authorities must state whether their own files are
+in-band (changing `N`) or out-of-band (never staged).
+
+# 23. Project / Package Boundaries
+
+Normally unchanged unless exact WP authority says otherwise:
+
+``` text
+AIQuantTradingResearch.slnx
+Directory.Build.props
+global.json
+eng/**
+.github/**
+```
+
+Default production package delta: `0`. Release 1.1 SQLite remains the
+default storage technology.
+
+Expected references remain:
+
+``` text
+Application → Domain
+Infrastructure → Application
+Worker → Application, Infrastructure
+```
+
+No new project/reference is authorized by default.
+
+# 24. Test Project Ownership
+
+``` text
+Domain.Tests         → WP13
+Application.Tests    → WP13
+Infrastructure.Tests → WP14
+Architecture.Tests   → WP15
+```
+
+Temporary probes in earlier WPs are removed before completion unless an
+owning test WP explicitly promotes them.
+
+# 25. Documentation Ownership
+
+WP02 initially owns dataset/reproducibility definition under
+`docs/architecture/data/**`. WP03/WP06 may refine only their explicitly
+owned semantic/model portions when authorized. WP15 owns broad
+current-state convergence and README alignment.
+
+Earlier WPs must not opportunistically rewrite broad architecture
+documentation.
+
+# 26. Release 1.1 Assets Must Be Preserved
+
+Release 1.2 extends but does not delete accepted Release 1.1 assets
+under:
+
+``` text
+src/AIQuantTradingResearch.Domain/**
+src/AIQuantTradingResearch.Application/**
+src/AIQuantTradingResearch.Infrastructure/**
+src/AIQuantTradingResearch.Worker/**
+tests/AIQuantTradingResearch.Domain.Tests/**
+tests/AIQuantTradingResearch.Application.Tests/**
+tests/AIQuantTradingResearch.Infrastructure.Tests/**
+tests/AIQuantTradingResearch.Architecture.Tests/**
+```
+
+# 27. Existing SQLite Boundary
+
+SQLite is already selected/integrated. WP07 owns Release 1.2 schema
+evolution, not engine reselection. Reuse the existing
+connection/bootstrap boundary where sufficient; preserve
+`historical_observations`; use minimal deterministic schema evolution;
+no destructive reset; no new database technology under this manifest.
+
+# 28. Namespace / Folder Policy
+
+Concrete source folders/namespaces must follow repository conventions.
+This manifest intentionally does not predeclare speculative paths such
+as `Application/Datasets/` or `Infrastructure/Datasets/`. The owning WP
+establishes them from repository truth.
+
+No new top-level production project/layer is authorized for folder
+aesthetics.
+
+# 29. Generated / Runtime Artifacts
+
+Must not become candidate files:
+
+``` text
+*.db
+*.sqlite
+*.sqlite3
+*-wal
+*-shm
+*-journal
+TestResults/**
+bin/**
+obj/**
+temporary probes
+temporary worktrees
+local secret/config files
+```
+
+All temporary artifacts are removed before WP completion.
+
+# 30. Security-Sensitive Files
+
+No WP may commit API keys/tokens/credentials, secret-bearing connection
+strings, personal database paths, local secrets, or production market
+datasets as fixtures without explicit authority. Existing
+secret-scanning/verification must remain operational.
+
+# 31. Work-Package Ownership Summary
+
+  -----------------------------------------------------------------------
+  WP                                  Primary Ownership
+  ----------------------------------- -----------------------------------
+  WP01                                Governance/preflight only
+
+  WP02                                Data-architecture
+                                      dataset/reproducibility definition
+
+  WP03                                Domain semantics if necessary +
+                                      narrow semantic docs
+
+  WP04                                Application
+                                      dataset/materialization/catalog
+                                      contracts
+
+  WP05                                Application materialization use
+                                      case
+
+  WP06                                Application metadata/catalog
+                                      model + narrow data docs
+
+  WP07                                Infrastructure physical
+                                      schema/model
+
+  WP08                                Infrastructure snapshot persistence
+
+  WP09                                Infrastructure catalog
+                                      persistence/lookup
+
+  WP10                                Application/Infrastructure
+                                      materialization integration
+
+  WP11                                Infrastructure validation/failure
+                                      mapping
+
+  WP12                                Minimal
+                                      Application/Infrastructure/Worker
+                                      composition/execution
+
+  WP13                                Domain.Tests + Application.Tests
+
+  WP14                                Infrastructure.Tests + explicitly
+                                      authorized test dependencies
+
+  WP15                                Architecture.Tests + authorized
+                                      current-state documentation
+
+  WP16                                Validation + explicitly authorized
+                                      integration transport
+  -----------------------------------------------------------------------
+
+Any deviation requires explicit authority.
+
+# 32. Candidate Reconciliation
+
+Every WP report classifies visible changes:
+
+``` text
+EXPECTED GOVERNANCE
+WP01 AUTHORIZED
+WP02 AUTHORIZED
+...
+WP16 AUTHORIZED
+UNBLOCK / RECONCILIATION AUTHORIZED
+EXPECTED GENERATED / IGNORED
+UNEXPECTED
+```
+
+Unexpected changes must be zero. Preserve prior accepted work.
+
+# 33. Staging / Commit Policy
+
+WP01--WP15 normally prohibit:
+
+``` text
+git add
+git commit
+git push
+PR creation
+```
+
+Cumulative work remains uncommitted until WP16 or a dedicated
+integration authority owns Git transport.
+
+# 34. Whitespace / Diff Policy
+
+Before integration:
+
+``` text
+git diff --check = PASS
+```
+
+After staging:
+
+``` text
+git diff --cached --check = PASS
+```
+
+The controlling integration authority should handle zero or more
+strictly mechanical whitespace findings without unnecessary recursive
+authority chains when exact findings are bounded and semantic
+equivalence can be proven. Corrections must name affected
+files/findings, remove only the defect, prove no semantic change, and
+define whether current authority artifacts are in-band or out-of-band.
+
+# 35. Clean-Checkout Requirement
+
+Acceptance/closure must prove no dependence on untracked databases,
+developer-machine state, secrets, pre-existing schema, machine-global
+data, network availability for canonical tests, or prior local Release
+1.2 execution. Fresh checkout restore/build/test/verify must pass.
+
+# 36. GitHub Planning Boundary
+
+The later GitHub-planning authority may create planning state but no
+implementation. It should establish one new authoritative Release 1.2
+milestone, 16 WP issues, Project #2 items/fields, and the exact
+dependency graph.
+
+Preserve:
+
+``` text
+legacy #43 = CLOSED / EMPTY
+Release 1.1 #52 = CLOSED
+Release 1.1 issues = terminal
+Release 1.3 implementation = NOT STARTED
+```
+
+Project field truth must be inspected rather than assumed.
+
+# 37. Standard Prompt-Pair Inventory
+
+``` text
+01-release-repository-preflight-codex-prompt.md
+01-release-repository-preflight-codex-prompt-chat.md
+02-research-dataset-definition-reproducibility-model-codex-prompt.md
+02-research-dataset-definition-reproducibility-model-codex-prompt-chat.md
+03-dataset-identity-version-provenance-semantics-codex-prompt.md
+03-dataset-identity-version-provenance-semantics-codex-prompt-chat.md
+04-application-dataset-contracts-codex-prompt.md
+04-application-dataset-contracts-codex-prompt-chat.md
+05-dataset-materialization-use-case-codex-prompt.md
+05-dataset-materialization-use-case-codex-prompt-chat.md
+06-dataset-metadata-catalog-model-codex-prompt.md
+06-dataset-metadata-catalog-model-codex-prompt-chat.md
+07-dataset-physical-storage-model-codex-prompt.md
+07-dataset-physical-storage-model-codex-prompt-chat.md
+08-dataset-snapshot-persistence-codex-prompt.md
+08-dataset-snapshot-persistence-codex-prompt-chat.md
+09-dataset-catalog-persistence-lookup-codex-prompt.md
+09-dataset-catalog-persistence-lookup-codex-prompt-chat.md
+10-dataset-materialization-integration-codex-prompt.md
+10-dataset-materialization-integration-codex-prompt-chat.md
+11-dataset-validation-failure-mapping-codex-prompt.md
+11-dataset-validation-failure-mapping-codex-prompt-chat.md
+12-dependency-registration-bounded-dataset-execution-codex-prompt.md
+12-dependency-registration-bounded-dataset-execution-codex-prompt-chat.md
+13-domain-application-dataset-tests-codex-prompt.md
+13-domain-application-dataset-tests-codex-prompt-chat.md
+14-infrastructure-dataset-tests-codex-prompt.md
+14-infrastructure-dataset-tests-codex-prompt-chat.md
+15-architecture-documentation-alignment-codex-prompt.md
+15-architecture-documentation-alignment-codex-prompt-chat.md
+16-full-validation-integration-acceptance-codex-prompt.md
+16-full-validation-integration-acceptance-codex-prompt-chat.md
+```
+
+All `-chat` companions are exactly five lines.
+
+# 38. Lifecycle Artifact Boundary
+
+Expected planning and closure artifacts:
+
+``` text
+release-1.2-github-planning-codex-prompt.md
+release-1.2-github-planning-codex-prompt-chat.md
+release-1.2-post-merge-closure-codex-prompt.md
+release-1.2-post-merge-closure-codex-prompt-chat.md
+```
+
+A separate GitHub-integration pair exists only if WP16 does not own
+integration. Never duplicate authority.
+
+# 39. Release 1.3 Protection
+
+No Release 1.2 WP owns artifacts primarily responsible for pipeline
+orchestration, pipeline stages, DAG/workflow execution, scheduling,
+recurring execution, pipeline monitoring, generic
+validation/transformation/enrichment stages, or feature generation. If
+such an artifact becomes necessary, return `BLOCKED`.
+
+# 40. Final Manifest Decision
+
+This manifest freezes Release 1.2 ownership/mutation boundaries while
+leaving concrete dataset/catalog filenames evidence-driven.
+
+``` text
+Release 1.2 governance
+→ GitHub planning
+→ WP01–WP16
+→ technical acceptance
+→ governed integration
+→ human merge
+→ post-merge closure
+→ RELEASE 1.2 CLOSED
+```
+
+Anything outside these boundaries requires explicit later authority.

--- a/docs/roadmap/release-1.2/prompts/01-release-repository-preflight-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/01-release-repository-preflight-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Use GPT-5.6 Sol. Execute Release 1.2 WP01 — Release & Repository Preflight.
+Read `docs/roadmap/release-1.2/prompts/01-release-repository-preflight-codex-prompt.md` completely and treat it as the execution authority.
+Verify the accepted Release 1.1 closure, Release 1.2 governance/GitHub planning, repository/toolchain/test/architecture/persistence baseline, and working-tree classification before any lifecycle mutation.
+Do not modify production code, tests, packages, repository governance, WP02+, or Release 1.3; only issue #121 lifecycle mutations are authorized after every starting gate passes.
+Return the required execution report and terminal marker; do not start WP02.

--- a/docs/roadmap/release-1.2/prompts/01-release-repository-preflight-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/01-release-repository-preflight-codex-prompt.md
@@ -1,0 +1,948 @@
+# Release 1.2 WP01 --- Release & Repository Preflight --- Codex Prompt
+
+## Role
+
+Act as the **WP01 Release & Repository Preflight Executor** for Release
+1.2 of `AIQuantTradingResearch`.
+
+This is a bounded governance, verification, and readiness work package.
+Its purpose is to establish a trustworthy execution baseline for:
+
+`Phase 3 - Release 1.2: Research Dataset Foundation`
+
+Do not implement dataset behavior. Do not start WP02.
+
+Use **GPT-5.6 Sol** for this work package.
+
+------------------------------------------------------------------------
+
+## 1. Mandatory Authorities
+
+Read completely before acting:
+
+``` text
+docs/roadmap/release-1.2/RELEASE_1.2_EXECUTION_PLAN.md
+docs/roadmap/release-1.2/RELEASE_1.2_FILE_MANIFEST.md
+docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt.md
+docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt-chat.md
+docs/roadmap/release-1.2/prompts/01-release-repository-preflight-codex-prompt.md
+docs/roadmap/release-1.2/prompts/01-release-repository-preflight-codex-prompt-chat.md
+```
+
+Read GitHub planning state for:
+
+``` text
+Milestone #53 — Phase 3 - Release 1.2: Research Dataset Foundation
+Issue #121 — Release 1.2 WP01 — Release & Repository Preflight
+Issues #122–#136 — WP02–WP16
+Project #2 — AIQuantTradingResearch Engineering Roadmap
+```
+
+Inspect the accepted Release 1.1 closure evidence needed to prove the
+predecessor release is terminal, including PR #120, milestone #52,
+issues #103--#118, and merged repository state.
+
+Inspect repository engineering authorities and scripts only as needed to
+execute WP01.
+
+Authority precedence:
+
+``` text
+1. RELEASE_1.2_EXECUTION_PLAN.md
+2. RELEASE_1.2_FILE_MANIFEST.md
+3. Accepted Release 1.2 GitHub planning state
+4. Accepted Release 1.1 closure/repository truth
+5. Existing repository engineering/governance conventions
+6. This execution prompt
+```
+
+If a lower authority materially conflicts with a higher authority, stop
+and report the smallest precise blocker. Do not invent a reconciliation
+authority and do not silently repair drift.
+
+------------------------------------------------------------------------
+
+## 2. Accepted Starting Planning Baseline
+
+Treat the following as the accepted Release 1.2 planning baseline unless
+current GitHub evidence proves drift:
+
+``` text
+Release 1.1:
+  PR #120: MERGED
+  milestone #52: CLOSED
+  issues #103–#118: CLOSED / DONE
+  terminal state: RELEASE 1.1 CLOSED
+
+Release 1.2:
+  authoritative milestone: #53
+  milestone #53 state: OPEN
+  milestone #53 issues: #121–#136
+  WP issues: exactly 16
+  WP01–WP16: OPEN / BACKLOG
+  assignee: samuel-santos-engineer on 16/16
+  Priority: P1 on 16/16
+  Release: 1.2 on 16/16
+  Area: populated on 16/16
+  dependency drift: 0
+  WP17+: 0
+  lifecycle-gate issues: 0
+
+Legacy:
+  milestone #43 — Phase 3 - Release 1.2: Storage: CLOSED / EMPTY
+
+Protection:
+  Release 1.3 implementation: NOT STARTED
+  WP02 implementation: NOT STARTED
+```
+
+Do not recreate planning objects merely because they already exist.
+
+------------------------------------------------------------------------
+
+## 3. Objective
+
+Prove, with current repository and GitHub evidence, that Release 1.2 may
+safely proceed from planning into execution.
+
+WP01 must establish:
+
+``` text
+Release 1.1 terminal closure remains valid
+PR #120 is merged into main
+milestone #52 remains closed
+issues #103–#118 remain closed/done
+local main and origin/main identity are understood
+repository truth is synchronized or any divergence is precisely classified
+working-tree state is fully classified
+the four accepted Release 1.2 pre-implementation governance artifacts are present or their exact state is understood
+Release 1.2 GitHub planning still matches the accepted baseline
+milestone #53 is the sole authoritative open Release 1.2 milestone
+issues #121–#136 represent exactly WP01–WP16
+dependency graph has zero drift
+Project #2 fields remain Backlog / P1 / Release 1.2 / authoritative Area
+toolchain and SDK baseline are known
+restore/build/format/test/canonical verification baseline is healthy
+current permanent test counts are established from execution, not assumed
+current production dependency graph is established
+Release 1.1 persistence/retrieval baseline remains healthy
+file-manifest assumptions are reconciled against repository reality
+no Release 1.2 dataset implementation has begun
+no Release 1.3 implementation has begun
+WP02 has not begun
+```
+
+WP01 is a **preflight/evidence package**, not a dataset design or
+implementation package.
+
+------------------------------------------------------------------------
+
+## 4. Authorized Scope
+
+You are authorized to:
+
+1.  Read repository files and GitHub planning state.
+2.  Inspect Git status, branches, remotes, upstreams, HEAD,
+    `origin/main`, and ahead/behind state.
+3.  Fetch remote metadata when required to establish current truth,
+    provided no repository content or history is rewritten.
+4.  Inspect PR #120 and Release 1.1 closure evidence.
+5.  Inspect milestone #52, milestone #53, legacy milestone #43, issues
+    #103--#136, and Project #2.
+6.  Inspect the Release 1.2 authority files and prompt companions.
+7.  Inspect SDK/tool versions and repository configuration.
+8.  Run repository-safe diagnostic commands.
+9.  Run restore, formatting verification, build, permanent tests,
+    architecture tests, canonical verification, and existing
+    non-mutating security/package checks.
+10. Inspect solution membership, project references, package state,
+    production dependency direction, current persistence implementation,
+    and test inventory.
+11. Classify every staged, tracked-modified, and untracked path.
+12. Compare current repository truth with the accepted Release 1.1
+    merged baseline and Release 1.2 manifest expectations.
+13. Move issue #121 / WP01 from `Backlog` to `In Progress` **only after
+    all mandatory starting-state gates and the initial technical
+    baseline pass**.
+14. After every WP01 acceptance gate passes, post concise evidence to
+    issue #121, close it, and set its Project #2 Status to `Done`.
+15. Produce the complete execution report required by this authority.
+
+Ordinary ignored build output produced by validation is acceptable. It
+must not be mistaken for governed implementation content.
+
+------------------------------------------------------------------------
+
+## 5. WP01 Mutation Boundary
+
+WP01 is normally non-implementation work.
+
+Repository mutations authorized by WP01:
+
+``` text
+normally: 0 production mutations
+normally: 0 test mutations
+normally: 0 documentation-semantic mutations
+normally: 0 package/project/solution/build/script mutations
+```
+
+The Release 1.2 execution plan and manifest allow governance/report
+artifacts only when specifically authorized. This prompt does **not**
+authorize creation of an additional repository report file.
+
+The WP01 prompt pair itself is an accepted governance input and must not
+be rewritten during execution.
+
+GitHub mutations authorized by this prompt are limited to the lifecycle
+of issue #121:
+
+``` text
+Backlog → In Progress
+Open → Closed
+Project Status → Done
+one concise evidence comment if useful
+```
+
+No other GitHub planning mutation is authorized.
+
+------------------------------------------------------------------------
+
+## 6. Prohibited Scope
+
+Do not:
+
+``` text
+start WP02
+define the research dataset model
+decide dataset reproducibility semantics
+define identity/version/provenance semantics
+create dataset contracts
+create dataset materialization behavior
+create catalog models
+create or evolve SQLite dataset schema
+implement snapshot persistence
+implement catalog persistence or lookup
+implement dataset failure mapping
+modify Worker dataset execution
+modify Domain/Application/Infrastructure/Worker production code
+modify permanent tests
+modify architecture tests
+modify architecture/data documentation
+modify engineering scripts
+modify package references
+modify project references
+modify solution membership
+modify build policy
+modify .editorconfig
+modify .gitattributes
+rewrite Release 1.2 authorities
+rewrite prompt files
+stage files
+commit
+push
+create branches
+create PRs
+merge PRs
+create tags
+create GitHub Releases
+close milestone #53
+edit issues #122–#136
+change dependencies
+change labels
+change assignees
+change Priority/Release/Area fields
+create WP17+
+create lifecycle-gate issues
+reopen or repurpose milestone #43
+create or modify Release 1.3 planning/implementation
+discard, stash, reset, clean, or overwrite accepted local work
+```
+
+Do not fix a discovered defect unless this prompt explicitly authorizes
+that exact mutation.
+
+If a correction is required but unauthorized, stop and report the
+smallest corrective authority required.
+
+------------------------------------------------------------------------
+
+## 7. Initial Git and Repository Gate
+
+Before substantive validation, capture:
+
+``` text
+repository identity
+current branch
+HEAD
+origin/main
+upstream
+ahead/behind
+working-tree status
+staged paths
+tracked modifications
+untracked paths
+recent main history
+PR #120 merge commit presence
+```
+
+Expected execution branch:
+
+``` text
+main
+```
+
+Expected baseline from accepted Release 1.1 closure:
+
+``` text
+merged Release 1.1 main includes PR #120
+```
+
+Do not hardcode an old SHA as current truth. The accepted Release 1.1
+closure recorded merged main at:
+
+``` text
+465c7d2f2c1cc5f99b4aa72a8d685db18951a9ad
+```
+
+Use that SHA as historical evidence, not as permission to reset current
+repository truth.
+
+If `origin/main` has legitimately advanced after Release 1.1 closure,
+inspect and classify the advancement. Continue only if it is compatible
+with the Release 1.2 authorities and does not represent unauthorized
+Release 1.2/1.3 implementation.
+
+Never reset or rewrite current `main` to force it back to the historical
+SHA.
+
+If local `main` is behind `origin/main`, do not automatically mutate it
+unless a fast-forward is both safe and necessary under existing
+repository conventions. Prefer establishing truth first. If
+synchronization would constitute an unapproved local mutation under the
+observed state, report it rather than guessing.
+
+------------------------------------------------------------------------
+
+## 8. Working-Tree Classification Gate
+
+Classify every non-clean path as exactly one of:
+
+``` text
+A. accepted Release 1.2 governance input
+B. accepted repository content already tracked
+C. ordinary ignored/generated validation output
+D. unexpected or ambiguous state
+```
+
+The accepted pre-implementation Release 1.2 governance set is:
+
+``` text
+RELEASE_1.2_EXECUTION_PLAN.md
+RELEASE_1.2_FILE_MANIFEST.md
+release-1.2-github-planning-codex-prompt.md
+release-1.2-github-planning-codex-prompt-chat.md
+```
+
+The WP01 prompt pair is also an accepted governance input for this
+execution.
+
+These files may be tracked or untracked depending on the current
+integration lifecycle. Their mere presence as untracked files is **not**
+a defect.
+
+Do not stage, commit, delete, normalize, relocate, or rewrite accepted
+governance artifacts.
+
+If any other untracked or modified path exists, determine whether it is
+accepted repository evolution or an unexpected mutation. If ambiguity
+could affect WP01 correctness, stop.
+
+------------------------------------------------------------------------
+
+## 9. Release 1.1 Closure Gate
+
+Prove current evidence for:
+
+``` text
+PR #120 is MERGED
+accepted Release 1.1 candidate is present on main
+issues #103–#118 are 16/16 CLOSED
+Project #2 Release 1.1 items are Done
+milestone #52 is CLOSED
+Release 1.1 terminal state remains valid
+```
+
+Also establish that Release 1.1 historical observation behavior needed
+by Release 1.2 still exists:
+
+``` text
+SQLite persistence foundation exists
+historical observation persistence exists
+historical observation retrieval exists
+target identity semantics remain available
+timestamp/offset fidelity remains available
+decimal fidelity remains available
+idempotent/conflict behavior remains available
+successful empty retrieval remains available
+Persistence:DatabasePath composition remains available
+bounded Worker persistence flow remains available
+```
+
+WP01 does not redesign or re-prove every internal semantic detail. It
+establishes that the accepted Release 1.1 foundation is present and that
+the canonical baseline remains healthy.
+
+If Release 1.1 terminal closure cannot be proven, stop.
+
+------------------------------------------------------------------------
+
+## 10. Release 1.2 Governance Gate
+
+Verify the authoritative governance set and its current state.
+
+Required pre-implementation authorities:
+
+``` text
+docs/roadmap/release-1.2/RELEASE_1.2_EXECUTION_PLAN.md
+docs/roadmap/release-1.2/RELEASE_1.2_FILE_MANIFEST.md
+docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt.md
+docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt-chat.md
+```
+
+Required WP01 authority:
+
+``` text
+docs/roadmap/release-1.2/prompts/01-release-repository-preflight-codex-prompt.md
+docs/roadmap/release-1.2/prompts/01-release-repository-preflight-codex-prompt-chat.md
+```
+
+Verify standard `-chat` companions are exactly five lines.
+
+Do not require later WP02--WP16 prompt pairs to exist yet. They are
+separately authored before their owning work packages.
+
+Verify that execution-plan and file-manifest responsibilities do not
+materially conflict.
+
+If a material contradiction exists, stop.
+
+------------------------------------------------------------------------
+
+## 11. GitHub Planning Gate
+
+Verify current GitHub state against the accepted planning result.
+
+### 11.1 Milestones
+
+Require:
+
+``` text
+#52 — Release 1.1 authoritative milestone: CLOSED
+#53 — Phase 3 - Release 1.2: Research Dataset Foundation: OPEN
+#43 — Phase 3 - Release 1.2: Storage: CLOSED / EMPTY
+```
+
+Require exactly one authoritative open Release 1.2 milestone: #53.
+
+Do not modify milestone #43 or #53.
+
+### 11.2 Issues
+
+Require exactly:
+
+``` text
+#121–#136 = WP01–WP16
+```
+
+Before WP01 lifecycle mutation:
+
+``` text
+#121: OPEN / Backlog
+#122–#136: OPEN / Backlog
+```
+
+No WP17+ or lifecycle-gate issue may exist as part of authoritative
+Release 1.2 planning.
+
+### 11.3 Exact Dependencies
+
+Verify:
+
+``` text
+WP01 ← Release 1.1 CLOSED
+WP02 ← WP01
+WP03 ← WP02
+WP04 ← WP03
+WP05 ← WP04
+WP06 ← WP03, WP04
+WP07 ← WP05, WP06
+WP08 ← WP07
+WP09 ← WP08
+WP10 ← WP05, WP08, WP09
+WP11 ← WP10
+WP12 ← WP11
+WP13 ← WP03, WP04, WP05, WP06
+WP14 ← WP07, WP08, WP09, WP10, WP11, WP12
+WP15 ← WP13, WP14
+WP16 ← WP15
+```
+
+Require:
+
+``` text
+missing edges: 0
+artificial edges: 0
+dependency drift: 0
+```
+
+### 11.4 Project #2
+
+Require all 16 Release 1.2 issues to be represented exactly once with:
+
+``` text
+Status = Backlog
+Priority = P1
+Release = 1.2
+Area = authoritative mapped value
+Assignee = samuel-santos-engineer
+```
+
+At the starting gate, WP01 must still be Backlog.
+
+Do not move WP01 to In Progress until the repository/governance/planning
+starting gates and initial technical baseline pass.
+
+------------------------------------------------------------------------
+
+## 12. Release 1.3 Protection Gate
+
+Inspect current state sufficiently to prove that Release 1.3 has not
+been started by Release 1.2 work.
+
+The known historical/legacy Release 1.3 milestone #44 may exist and must
+not be mutated merely because it exists.
+
+Require:
+
+``` text
+Release 1.3 implementation introduced by Release 1.2: 0
+Release 1.3 planning objects created by this execution: 0
+Release 1.3 repository artifacts created by this execution: 0
+```
+
+Do not attempt to reconcile legacy Release 1.3 planning in WP01.
+
+------------------------------------------------------------------------
+
+## 13. Toolchain and Repository Baseline
+
+Capture the actual environment, including where applicable:
+
+``` text
+dotnet --version
+dotnet --info
+global.json
+target frameworks
+solution membership
+central package management state
+repository package sources
+current branch and remote state
+```
+
+Do not upgrade or alter the SDK, packages, package sources, or project
+files.
+
+Record relevant versions as evidence.
+
+------------------------------------------------------------------------
+
+## 14. Initial Technical Baseline
+
+Before changing issue #121 lifecycle, run the repository's canonical
+non-mutating baseline.
+
+At minimum:
+
+``` text
+dotnet restore AIQuantTradingResearch.slnx
+dotnet format AIQuantTradingResearch.slnx --verify-no-changes
+dotnet build AIQuantTradingResearch.slnx --no-restore
+dotnet test AIQuantTradingResearch.slnx --no-build
+eng/verify.ps1
+git diff --check
+git diff --cached --check
+```
+
+Use repository-native equivalents if the canonical scripts establish a
+slightly different exact invocation.
+
+Also run the existing architecture-test suite and any existing
+repository-owned secret/package/security validation included by
+canonical verification.
+
+Do not contact Twelve Data or any other provider as part of WP01
+validation.
+
+All WP01 validation must remain offline except for Git/GitHub metadata
+operations and ordinary package restore if required by the repository.
+
+If the baseline fails, do not move issue #121 to In Progress. Report the
+failure and stop unless the failure is clearly caused only by an
+external transient dependency and can be safely rerun without mutation.
+
+------------------------------------------------------------------------
+
+## 15. Baseline Test Inventory
+
+Derive test counts from the actual execution.
+
+The accepted Release 1.1 closure recorded:
+
+``` text
+Domain.Tests: 11
+Application.Tests: 42
+Infrastructure.Tests: 79
+Architecture.Tests: 13
+Total: 145
+```
+
+These are historical expectations, not values to fake.
+
+Report current actual counts and explain any legitimate delta.
+
+A changed count is not automatically a failure if repository truth
+legitimately advanced. It is a blocker if the delta is unexplained,
+unauthorized, or indicates Release 1.2/1.3 implementation already began.
+
+------------------------------------------------------------------------
+
+## 16. Production Dependency Graph Gate
+
+Inspect current production project references and verify the accepted
+graph remains compatible with:
+
+``` text
+Domain → none
+Application → Domain
+Infrastructure → Application
+Worker → Application, Infrastructure
+```
+
+Require:
+
+``` text
+unexpected production dependency edges: 0
+dependency cycles: 0
+Domain SQLite leakage: 0
+Application SQLite leakage: 0
+Domain provider/HTTP mechanics: 0
+Application provider/HTTP mechanics: 0
+```
+
+Do not add or remove references.
+
+------------------------------------------------------------------------
+
+## 17. Release 1.1 Persistence Regression Baseline
+
+WP01 must establish that Release 1.2 begins from a healthy Release 1.1
+persistence foundation.
+
+Use existing permanent tests and canonical verification to confirm, at
+minimum, continued evidence for:
+
+``` text
+SQLite schema/bootstrap baseline
+connection lifecycle
+observation persistence
+idempotency
+conflict preservation
+atomicity
+immutable accepted history
+historical retrieval
+target isolation
+ascending ordering
+timestamp/offset fidelity
+decimal fidelity
+successful empty retrieval
+failure mapping
+DI/configuration
+bounded Worker persistence execution
+```
+
+Do not create new tests or temporary semantic probes unless an existing
+repository verification mechanism already does so.
+
+WP01 is not the place to improve coverage.
+
+------------------------------------------------------------------------
+
+## 18. File-Manifest Reconciliation
+
+Reconcile current repository reality with
+`RELEASE_1.2_FILE_MANIFEST.md`.
+
+Verify:
+
+``` text
+WP01 has not mutated prohibited src/** surfaces
+WP01 has not mutated prohibited tests/** surfaces
+WP01 has not mutated package/build/solution files
+WP01 has not mutated eng/**
+WP01 has not mutated .github/**
+WP02 definition artifacts have not already appeared as unauthorized implementation
+WP03+ implementation artifacts have not already appeared
+Release 1.3 implementation artifacts have not appeared
+temporary SQLite/probe/generated artifacts are not being treated as candidate content
+```
+
+Do not hardcode a final Release 1.2 candidate path count in WP01.
+
+------------------------------------------------------------------------
+
+## 19. WP02 Protection
+
+Before WP01 can complete, explicitly prove WP02 has not begun.
+
+Require:
+
+``` text
+issue #122 remains OPEN / Backlog
+no Research Dataset Definition & Reproducibility Model implementation produced by WP01
+no WP02 decision/definition artifact created by WP01
+no dataset identity/version/provenance design started by WP01
+no source/test/schema/Worker mutation attributable to WP02
+```
+
+WP01 may inspect existing architecture/data documentation for baseline
+understanding, but must not edit it.
+
+------------------------------------------------------------------------
+
+## 20. Issue #121 Lifecycle
+
+Only after Sections 7--19 pass:
+
+1.  Move issue #121 / WP01 Project Status from `Backlog` to
+    `In Progress`.
+2.  Perform the final WP01 evidence pass.
+3.  Confirm no unauthorized repository mutation occurred.
+4.  Confirm issue #122 remains Open/Backlog.
+5.  Post concise evidence to #121.
+6.  Close issue #121.
+7.  Set Project Status to `Done`.
+
+Do not close #121 if any acceptance gate is unresolved.
+
+Do not modify Priority, Release, Area, assignee, dependencies, title,
+body, milestone, or labels unless the accepted planning state itself
+proves they have drifted; even then, WP01 does not authorize repair.
+Report drift instead.
+
+------------------------------------------------------------------------
+
+## 21. Final Validation
+
+After the issue lifecycle change, rerun enough non-mutating checks to
+prove that WP01 itself did not alter repository correctness.
+
+At minimum confirm:
+
+``` text
+working-tree classification unchanged except ordinary ignored validation output
+staged paths = 0
+tracked WP01 implementation mutations = 0
+restore/build/test baseline remains healthy
+architecture tests pass
+canonical verification passes
+git diff --check passes
+git diff --cached --check passes
+issue #121 = CLOSED / Done
+issue #122 = OPEN / Backlog
+milestone #53 remains OPEN
+Release 1.3 implementation remains not started
+```
+
+Remove only temporary artifacts created by WP01 itself when safe and
+explicitly identifiable. Never remove pre-existing user work or accepted
+governance inputs.
+
+------------------------------------------------------------------------
+
+## 22. Blocker Policy
+
+Stop without implementation if any of these occurs:
+
+``` text
+Release 1.1 closure cannot be proven
+PR #120 is not merged
+milestone #52 is unexpectedly open
+authoritative Release 1.2 milestone #53 is missing, duplicated, or closed
+legacy milestone #43 is unexpectedly active in a way that conflicts with accepted planning
+issues #121–#136 do not represent exactly WP01–WP16
+dependency drift is nonzero
+Project #2 required fields materially drift
+WP02 or later Release 1.2 implementation has already begun without accepted authority
+Release 1.3 implementation has begun
+working-tree state contains unexplained material mutations
+authority files materially conflict
+canonical baseline fails
+architecture baseline fails
+security/package baseline exposes an unresolved blocker
+required correction exceeds WP01 mutation authority
+```
+
+For a blocker, report:
+
+``` text
+blocker ID
+observed evidence
+why it violates authority
+what was not mutated
+smallest corrective authority required
+safe resume point
+```
+
+Do not create a recursive authority chain for cosmetic findings.
+Whitespace or formatting findings are simply baseline failures unless an
+existing authority already permits their correction.
+
+------------------------------------------------------------------------
+
+## 23. Required Execution Report
+
+Produce a structured report containing at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Release 1.1 Closure Gate
+7.  Release 1.2 Governance Gate
+8.  GitHub Planning Gate
+9.  Release 1.3 Protection
+10. Toolchain / SDK Baseline
+11. Initial Restore / Format / Build Evidence
+12. Initial Permanent Test Evidence
+13. Canonical Verification Evidence
+14. Architecture Baseline
+15. Release 1.1 Persistence Regression Baseline
+16. File-Manifest Reconciliation
+17. WP02 Protection
+18. Issue #121 Lifecycle
+19. Security / Offline Evidence
+20. Whitespace / Diff Evidence
+21. Mutation Accounting
+22. Git / GitHub Protection
+23. Findings / Blockers
+24. Acceptance Matrix
+25. Final Repository / GitHub State
+26. WP02 Handoff
+27. Final Decision
+28. Next Authorized Work Package
+
+Report actual observed values. Do not copy historical counts or SHAs as
+if newly verified.
+
+------------------------------------------------------------------------
+
+## 24. Acceptance Matrix
+
+WP01 passes only if all applicable rows pass:
+
+  Requirement                          Required result
+  ------------------------------------ -----------------------------------
+  Release 1.1 terminal closure         PASS
+  PR #120                              MERGED
+  Milestone #52                        CLOSED
+  Issues #103--#118                    CLOSED / DONE
+  Release 1.2 governance authorities   PRESENT / CONSISTENT
+  WP01 chat companion                  EXACTLY 5 LINES
+  Milestone #53                        EXACTLY 1 / OPEN
+  WP01--WP16 issues                    16/16
+  Dependency drift                     0
+  Project membership                   16/16
+  Starting Project Status              Backlog 16/16
+  Priority                             P1 16/16
+  Release                              1.2 16/16
+  Area                                 populated 16/16
+  WP17+                                0
+  Lifecycle-gate issues                0
+  Legacy #43                           CLOSED / EMPTY
+  Local/remote repository state        CLASSIFIED / SAFE
+  Unexpected working-tree paths        0 or fully explained non-blocking
+  Restore                              PASS
+  Format verification                  PASS
+  Build                                PASS / 0 errors
+  Permanent tests                      PASS
+  Architecture tests                   PASS
+  Canonical verification               PASS
+  Production dependency drift          0
+  Domain/Application SQLite leakage    0
+  Release 1.1 persistence regression   PASS
+  Unauthorized production mutations    0
+  Unauthorized test mutations          0
+  Package/reference delta              0/0
+  WP02 started                         NO
+  Release 1.3 implementation started   NO
+  Issue #121 final state               CLOSED / DONE
+  Issue #122 final state               OPEN / BACKLOG
+  Milestone #53 final state            OPEN
+  Staged paths                         0
+
+------------------------------------------------------------------------
+
+## 25. Required Terminal Summary
+
+If successful, end exactly with:
+
+``` text
+RELEASE 1.2 WP01 COMPLETE
+
+RELEASE & REPOSITORY PREFLIGHT:
+Release 1.1 closure: PASS
+PR #120 merged: PASS
+Milestone #52 closed: PASS
+Release 1.2 governance: PASS
+Milestone #53 authoritative/open: PASS
+WP01–WP16 planning: PASS
+Dependency drift: 0
+Repository baseline: PASS
+Restore/build/format: PASS
+Permanent tests: PASS
+Architecture validation: PASS
+Canonical verification: PASS
+Release 1.1 persistence regression: PASS
+Unauthorized production mutations: 0
+Unauthorized test mutations: 0
+Package/reference delta: 0/0
+WP02 started: NO
+Release 1.3 implementation started: NO
+Issue #121: CLOSED / DONE
+
+NEXT AUTHORIZED WORK PACKAGE:
+WP02 — Research Dataset Definition & Reproducibility Model
+GitHub issue #122
+```
+
+If blocked, end exactly with:
+
+``` text
+RELEASE 1.2 WP01 BLOCKED
+```
+
+Do not print the success terminal unless every mandatory acceptance gate
+passes.
+
+------------------------------------------------------------------------
+
+## 26. Final Constraint
+
+WP01 establishes the trusted starting point for Release 1.2.
+
+It must not make the repository appear ready by repairing evidence it
+was only authorized to inspect.
+
+**Verify first. Classify precisely. Mutate only issue #121 lifecycle
+after the baseline passes. Preserve Release 1.1. Do not start WP02.**

--- a/docs/roadmap/release-1.2/prompts/02-research-dataset-definition-reproducibility-model-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/02-research-dataset-definition-reproducibility-model-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Use GPT-5.6 Sol. Execute Release 1.2 WP02 — Research Dataset Definition & Reproducibility Model.
+Read `02-research-dataset-definition-reproducibility-model-codex-prompt.md` completely and treat it as the execution authority.
+Reconcile the accepted WP01 baseline, Release 1.1 observation semantics, Release 1.2 plan/manifest, issue #122, milestone #53, and current repository truth before mutation.
+Produce only manifest-authorized WP02 definition/research artifacts; do not change production code, tests, packages/references, physical storage, WP03+, or Release 1.3.
+Return the required execution report and terminal marker; close #122 only after every gate passes and leave #123 Open/Backlog.

--- a/docs/roadmap/release-1.2/prompts/02-research-dataset-definition-reproducibility-model-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/02-research-dataset-definition-reproducibility-model-codex-prompt.md
@@ -1,0 +1,1122 @@
+# Release 1.2 WP02 --- Research Dataset Definition & Reproducibility Model --- Codex Prompt
+
+## Role
+
+Act as the **WP02 Research Dataset Definition & Reproducibility Model
+Executor** for Release 1.2 of `AIQuantTradingResearch`.
+
+This is a bounded **research, definition, and decision** work package.
+Its purpose is to establish the authoritative conceptual model for a
+deterministic, versioned, reproducible research dataset built from the
+accepted Release 1.1 historical-observation foundation.
+
+Use **GPT-5.6 Sol** for this work package.
+
+Do not implement dataset behavior. Do not start WP03.
+
+------------------------------------------------------------------------
+
+## 1. Mandatory Authorities
+
+Read completely before acting:
+
+``` text
+RELEASE_1.2_EXECUTION_PLAN.md
+RELEASE_1.2_FILE_MANIFEST.md
+release-1.2-github-planning-codex-prompt.md
+release-1.2-github-planning-codex-prompt-chat.md
+01-release-repository-preflight-codex-prompt.md
+01-release-repository-preflight-codex-prompt-chat.md
+02-research-dataset-definition-reproducibility-model-codex-prompt.md
+02-research-dataset-definition-reproducibility-model-codex-prompt-chat.md
+```
+
+Also inspect:
+
+``` text
+accepted WP01 execution result
+accepted Release 1.1 persistence semantics and implementation
+current Domain/Application/Infrastructure/Worker contracts
+current data architecture and glossary documentation
+current repository and test state
+GitHub milestone #53
+GitHub issue #122
+GitHub issue #123
+Project #2
+```
+
+Authority precedence:
+
+``` text
+1. RELEASE_1.2_EXECUTION_PLAN.md
+2. RELEASE_1.2_FILE_MANIFEST.md
+3. Accepted Release 1.2 GitHub planning state
+4. Accepted WP01 result
+5. Accepted Release 1.1 repository truth
+6. Existing repository architecture/governance conventions
+7. This execution prompt
+```
+
+If authorities materially conflict, stop and report the smallest precise
+blocker. Do not silently reconcile contradictory authority.
+
+------------------------------------------------------------------------
+
+## 2. Accepted Starting Baseline
+
+Treat the accepted WP01 result as the starting baseline unless current
+evidence proves drift:
+
+``` text
+Repository: samuel-santos-engineer/AIQuantTradingResearch
+Branch: main
+WP01 accepted HEAD: 3ae8ba300fcd356b71fb4fdef5258dc23a99abeb
+local main = origin/main at WP01 completion
+staged paths: 0
+tracked modifications: 0
+
+Release 1.1:
+  PR #120: MERGED
+  milestone #52: CLOSED
+  issues #103–#118: CLOSED / DONE
+  persistence regression baseline: PASS
+
+Release 1.2:
+  milestone #53: OPEN
+  issue #121: CLOSED / DONE
+  issue #122: OPEN / BACKLOG
+  issue #123: OPEN / BACKLOG
+  dependency drift: 0
+  legacy milestone #43: CLOSED / EMPTY
+  Release 1.3 implementation: NOT STARTED
+
+Technical baseline:
+  .NET SDK: 10.0.103
+  target framework: net10.0
+  Domain.Tests: 11/11
+  Application.Tests: 42/42
+  Infrastructure.Tests: 79/79
+  Architecture.Tests: 13/13
+  total permanent tests: 145/145
+  canonical verification: PASS
+```
+
+The SHA and test counts above are historical WP01 evidence. Re-observe
+current truth; do not reset or falsify current state to match them.
+
+------------------------------------------------------------------------
+
+## 3. Objective
+
+Define the Release 1.2 **Research Dataset** concept and its
+**reproducibility model** precisely enough that WP03--WP16 can build on
+it without reopening foundational meaning.
+
+WP02 must answer, at minimum:
+
+``` text
+What is a research dataset in this platform?
+What is explicitly not a research dataset?
+What source material may participate in a dataset?
+What constitutes the dataset definition/specification?
+What constitutes a materialized dataset?
+What is a dataset snapshot?
+What makes a materialization deterministic?
+What does reproducibility mean?
+What inputs must be fixed for reproducibility?
+What outputs must be invariant for equivalent materializations?
+How are observation selection boundaries expressed conceptually?
+How are ordering and normalization treated?
+How does Release 1.1 historical observation truth participate?
+What happens when source history changes after a dataset is materialized?
+What must be immutable versus recomputable?
+What metadata is conceptually required to explain a materialization?
+What belongs to WP02 versus WP03 identity/version/provenance?
+What belongs to WP06 catalog metadata?
+What belongs to WP07+ physical storage?
+What belongs to Release 1.3 pipelines and is therefore excluded?
+```
+
+The result must be sufficiently deterministic to constrain later
+implementation while remaining **storage-independent,
+provider-independent, and implementation-independent**.
+
+------------------------------------------------------------------------
+
+## 4. WP02 Core Boundary
+
+WP02 owns **definition and reproducibility semantics**.
+
+WP02 does not own:
+
+``` text
+final dataset identifier representation
+final version identifier representation
+hash/digest algorithm selection
+canonical serialization format
+provenance identifier encoding
+lineage persistence representation
+Application interfaces or result types
+materialization use-case implementation
+catalog object implementation
+SQLite tables/columns/indexes/schema
+snapshot persistence implementation
+catalog persistence/lookup implementation
+failure mapping implementation
+DI registration
+Worker execution
+permanent tests
+Release 1.3 ingestion/pipeline orchestration
+```
+
+Where WP02 needs a concept later owned by WP03+, define the **semantic
+requirement** without selecting the later work package's representation.
+
+Example:
+
+``` text
+Allowed in WP02:
+"Equivalent materializations must be distinguishable from materially different dataset definitions."
+
+Not allowed in WP02:
+"The dataset ID is SHA-256 over canonical JSON."
+```
+
+------------------------------------------------------------------------
+
+## 5. Authorized Repository Scope
+
+Use `RELEASE_1.2_FILE_MANIFEST.md` as the exact path authority.
+
+You may create or modify **only the WP02 research/definition artifacts
+explicitly assigned to WP02 by the manifest**.
+
+Do not invent alternative paths merely because they seem convenient.
+
+If the manifest permits a WP02 definition artifact but does not fully
+prescribe its content, produce the smallest coherent authoritative
+artifact set necessary to capture the decisions in this prompt.
+
+Expected character of WP02 artifacts:
+
+``` text
+research/definition/decision documentation
+no production source
+no permanent test source
+no package changes
+no project-reference changes
+no solution/build/script changes
+no GitHub workflow changes
+```
+
+The WP02 prompt pair itself is governance input and must not be
+rewritten.
+
+If the manifest provides no legal location for a required WP02 output,
+stop and report the manifest gap rather than writing outside authority.
+
+------------------------------------------------------------------------
+
+## 6. Prohibited Scope
+
+Do not:
+
+``` text
+modify Domain production code
+modify Application production code
+modify Infrastructure production code
+modify Worker production code
+modify permanent tests
+modify architecture tests
+add packages
+change package versions
+change project references
+change solution membership
+change build policy
+change engineering scripts
+change GitHub workflows
+define SQLite schema
+write SQL
+create database files as repository artifacts
+implement dataset materialization
+implement snapshot persistence
+implement catalog persistence
+implement lookup behavior
+implement dataset validation/failure mapping
+implement DI/configuration
+implement Worker dataset execution
+define Release 1.3 pipelines
+start WP03
+stage
+commit
+push
+create a branch
+create a PR
+merge
+tag
+create a GitHub Release
+close milestone #53
+edit issues #123–#136
+change planning dependencies
+change Project fields other than authorized #122 lifecycle
+```
+
+Do not repair unrelated repository drift.
+
+------------------------------------------------------------------------
+
+## 7. Starting-State Gate
+
+Before changing issue #122:
+
+1.  Verify repository identity and current Git state.
+2.  Verify WP01 issue #121 is Closed/Done.
+3.  Verify WP02 issue #122 is Open/Backlog.
+4.  Verify WP03 issue #123 is Open/Backlog.
+5.  Verify milestone #53 is Open.
+6.  Verify WP02 dependency is exactly WP01.
+7.  Verify no dependency drift affecting WP02.
+8.  Verify Release 1.3 implementation remains unstarted.
+9.  Classify all staged, modified, and untracked paths.
+10. Verify accepted cumulative Release 1.2 governance artifacts are
+    preserved.
+11. Verify no WP02 semantic artifact already exists in a conflicting or
+    ambiguous state.
+12. Verify no WP03 implementation/decision artifact has already
+    preempted WP02.
+
+If any material ambiguity exists, stop before lifecycle mutation.
+
+------------------------------------------------------------------------
+
+## 8. Initial Technical Baseline
+
+Before moving #122 to In Progress, run the canonical non-mutating
+baseline appropriate to the repository:
+
+``` text
+restore
+format verification
+build
+permanent tests
+architecture tests
+eng/verify.ps1
+git diff --check
+git diff --cached --check
+```
+
+Record actual current counts.
+
+Provider/network calls are prohibited except Git/GitHub metadata and
+ordinary package restore if needed.
+
+If baseline validation fails, do not start WP02.
+
+------------------------------------------------------------------------
+
+## 9. Research Method
+
+Base the definition on repository truth, not generic dataset theory
+alone.
+
+Inspect and reconcile at least:
+
+``` text
+Release 1.1 PriceObservation semantics
+historical observation persistence semantics
+target identity behavior
+semantic instant identity
+timestamp/offset fidelity
+decimal fidelity
+retrieval ordering
+immutable-history behavior
+idempotency/conflict semantics
+successful empty retrieval
+current data architecture documentation
+current domain glossary/business concepts
+current Application boundaries
+Release 1.2 execution plan
+Release 1.2 file manifest
+```
+
+You may reason from established software/data principles where
+repository authority leaves a genuine design choice, but clearly
+distinguish:
+
+``` text
+existing repository fact
+Release 1.2 requirement
+WP02 decision
+deferred decision
+```
+
+Do not browse for or adopt an external dataset framework unless the
+execution plan explicitly requires one. WP02 should remain
+repository-native and zero-cost.
+
+------------------------------------------------------------------------
+
+## 10. Required Dataset Vocabulary
+
+Establish precise definitions for at least:
+
+``` text
+Research Dataset
+Dataset Definition
+Dataset Materialization
+Dataset Snapshot
+Source Observation
+Selection Boundary
+Reproducibility
+Determinism
+Equivalent Materialization
+Dataset Metadata
+Provenance
+Lineage
+Catalog
+```
+
+Definitions must avoid circularity.
+
+Where terms belong primarily to later WPs, WP02 should define only
+enough meaning to establish boundaries and defer representation.
+
+Use existing repository terminology where it already has authoritative
+meaning.
+
+------------------------------------------------------------------------
+
+## 11. Research Dataset Definition
+
+The definition must establish that a Release 1.2 research dataset is a
+**research-owned, deterministic materialization of explicitly selected
+accepted market observations plus the metadata necessary to explain how
+that materialization was produced**.
+
+Reconcile this statement against repository truth rather than copying it
+blindly.
+
+At minimum determine whether the dataset is:
+
+``` text
+a live query or a durable research artifact
+provider transport data or normalized platform data
+mutable working state or immutable materialized state
+defined by source observations alone or by observations plus selection/transformation rules
+allowed to depend on current wall-clock time implicitly
+allowed to depend on provider ordering implicitly
+allowed to contain observations rejected by Release 1.1 semantics
+allowed to rewrite accepted historical observations
+```
+
+The preferred direction is:
+
+``` text
+not provider transport
+not a live provider query
+not an implicit "latest data" view
+not permission to mutate Release 1.1 history
+based on accepted normalized historical observations
+explicitly bounded
+deterministically ordered
+materialized as immutable research evidence
+```
+
+If repository authority contradicts any preferred direction, follow
+repository authority and document the conflict.
+
+------------------------------------------------------------------------
+
+## 12. Definition vs Materialization vs Snapshot
+
+WP02 must separate three concepts.
+
+### Dataset Definition
+
+The declarative intent/rules that determine what dataset should be
+produced.
+
+Conceptually consider:
+
+``` text
+source target(s)
+selection interval/boundaries
+inclusion semantics
+ordering semantics
+any Release 1.2-authorized deterministic transformation/filter semantics
+definition-level parameters
+```
+
+Do not invent transformations not required by the accepted Release 1.2
+scope.
+
+### Dataset Materialization
+
+The act/result of resolving a dataset definition against accepted source
+history.
+
+A materialization must not be confused with the definition itself.
+
+### Dataset Snapshot
+
+The durable immutable representation of one successful materialization.
+
+WP08 owns persistence mechanics. WP02 owns only the semantic
+distinction.
+
+State explicitly whether a successful materialization with zero selected
+observations is valid, invalid, or deferred. Make the decision
+consistent with Release 1.1 successful-empty retrieval and the Release
+1.2 purpose.
+
+Do not let physical storage considerations dictate this semantic
+decision.
+
+------------------------------------------------------------------------
+
+## 13. Reproducibility Model
+
+Define reproducibility operationally.
+
+A strong default requirement is:
+
+> Given the same authoritative dataset definition and the same
+> authoritative source-observation state relevant to that definition,
+> materialization must produce semantically equivalent dataset content
+> and explanatory metadata independent of execution time, process
+> instance, machine, provider response order, or database row-return
+> order.
+
+Refine this into repository-specific requirements.
+
+Explicitly decide treatment of:
+
+``` text
+execution timestamp
+wall-clock "now"
+machine path
+process ID
+random values
+unordered collections
+database natural row order
+provider response order
+locale/culture
+timezone conversion
+floating-point conversion
+current provider state
+environment-specific configuration
+```
+
+Any non-deterministic operational metadata that may legitimately differ
+between executions must be clearly separated from the semantic content
+used to determine equivalence.
+
+Do not select the final canonical byte representation or digest
+algorithm; WP03 owns identity/version/provenance representation.
+
+------------------------------------------------------------------------
+
+## 14. Reproducibility Inputs
+
+Identify the minimal semantic inputs that must be fixed to reproduce a
+materialization.
+
+At minimum evaluate:
+
+``` text
+dataset definition
+target identity
+selection boundaries
+accepted source observations
+source observation semantic instants
+source observation values
+ordering rule
+definition parameters
+transformation/filter rules, if any are actually in Release 1.2 scope
+```
+
+For every proposed input classify it as:
+
+``` text
+required semantic input
+explanatory metadata only
+operational metadata only
+deferred to later WP
+out of scope
+```
+
+Do not make a physical database row ID, file path, connection string,
+provider DTO, or machine-specific value part of dataset semantics.
+
+------------------------------------------------------------------------
+
+## 15. Source Observation Authority
+
+Release 1.2 must reuse Release 1.1 accepted historical observations
+rather than redefine market-observation truth.
+
+Establish:
+
+``` text
+Release 1.1 persisted observations are the authoritative normalized source material for Release 1.2 datasets
+provider DTOs are not dataset source truth
+dataset materialization does not rewrite source observations
+dataset materialization does not repair source history
+source identity retains exact target + semantic instant meaning
+source timestamp/offset and decimal fidelity must not be degraded
+source retrieval ordering must not be treated as accidental
+```
+
+Clarify whether dataset semantic content requires preserving the
+original offset representation in addition to the absolute instant.
+Follow accepted Release 1.1 fidelity semantics and avoid silently
+weakening them.
+
+------------------------------------------------------------------------
+
+## 16. Selection-Boundary Semantics
+
+Define conceptual selection boundaries without choosing storage or API
+representation.
+
+Decide:
+
+``` text
+whether time boundaries are explicit
+whether lower/upper boundaries are inclusive or exclusive
+whether an unbounded side is allowed
+whether target selection is exact
+whether multiple targets are in Release 1.2 scope
+how empty selections behave
+whether selection depends on insertion order
+```
+
+Use the execution plan and accepted definition to determine whether
+Release 1.2 is single-target or multi-target. Do not broaden scope
+merely for future flexibility.
+
+Boundary semantics must be deterministic and testable by later WPs.
+
+------------------------------------------------------------------------
+
+## 17. Ordering and Canonical Semantic Content
+
+Define semantic ordering independently of physical storage.
+
+At minimum:
+
+``` text
+dataset observation order must be deterministic
+database natural order is not authoritative
+provider response order is not authoritative
+semantic instant ordering from Release 1.1 must be preserved where applicable
+duplicate semantic identities must not be introduced by dataset materialization
+```
+
+If multi-target datasets are in scope, define a deterministic
+cross-target ordering rule at the semantic level or explicitly defer it
+only if the accepted Release 1.2 definition guarantees single-target
+datasets.
+
+Do not choose a serialization format.
+
+------------------------------------------------------------------------
+
+## 18. Source-History Change Model
+
+This is a mandatory WP02 decision.
+
+Distinguish:
+
+``` text
+dataset definition stability
+source-history state
+materialization event
+materialized snapshot
+```
+
+Decide what happens when accepted Release 1.1 history changes after a
+dataset was materialized.
+
+The model must support both facts:
+
+1.  A previously materialized snapshot is immutable research evidence.
+2.  Re-materializing the same definition against a materially changed
+    authoritative source state may legitimately produce a different
+    materialization.
+
+Do not solve this by inventing the final version/provenance identifier.
+WP03 owns how distinct states are identified and related.
+
+Define the semantic requirement WP03 must satisfy.
+
+------------------------------------------------------------------------
+
+## 19. Equivalent Materialization
+
+Define semantic equivalence precisely enough for WP03 and later tests.
+
+Evaluate whether equivalence requires equality of:
+
+``` text
+dataset definition semantics
+selected target(s)
+selection boundaries
+ordered observation identities
+ordered observation values
+timestamp/offset fidelity
+definition-level parameters
+deterministic transformations
+semantic metadata
+operational execution metadata
+```
+
+Operational facts such as execution duration or process identity should
+not make otherwise equivalent datasets semantically different unless
+repository authority explicitly requires that.
+
+State which fields must be excluded from equivalence.
+
+Do not define hash bytes.
+
+------------------------------------------------------------------------
+
+## 20. Immutability and Re-materialization
+
+Define:
+
+``` text
+whether a materialized snapshot is immutable
+whether an existing snapshot may be overwritten
+whether re-materialization creates/reuses an equivalent semantic result
+whether a changed source state may replace an older snapshot
+whether old snapshots remain valid historical research evidence
+```
+
+Preferred invariant:
+
+``` text
+accepted snapshots are immutable
+re-materialization never rewrites historical evidence
+equivalent re-materialization may be recognized as equivalent
+materially different re-materialization must remain distinguishable
+```
+
+WP08/WP09 own persistence mechanics; WP03 owns
+identity/version/provenance representation.
+
+------------------------------------------------------------------------
+
+## 21. Metadata, Provenance, Lineage, and Catalog Boundary
+
+Define the semantic boundary among:
+
+### Dataset Metadata
+
+Descriptive information needed to understand the dataset.
+
+### Provenance
+
+Evidence of the authoritative source state and definition from which the
+materialization arose.
+
+### Lineage
+
+The relationship between the dataset and its source observations/inputs.
+
+### Catalog
+
+The discoverable record/index of dataset materializations and their
+metadata.
+
+WP02 must identify **what must be knowable**.
+
+WP03 owns identity/version/provenance semantics in detail.
+
+WP06 owns the metadata/catalog model.
+
+WP09 owns catalog persistence and lookup.
+
+Do not preempt those designs with storage structures or concrete
+identifiers.
+
+------------------------------------------------------------------------
+
+## 22. Failure and Validation Boundary
+
+WP02 may identify semantic invalidity conditions necessary to define
+reproducibility, for example:
+
+``` text
+ambiguous definition
+invalid selection boundaries
+unsupported target scope
+non-deterministic definition input
+source state that cannot satisfy required fidelity
+```
+
+Do not create public failure enums or Infrastructure exception mappings.
+
+WP11 owns validation and failure mapping.
+
+Distinguish:
+
+``` text
+invalid dataset definition
+valid definition producing empty dataset
+materialization operational failure
+source-data semantic failure
+```
+
+Only define categories conceptually where required.
+
+------------------------------------------------------------------------
+
+## 23. Release 1.3 Pipeline Exclusion
+
+Release 1.2 is the Research Dataset Foundation, not the pipeline
+release.
+
+Explicitly exclude:
+
+``` text
+continuous ingestion pipelines
+scheduled dataset refresh
+event-driven rematerialization
+automatic recomputation
+stream processing
+pipeline DAG orchestration
+background dataset monitoring
+production scheduling
+pipeline retries/resilience
+```
+
+A bounded execution path later owned by WP12 may demonstrate dataset
+execution, but it must not become Release 1.3 pipeline infrastructure.
+
+------------------------------------------------------------------------
+
+## 24. Decision Alternatives
+
+For each material WP02 decision, document:
+
+``` text
+decision
+alternatives considered
+selected option
+rationale
+consequences
+deferred representation/implementation
+```
+
+At minimum compare alternatives for:
+
+1.  live-query dataset vs durable materialized dataset
+2.  mutable dataset vs immutable snapshot
+3.  implicit current source state vs explicit reproducibility inputs
+4.  execution metadata included vs excluded from semantic equivalence
+5.  overwrite-on-rematerialization vs preserve historical snapshots
+6.  empty selection invalid vs valid empty materialization
+7.  source-provider data vs accepted Release 1.1 observations as source
+    truth
+
+Keep analysis proportional. Do not create speculative architecture for
+later releases.
+
+------------------------------------------------------------------------
+
+## 25. Required WP03 Handoff Contract
+
+End the WP02 definition artifacts with an explicit handoff to WP03.
+
+WP03 must receive settled semantic requirements for:
+
+``` text
+what needs identity
+what constitutes semantic equivalence
+what changes require distinguishability
+what source-state facts provenance must explain
+what lineage must relate
+what must remain immutable
+what operational metadata must not affect semantic identity
+what definition/source changes may produce a distinct materialization
+```
+
+WP02 must explicitly leave these representation decisions open for WP03:
+
+``` text
+identifier shape
+version shape
+digest/hash choice
+canonical serialization
+provenance encoding
+lineage identifier encoding
+physical persistence representation
+```
+
+If WP02 accidentally decides these, revise the WP02 artifact before
+acceptance.
+
+------------------------------------------------------------------------
+
+## 26. Issue #122 Lifecycle
+
+Only after the starting-state and initial technical baseline pass:
+
+1.  Move issue #122 from `Backlog` to `In Progress`.
+2.  Perform the authorized WP02 research/definition work.
+3.  Validate the artifacts against this authority and the file manifest.
+4.  Rerun final technical and scope checks.
+5.  Post concise evidence to issue #122.
+6.  Close issue #122.
+7.  Set Project Status to `Done`.
+
+Do not modify #123 except to inspect and prove it remains Open/Backlog.
+
+------------------------------------------------------------------------
+
+## 27. Validation Requirements
+
+Before closing WP02, run:
+
+``` text
+dotnet restore AIQuantTradingResearch.slnx
+dotnet format AIQuantTradingResearch.slnx --verify-no-changes
+dotnet build AIQuantTradingResearch.slnx --no-restore
+dotnet test AIQuantTradingResearch.slnx --no-build
+eng/verify.ps1
+git diff --check
+git diff --cached --check
+```
+
+Also verify:
+
+``` text
+Domain production delta: 0
+Application production delta: 0
+Infrastructure production delta: 0
+Worker production delta: 0
+permanent test delta: 0
+package delta: 0
+project-reference delta: 0
+solution/build/script delta: 0
+WP03 started: NO
+Release 1.3 implementation started: NO
+provider/network calls during WP02 validation: 0
+temporary database residue: 0
+```
+
+Run any existing repository-relative Markdown/link validation applicable
+to newly created documentation.
+
+Do not introduce a new validator merely for WP02.
+
+------------------------------------------------------------------------
+
+## 28. Semantic Acceptance Matrix
+
+WP02 passes only if the accepted artifacts establish all applicable
+rows:
+
+  Requirement                                              Required result
+  -------------------------------------------------------- -----------------
+  Research Dataset defined                                 PASS
+  Dataset Definition defined                               PASS
+  Materialization defined                                  PASS
+  Snapshot defined                                         PASS
+  Source truth is Release 1.1 accepted observations        PASS
+  Provider transport excluded from source truth            PASS
+  Selection boundaries deterministic                       PASS
+  Ordering deterministic                                   PASS
+  Reproducibility operationally defined                    PASS
+  Required reproducibility inputs classified               PASS
+  Non-semantic operational metadata separated              PASS
+  Equivalent materialization defined                       PASS
+  Source-history change behavior defined                   PASS
+  Snapshot immutability defined                            PASS
+  Re-materialization behavior defined                      PASS
+  Empty selection/materialization semantics decided        PASS
+  Timestamp/offset fidelity preserved                      PASS
+  Decimal fidelity preserved                               PASS
+  Dataset does not mutate source history                   PASS
+  Metadata/provenance/lineage/catalog boundaries defined   PASS
+  WP03 representation decisions deferred                   PASS
+  WP06 catalog implementation deferred                     PASS
+  WP07+ physical storage deferred                          PASS
+  Release 1.3 pipelines excluded                           PASS
+  Cross-document contradictions                            0
+
+------------------------------------------------------------------------
+
+## 29. Mutation Acceptance Matrix
+
+  Requirement                          Required result
+  ------------------------------------ --------------------------
+  WP01 predecessor                     CLOSED / DONE
+  Issue #122 initial state             OPEN / BACKLOG
+  Issue #123 initial/final state       OPEN / BACKLOG
+  Milestone #53                        OPEN
+  Authorized WP02 artifact paths       only manifest-authorized
+  Production code delta                0
+  Permanent test delta                 0
+  Package/reference delta              0/0
+  Solution/build/script delta          0
+  Unauthorized documentation delta     0
+  Restore                              PASS
+  Format verification                  PASS
+  Build                                PASS / 0 errors
+  Permanent tests                      PASS
+  Architecture tests                   PASS
+  Canonical verification               PASS
+  Diff checks                          PASS
+  Provider/network calls               0
+  Temporary database residue           0
+  WP03 started                         NO
+  Release 1.3 implementation started   NO
+  Issue #122 final state               CLOSED / DONE
+
+------------------------------------------------------------------------
+
+## 30. Blocker Policy
+
+Stop if:
+
+``` text
+WP01 is not Closed/Done
+#122 is not Open/Backlog at start
+#123 has already started
+milestone #53 is not the authoritative open Release 1.2 milestone
+repository state contains unexplained material drift
+Release 1.3 implementation has started
+the file manifest provides no authorized location for required WP02 outputs
+authorities materially conflict
+baseline restore/build/test/architecture/canonical verification fails
+a semantic decision cannot be made without preempting WP03 or another later WP
+the accepted Release 1.1 observation foundation is insufficient for the Release 1.2 definition
+```
+
+Report:
+
+``` text
+blocker ID
+evidence
+authority violated
+smallest corrective authority required
+repository/GitHub mutations avoided
+safe resume point
+```
+
+Do not create a recursive authority chain for ordinary wording or
+whitespace findings. Correct findings inside WP02-authorized artifacts
+before acceptance when the correction stays inside this authority.
+
+------------------------------------------------------------------------
+
+## 31. Required Execution Report
+
+Produce a structured report containing at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Predecessor / Lifecycle Gates
+7.  Issue #122 Lifecycle
+8.  Initial Technical Baseline
+9.  Existing Data / Persistence Semantics Reconciled
+10. Research Dataset Definition
+11. Dataset Definition Model
+12. Materialization Model
+13. Snapshot Model
+14. Reproducibility Definition
+15. Reproducibility Inputs
+16. Source Observation Authority
+17. Selection-Boundary Semantics
+18. Ordering Semantics
+19. Empty Materialization Decision
+20. Source-History Change Model
+21. Equivalent Materialization Semantics
+22. Immutability / Re-materialization Model
+23. Metadata / Provenance / Lineage / Catalog Boundary
+24. Validation / Failure Concept Boundary
+25. Release 1.3 Exclusions
+26. Alternatives and Decisions
+27. WP03 Handoff
+28. Exact Files Added / Modified
+29. Production / Test Delta
+30. Package / Reference Delta
+31. Security / Offline Evidence
+32. Whitespace / Link Evidence
+33. Restore / Build / Test Evidence
+34. Canonical Verification
+35. Architecture Validation
+36. Mutation Accounting
+37. Git / GitHub Protection
+38. Findings / Blockers
+39. Semantic Acceptance Matrix
+40. Final Repository / GitHub State
+41. Final Decision
+42. Next Authorized Work Package
+
+Use actual observed evidence, not assumed values.
+
+------------------------------------------------------------------------
+
+## 32. Required Terminal Summary
+
+If successful, end exactly with:
+
+``` text
+RELEASE 1.2 WP02 COMPLETE
+
+RESEARCH DATASET DEFINITION & REPRODUCIBILITY MODEL:
+Research Dataset definition: PASS
+Dataset Definition / Materialization / Snapshot separation: PASS
+Release 1.1 observations as source truth: PASS
+Deterministic selection: PASS
+Deterministic ordering: PASS
+Reproducibility model: PASS
+Equivalent materialization semantics: PASS
+Source-history change model: PASS
+Snapshot immutability: PASS
+Empty materialization semantics: PASS
+Timestamp/offset/decimal fidelity: PASS
+Metadata/provenance/lineage/catalog boundaries: PASS
+WP03 representation decisions deferred: PASS
+Production code delta: 0
+Permanent test delta: 0
+Package/reference delta: 0/0
+WP03 started: NO
+Release 1.3 implementation started: NO
+Issue #122: CLOSED / DONE
+
+NEXT AUTHORIZED WORK PACKAGE:
+WP03 — Dataset Identity, Version & Provenance Semantics
+GitHub issue #123
+```
+
+If blocked, end exactly with:
+
+``` text
+RELEASE 1.2 WP02 BLOCKED
+```
+
+Do not print the success marker unless every mandatory gate passes.
+
+------------------------------------------------------------------------
+
+## 33. Final Constraint
+
+WP02 is the semantic foundation for the rest of Release 1.2.
+
+Prefer a **small, explicit, deterministic model** over speculative
+flexibility.
+
+Preserve Release 1.1 observation truth. Separate definition from
+materialization from snapshot. Define reproducibility without
+prematurely defining identifiers. Keep storage, contracts, catalog
+implementation, and pipelines out of scope.
+
+**Settle meaning now; leave representation to the work package that owns
+it.**

--- a/docs/roadmap/release-1.2/prompts/03-dataset-identity-version-provenance-semantics-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/03-dataset-identity-version-provenance-semantics-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Use GPT-5.6 Sol and execute `03-dataset-identity-version-provenance-semantics-codex-prompt.md` as the authoritative Release 1.2 WP03 contract.
+Read all mandatory authorities and accepted WP02 evidence before mutation; verify issue #123 is Open/Backlog and #124 remains Open/Backlog.
+Perform only manifest-authorized identity/version/provenance semantic work; do not implement WP04 contracts, storage, catalog persistence, tests, or Release 1.3 behavior.
+Run every required baseline, semantic, scope, architecture, security, whitespace, and final validation gate; stop on any material authority conflict or unexplained drift.
+If all gates pass, close #123 as Done, leave #124 untouched, and end with the exact `RELEASE 1.2 WP03 COMPLETE` terminal summary.

--- a/docs/roadmap/release-1.2/prompts/03-dataset-identity-version-provenance-semantics-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/03-dataset-identity-version-provenance-semantics-codex-prompt.md
@@ -1,0 +1,1230 @@
+# Release 1.2 WP03 --- Dataset Identity, Version & Provenance Semantics --- Codex Prompt
+
+## Role
+
+Act as the **WP03 Dataset Identity, Version & Provenance Semantics
+Executor** for Release 1.2 of `AIQuantTradingResearch`.
+
+This is a bounded **semantic design and decision** work package. Its
+purpose is to convert the accepted WP02 dataset/reproducibility model
+into precise, deterministic identity, version, provenance, and lineage
+semantics that later Application, catalog, persistence, integration, and
+test work can implement without reopening foundational meaning.
+
+Use **GPT-5.6 Sol** for this work package.
+
+Do not implement Application contracts, storage, catalog persistence, or
+materialization behavior. Do not start WP04.
+
+------------------------------------------------------------------------
+
+## 1. Mandatory Authorities
+
+Read completely before acting:
+
+``` text
+RELEASE_1.2_EXECUTION_PLAN.md
+RELEASE_1.2_FILE_MANIFEST.md
+release-1.2-github-planning-codex-prompt.md
+release-1.2-github-planning-codex-prompt-chat.md
+01-release-repository-preflight-codex-prompt.md
+01-release-repository-preflight-codex-prompt-chat.md
+02-research-dataset-definition-reproducibility-model-codex-prompt.md
+02-research-dataset-definition-reproducibility-model-codex-prompt-chat.md
+03-dataset-identity-version-provenance-semantics-codex-prompt.md
+03-dataset-identity-version-provenance-semantics-codex-prompt-chat.md
+docs/architecture/data/RESEARCH_DATASET_DEFINITION.md
+```
+
+Also inspect:
+
+``` text
+accepted WP01 execution result
+accepted WP02 execution result
+accepted Release 1.1 persistence semantics and implementation
+current Domain/Application/Infrastructure/Worker contracts
+current data architecture, glossary, catalog, versioning, and provenance-related documentation
+current repository and permanent-test state
+GitHub milestone #53
+GitHub issue #123
+GitHub issue #124
+Project #2
+```
+
+Authority precedence:
+
+``` text
+1. RELEASE_1.2_EXECUTION_PLAN.md
+2. RELEASE_1.2_FILE_MANIFEST.md
+3. Accepted Release 1.2 GitHub planning state
+4. Accepted WP02 result and RESEARCH_DATASET_DEFINITION.md
+5. Accepted WP01 result
+6. Accepted Release 1.1 repository truth
+7. Existing repository architecture/governance conventions
+8. This execution prompt
+```
+
+If authorities materially conflict, stop and report the smallest precise
+blocker. Do not silently reconcile contradictory authority.
+
+------------------------------------------------------------------------
+
+## 2. Accepted Starting Baseline
+
+Treat the accepted WP02 result as the semantic starting baseline unless
+current evidence proves drift:
+
+``` text
+Repository: samuel-santos-engineer/AIQuantTradingResearch
+Branch: main
+WP02 accepted HEAD: 3ae8ba300fcd356b71fb4fdef5258dc23a99abeb
+local main = origin/main at WP02 completion
+staged paths: 0
+tracked modifications: 0
+
+Release 1.2:
+  milestone #53: OPEN
+  issue #121: CLOSED / DONE
+  issue #122: CLOSED / DONE
+  issue #123: OPEN / BACKLOG
+  issue #124: OPEN / BACKLOG
+  WP03 dependency: exactly WP02
+  dependency drift: 0
+  Release 1.3 implementation: NOT STARTED
+
+Technical baseline at WP02:
+  Domain.Tests: 11/11
+  Application.Tests: 42/42
+  Infrastructure.Tests: 79/79
+  Architecture.Tests: 13/13
+  total permanent tests: 145/145
+  canonical verification: PASS
+```
+
+The SHA and counts are historical evidence. Re-observe current truth; do
+not reset or falsify current state to match them.
+
+Accepted WP02 semantics include:
+
+``` text
+Research Dataset:
+  immutable, research-owned deterministic materialization
+  of explicitly selected accepted observations plus explanatory semantic metadata
+
+Dataset Definition:
+  exact single target
+  explicit [from, to) semantic-instant boundaries
+  deterministic inclusion and ordering
+  explicitly authorized deterministic parameters
+
+Materialization:
+  deterministic resolution of a definition against a fixed relevant source-observation state
+
+Snapshot:
+  durable immutable evidence of one successful materialization
+
+Source truth:
+  accepted Release 1.1 PriceObservation history
+  exact target + semantic instant identity
+
+Ordering:
+  strictly ascending semantic instant
+
+Empty result:
+  valid successful materialization
+
+Fidelity:
+  original DateTimeOffset offset representation preserved
+  exact decimal value preserved
+
+Reproducibility:
+  equivalent definition + equivalent relevant source state
+  => equivalent ordered content + semantic metadata
+
+Source-history change:
+  prior snapshots remain immutable
+  changed relevant source state may yield a distinguishable later snapshot
+
+Operational metadata:
+  wall clock, machine/process identity, paths, connection strings,
+  random values, provider order, DB natural order, culture/local timezone
+  do not define semantic equivalence
+```
+
+------------------------------------------------------------------------
+
+## 3. Objective
+
+Define the Release 1.2 semantic model for:
+
+``` text
+dataset identity
+dataset-definition identity
+snapshot identity
+version semantics
+semantic equivalence
+source-state identity
+provenance
+lineage
+distinguishability
+immutability across re-materialization
+```
+
+WP03 must answer, at minimum:
+
+``` text
+What entity or concept needs a stable logical identity?
+What distinguishes dataset-definition identity from snapshot identity?
+What does "version" mean in Release 1.2?
+Does equivalent re-materialization create a new semantic version/snapshot identity?
+What changes must make two snapshots distinguishable?
+What changes must not make them distinguishable?
+Which definition facts participate in semantic identity?
+Which source-state facts participate in snapshot identity/provenance?
+How is successful empty materialization identified?
+How does provenance explain the authoritative source state?
+How does lineage relate snapshot, definition, and source observations?
+Must identity be deterministic and content-derived?
+If a digest is used, what semantic representation does it cover?
+What canonicalization requirements are necessary before hashing?
+Which operational facts are excluded from semantic identity?
+How are collisions or algorithm/version evolution treated semantically?
+What is deferred to WP04, WP06, WP07, WP08, and WP09?
+```
+
+The result must be deterministic, implementation-independent,
+provider-independent, and storage-independent while being precise enough
+for later implementation.
+
+------------------------------------------------------------------------
+
+## 4. WP03 Core Boundary
+
+WP03 owns **identity, version, provenance, lineage, and semantic
+distinguishability requirements**.
+
+WP03 may select representation-level semantics only where the execution
+plan and manifest assign them here, including a deterministic
+identifier/digest strategy if required to make the model implementable.
+
+WP03 does not own:
+
+``` text
+Application interfaces, request/result records, or public failure types
+materialization use-case implementation
+catalog object implementation beyond semantic requirements
+SQLite tables, columns, indexes, DDL, or migrations
+snapshot persistence behavior
+catalog persistence or lookup behavior
+DI/configuration
+Worker execution
+permanent tests
+Release 1.3 pipelines
+```
+
+Do not let later physical storage concerns dictate identity semantics.
+
+------------------------------------------------------------------------
+
+## 5. Authorized Repository Scope
+
+Use `RELEASE_1.2_FILE_MANIFEST.md` as the exact path authority.
+
+Create or modify **only WP03 artifacts explicitly assigned by the
+manifest**.
+
+Expected WP03 character:
+
+``` text
+semantic architecture / decision documentation
+possibly repository-owned identity/version/provenance specification if manifest-authorized
+no production source
+no permanent tests
+no packages
+no project references
+no solution/build/script changes
+```
+
+The WP03 prompt pair itself is governance input and must not be
+rewritten.
+
+If the manifest provides no legal location for a required output, stop
+and report the manifest gap.
+
+------------------------------------------------------------------------
+
+## 6. Prohibited Scope
+
+Do not:
+
+``` text
+modify Domain production code
+modify Application production code
+modify Infrastructure production code
+modify Worker production code
+modify permanent or architecture tests
+add/change packages
+change project references
+change solution membership
+change build policy/scripts/workflows
+define SQLite schema or write SQL
+implement identifiers in code
+implement hashing/canonicalization code
+implement dataset materialization
+implement snapshot persistence
+implement catalog persistence/lookup
+implement validation/failure mapping
+implement DI/configuration
+implement Worker dataset execution
+define Release 1.3 pipelines
+start WP04
+stage, commit, push, branch, PR, merge, tag, or release
+close milestone #53
+edit issues #124–#136
+change planning dependencies
+change Project fields other than authorized #123 lifecycle
+```
+
+Do not repair unrelated drift.
+
+------------------------------------------------------------------------
+
+## 7. Starting-State Gate
+
+Before changing issue #123:
+
+1.  Verify repository identity and current Git state.
+2.  Verify WP01 #121 and WP02 #122 are Closed/Done.
+3.  Verify WP03 #123 is Open/Backlog.
+4.  Verify WP04 #124 is Open/Backlog.
+5.  Verify milestone #53 is Open.
+6.  Verify WP03 dependency is exactly #122.
+7.  Verify no dependency drift affecting WP03.
+8.  Verify Release 1.3 implementation remains unstarted.
+9.  Classify every staged, modified, and untracked path.
+10. Verify accepted cumulative Release 1.2 governance and WP02
+    definition artifacts are preserved.
+11. Verify no conflicting WP03 identity/provenance artifact already
+    exists.
+12. Verify WP04 contracts have not preempted WP03 semantics.
+
+If material ambiguity exists, stop before lifecycle mutation.
+
+------------------------------------------------------------------------
+
+## 8. Initial Technical Baseline
+
+Before moving #123 to In Progress, run the repository's canonical
+non-mutating baseline:
+
+``` text
+restore
+format verification
+build
+permanent tests
+architecture tests
+eng/verify.ps1
+git diff --check
+git diff --cached --check
+```
+
+Record actual current counts.
+
+Provider/network calls are prohibited except Git/GitHub metadata and
+ordinary package restore if needed.
+
+If baseline validation fails, do not start WP03.
+
+------------------------------------------------------------------------
+
+## 9. Research Method
+
+Reconcile repository truth before deciding.
+
+Inspect at least:
+
+``` text
+RESEARCH_DATASET_DEFINITION.md
+Release 1.1 PriceObservation identity/fidelity semantics
+Release 1.1 persistence idempotency/conflict semantics
+Release 1.1 immutable-history behavior
+existing versioning strategy documentation
+existing data catalog documentation
+existing data glossary and architecture
+existing public contracts and naming conventions
+Release 1.2 execution plan and file manifest
+```
+
+For every material conclusion classify it as:
+
+``` text
+existing repository fact
+accepted WP02 semantic requirement
+WP03 decision
+deferred representation/implementation
+```
+
+Do not import an external data-versioning framework unless explicitly
+required.
+
+------------------------------------------------------------------------
+
+## 10. Required Identity Vocabulary
+
+Define precisely and non-circularly at least:
+
+``` text
+Dataset Definition Identity
+Research Dataset Identity
+Dataset Snapshot Identity
+Dataset Version
+Source State
+Source-State Identity
+Semantic Identity
+Semantic Equivalence
+Provenance
+Lineage
+Canonical Semantic Representation
+Digest / Fingerprint (if selected)
+Algorithm/Representation Version
+```
+
+Clarify which terms are logical concepts versus concrete
+representations.
+
+------------------------------------------------------------------------
+
+## 11. Identity Layers
+
+WP03 must explicitly separate identity layers.
+
+At minimum evaluate and settle:
+
+### Dataset Definition Identity
+
+Represents the semantics of the declarative dataset definition.
+
+It must be insensitive to irrelevant operational metadata.
+
+Evaluate participation of:
+
+``` text
+exact target
+[from, to) boundaries
+inclusion semantics
+ordering semantics
+authorized deterministic definition parameters
+future-compatible semantic representation version
+```
+
+### Source-State Identity
+
+Represents the authoritative Release 1.1 source state relevant to the
+definition.
+
+It must not depend on:
+
+``` text
+SQLite row IDs
+insertion order
+database natural order
+machine path
+connection string
+provider DTO identity
+execution time
+```
+
+Evaluate whether it must cover the complete ordered selected observation
+sequence including exact semantic instant, original offset
+representation, and exact decimal value.
+
+### Snapshot Identity
+
+Represents one semantic materialization result.
+
+Settle whether it is derived from:
+
+``` text
+definition identity
+source-state identity
+ordered materialized semantic content
+semantic metadata required by WP02
+representation/algorithm version
+```
+
+Avoid redundant inputs unless redundancy has an explicit integrity
+purpose.
+
+### Research Dataset Identity
+
+Decide whether Release 1.2 needs a logical identity above individual
+snapshots, and if so what remains stable across distinguishable
+snapshots.
+
+Do not invent mutable "latest" semantics.
+
+------------------------------------------------------------------------
+
+## 12. Definition Identity Semantics
+
+Define exactly what makes two definitions semantically equivalent.
+
+At minimum:
+
+``` text
+same exact target
+same [from, to) boundaries
+same inclusion semantics
+same deterministic ordering rule
+same authorized semantic parameters
+same interpretation/version of the definition model
+```
+
+Exclude:
+
+``` text
+creation time
+execution time
+machine
+process
+file path
+database path
+connection string
+display formatting
+JSON property order or whitespace
+culture/local timezone
+```
+
+If a canonical representation is selected, define semantic normalization
+rules without tying them to physical persistence.
+
+------------------------------------------------------------------------
+
+## 13. Source-State Semantics
+
+WP02 requires changed relevant source history to be distinguishable.
+
+Define the relevant source state as the exact accepted observations
+selected by the definition, in deterministic semantic order.
+
+For each observation, evaluate identity contribution from:
+
+``` text
+exact target
+absolute semantic instant
+original offset representation
+exact decimal price
+```
+
+Because WP02 explicitly preserves original offset representation and
+decimal fidelity, do not silently omit them from equivalence or
+provenance unless a compelling accepted authority supports doing so.
+
+Clarify empty source state: an empty selected sequence is a valid,
+deterministic source state and must be representable unambiguously.
+
+------------------------------------------------------------------------
+
+## 14. Version Semantics
+
+Define what **Dataset Version** means.
+
+Compare at least:
+
+1.  mutable sequential revision number;
+2.  timestamp-based version;
+3.  deterministic semantic/content-derived version;
+4.  hybrid logical identity + immutable snapshot fingerprint.
+
+The selected model must satisfy:
+
+``` text
+determinism
+reproducibility
+immutability
+distinguishability after relevant source change
+equivalent re-materialization recognition
+no wall-clock dependence
+no overwrite semantics
+offline/local operation
+future algorithm evolution
+```
+
+Do not use execution timestamps as semantic versions.
+
+If human-friendly sequential versions are useful only for catalog
+presentation, classify them as non-authoritative/deferred unless the
+plan requires otherwise.
+
+------------------------------------------------------------------------
+
+## 15. Equivalent Re-materialization
+
+Settle this explicitly.
+
+Given:
+
+``` text
+same semantic definition
+same relevant authoritative source state
+same deterministic semantic model
+```
+
+a repeated materialization must be semantically equivalent.
+
+Decide whether it:
+
+``` text
+reuses the same deterministic snapshot identity
+creates a new operational event but the same semantic snapshot identity
+creates a new semantic version
+```
+
+Preferred direction: operational executions may differ, but equivalent
+materializations resolve to the same semantic identity/version and must
+not create distinguishable research evidence merely because they ran
+twice.
+
+If repository authority requires another model, follow it and document
+why.
+
+------------------------------------------------------------------------
+
+## 16. Changed Source-State Semantics
+
+When the same definition is materialized after the relevant accepted
+source history changes:
+
+``` text
+old snapshot remains immutable
+new materialization must be distinguishable if semantic content/source state differs
+old identity/version must not be reassigned
+new snapshot must carry provenance explaining the new source state
+```
+
+Define what counts as a relevant source-state change.
+
+Examples to evaluate:
+
+``` text
+observation added inside [from, to)
+observation added outside [from, to)
+selected observation price changes through a legitimately distinct accepted source state
+selected observation offset representation differs
+unrelated target changes
+database insertion order changes
+database file moves
+execution time changes
+```
+
+Only semantically relevant changes should alter snapshot identity.
+
+------------------------------------------------------------------------
+
+## 17. Canonical Semantic Representation
+
+Determine whether deterministic content-derived identity requires a
+canonical semantic representation.
+
+If yes, specify canonical **semantic encoding requirements**
+sufficiently for later implementation, while avoiding storage schema.
+
+At minimum settle:
+
+``` text
+field order
+sequence order
+string encoding expectation
+target exactness
+timestamp representation
+offset representation
+decimal representation
+boundary representation
+empty sequence representation
+domain separators/type tags
+representation versioning
+```
+
+The representation must be unambiguous and culture-independent.
+
+Do not use locale-sensitive formatting, floating point, database
+serialization, provider JSON, or platform-specific binary layout.
+
+If choosing a concrete serialization is unnecessary at WP03, define a
+normative field/value canonicalization contract instead and explicitly
+defer byte encoding.
+
+------------------------------------------------------------------------
+
+## 18. Digest / Fingerprint Decision
+
+Evaluate whether a cryptographic digest is appropriate for deterministic
+semantic identity.
+
+Compare at least:
+
+``` text
+opaque random identifiers
+GUIDs
+sequential IDs
+raw canonical semantic key
+cryptographic content digest
+```
+
+For a public, zero-cost, offline reproducibility model, a
+content-derived digest is a strong candidate.
+
+If selecting a digest:
+
+``` text
+choose a standard non-secret cryptographic hash available without new package dependencies
+state whether the digest is identity evidence, not a security/authentication mechanism
+define algorithm naming/versioning
+define textual representation requirements if needed
+define collision handling policy semantically
+do not implement it in code
+```
+
+Do not claim mathematical impossibility of collisions.
+
+If the execution plan or manifest expects the digest choice to remain
+deferred, honor that authority instead.
+
+------------------------------------------------------------------------
+
+## 19. Algorithm and Representation Evolution
+
+The identity model must not become ambiguous if canonicalization or
+digest algorithms evolve.
+
+Define a semantic strategy such as:
+
+``` text
+identity scheme/version is explicit
+algorithm identifier is explicit when applicable
+old snapshots retain their original identity scheme
+new schemes do not reinterpret old identifiers
+equivalence across schemes, if ever needed, requires semantic comparison or explicit migration authority
+```
+
+Do not design a migration framework.
+
+------------------------------------------------------------------------
+
+## 20. Provenance Semantics
+
+Provenance must explain **why this snapshot exists and from what
+authoritative semantic state it was produced**.
+
+At minimum determine what must be knowable:
+
+``` text
+dataset-definition identity/semantics
+source-state identity
+source authority = accepted Release 1.1 observations
+exact target
+selection boundaries
+observation count
+ordered semantic content or sufficient deterministic source-state evidence
+identity/canonicalization scheme version
+materialization semantic result identity
+```
+
+Separate semantic provenance from operational audit facts.
+
+Operational facts such as execution timestamp may be useful
+catalog/audit metadata but must not affect semantic identity unless
+explicitly required.
+
+Do not persist provenance here.
+
+------------------------------------------------------------------------
+
+## 21. Lineage Semantics
+
+Define lineage relationships conceptually.
+
+At minimum:
+
+``` text
+snapshot derives from one dataset definition
+snapshot derives from one relevant authoritative source state
+source state consists of zero or more accepted Release 1.1 observations selected by the definition
+definition and source state together explain the snapshot
+```
+
+For empty materializations, lineage must still relate the snapshot to
+its definition and an explicitly empty relevant source state.
+
+Do not require one physical lineage row per observation unless later
+work chooses that representation.
+
+------------------------------------------------------------------------
+
+## 22. Identity and Immutability Invariants
+
+Establish invariants suitable for later contracts/tests.
+
+At minimum:
+
+``` text
+same semantic definition => same definition identity
+same relevant ordered source state => same source-state identity
+same definition + same relevant source state => same semantic snapshot identity
+operational metadata changes alone => no semantic identity change
+relevant source semantic change => distinguishable source/snapshot identity
+definition semantic change => distinguishable definition/snapshot identity
+accepted snapshot identity is immutable
+an identity is never reassigned to different semantic content
+old snapshots are never overwritten by newer versions
+empty materialization has deterministic identity
+```
+
+If the chosen model makes any invariant invalid, explain and replace it
+explicitly.
+
+------------------------------------------------------------------------
+
+## 23. Collision / Integrity Semantics
+
+If content digests are selected, define bounded collision behavior.
+
+At minimum:
+
+``` text
+digest equality is expected to imply semantic equivalence under the same identity scheme
+if stored semantic metadata/content contradicts a supposedly equal digest, treat it as an integrity conflict, never overwrite
+collision handling must preserve both evidence and fail deterministically
+no silent aliasing of materially different snapshots
+```
+
+WP11 owns concrete validation/failure mapping.
+
+------------------------------------------------------------------------
+
+## 24. Metadata and Catalog Boundary
+
+WP03 must hand WP06 enough semantics to model catalog metadata without
+designing the catalog.
+
+Identify which identity/provenance facts must be catalog-visible, such
+as:
+
+``` text
+logical dataset/definition identity
+snapshot identity/version
+source-state identity
+target
+selection boundaries
+observation count
+identity scheme/version
+provenance relation
+```
+
+Defer:
+
+``` text
+catalog classes/records if not assigned to WP03
+indexes
+lookup APIs
+SQLite schema
+storage layout
+pagination/query behavior
+```
+
+------------------------------------------------------------------------
+
+## 25. Application Contract Boundary
+
+WP04 will translate WP03 semantics into Application-owned contracts.
+
+Provide WP04 with explicit requirements for:
+
+``` text
+identity values that Application must be able to carry
+definition semantics
+snapshot/version semantics
+provenance facts
+lineage relationships
+equivalence/distinguishability invariants
+empty snapshot identity
+storage/provider independence
+```
+
+Do not create the interfaces or result records in WP03.
+
+------------------------------------------------------------------------
+
+## 26. Physical Storage Boundary
+
+WP07 owns the physical storage model.
+
+WP03 must not specify:
+
+``` text
+table names
+column names
+SQLite types
+indexes
+foreign keys
+DDL
+migration mechanics
+file paths
+```
+
+It may require lossless persistence of selected semantic
+identity/provenance values.
+
+WP08 owns immutable snapshot persistence. WP09 owns catalog persistence
+and lookup.
+
+------------------------------------------------------------------------
+
+## 27. Decision Alternatives
+
+For each material decision, document:
+
+``` text
+decision
+alternatives considered
+selected option
+rationale
+consequences
+deferred implementation
+```
+
+At minimum compare:
+
+1.  random/sequential identity vs deterministic semantic identity;
+2.  definition identity vs snapshot identity conflation;
+3.  execution timestamp version vs semantic/content-derived version;
+4.  source-state identity from physical rows vs semantic observation
+    content;
+5.  equivalent re-materialization as new version vs same semantic
+    version;
+6.  operational metadata included vs excluded from identity;
+7.  canonical semantic representation versioned vs implicit;
+8.  digest-based identity vs non-digest deterministic representation, if
+    applicable.
+
+Keep the analysis bounded to Release 1.2.
+
+------------------------------------------------------------------------
+
+## 28. Required WP04 Handoff Contract
+
+End the WP03 artifact with an explicit handoff to WP04.
+
+WP04 must receive settled answers for:
+
+``` text
+which identity concepts exist
+which are stable across snapshots
+which identify immutable snapshots
+what version means
+what constitutes semantic equivalence
+what changes require a new/distinguishable snapshot identity
+what provenance must carry
+what lineage must express
+what operational metadata is excluded
+how empty materialization is identified
+what canonicalization/digest semantics are normative, if selected
+what identity-scheme/version metadata must be carried
+```
+
+Explicitly leave these to later WPs:
+
+``` text
+Application interface/type shape — WP04
+materialization orchestration — WP05
+catalog metadata object model — WP06
+physical schema — WP07
+snapshot persistence — WP08
+catalog persistence/lookup — WP09
+integration consistency mechanics — WP10
+validation/failure mapping — WP11
+DI/Worker execution — WP12
+tests — WP13/WP14
+```
+
+------------------------------------------------------------------------
+
+## 29. Issue #123 Lifecycle
+
+Only after starting-state and baseline gates pass:
+
+1.  Move issue #123 `Backlog → In Progress`.
+2.  Perform only authorized WP03 semantic work.
+3.  Validate artifacts against this authority and manifest.
+4.  Rerun final technical/scope checks.
+5.  Post concise evidence to #123.
+6.  Close #123.
+7.  Set Project Status to `Done`.
+
+Do not modify #124 except to inspect and prove it remains Open/Backlog.
+
+------------------------------------------------------------------------
+
+## 30. Validation Requirements
+
+Before closing WP03, run:
+
+``` text
+dotnet restore AIQuantTradingResearch.slnx
+dotnet format AIQuantTradingResearch.slnx --verify-no-changes
+dotnet build AIQuantTradingResearch.slnx --no-restore
+dotnet test AIQuantTradingResearch.slnx --no-build
+eng/verify.ps1
+git diff --check
+git diff --cached --check
+```
+
+Also verify:
+
+``` text
+Domain production delta: 0
+Application production delta: 0
+Infrastructure production delta: 0
+Worker production delta: 0
+permanent test delta: 0
+package delta: 0
+project-reference delta: 0
+solution/build/script delta: 0
+WP04 started: NO
+Release 1.3 implementation started: NO
+provider/network calls during WP03 validation: 0
+temporary database residue: 0
+```
+
+Run existing repository-relative Markdown/link validation applicable to
+new documentation.
+
+For untracked WP03 artifacts, perform an equivalent direct whitespace
+check if Git diff checks do not inspect them.
+
+------------------------------------------------------------------------
+
+## 31. Semantic Acceptance Matrix
+
+WP03 passes only if all applicable rows are established:
+
+  Requirement                                  Required result
+  -------------------------------------------- ---------------------------------------
+  Definition identity semantics                PASS
+  Research dataset logical identity decision   PASS
+  Snapshot identity semantics                  PASS
+  Dataset version semantics                    PASS
+  Source-state semantics                       PASS
+  Equivalent re-materialization                PASS
+  Relevant source change distinguishability    PASS
+  Irrelevant operational change exclusion      PASS
+  Empty materialization identity               PASS
+  Exact target semantics                       PASS
+  `[from, to)` boundaries preserved            PASS
+  Ascending semantic ordering preserved        PASS
+  Timestamp/offset fidelity preserved          PASS
+  Decimal fidelity preserved                   PASS
+  Canonical semantic representation decision   PASS
+  Digest/fingerprint decision                  PASS or explicitly authority-deferred
+  Identity scheme evolution semantics          PASS
+  Provenance semantics                         PASS
+  Lineage semantics                            PASS
+  Snapshot immutability                        PASS
+  Identity reassignment prohibited             PASS
+  Collision/integrity semantics                PASS if digest selected
+  WP04 handoff complete                        PASS
+  WP06/WP07/WP08/WP09 boundaries preserved     PASS
+  Release 1.3 excluded                         PASS
+  Cross-document contradictions                0
+
+------------------------------------------------------------------------
+
+## 32. Mutation Acceptance Matrix
+
+  Requirement                          Required result
+  ------------------------------------ --------------------------
+  WP02 predecessor                     CLOSED / DONE
+  Issue #123 initial state             OPEN / BACKLOG
+  Issue #124 initial/final state       OPEN / BACKLOG
+  Milestone #53                        OPEN
+  Authorized WP03 paths                only manifest-authorized
+  Production code delta                0
+  Permanent test delta                 0
+  Package/reference delta              0/0
+  Solution/build/script delta          0
+  Unauthorized documentation delta     0
+  Restore                              PASS
+  Format verification                  PASS
+  Build                                PASS / 0 errors
+  Permanent tests                      PASS
+  Architecture tests                   PASS
+  Canonical verification               PASS
+  Diff/whitespace checks               PASS
+  Provider/network calls               0
+  Temporary database residue           0
+  WP04 started                         NO
+  Release 1.3 implementation started   NO
+  Issue #123 final state               CLOSED / DONE
+
+------------------------------------------------------------------------
+
+## 33. Blocker Policy
+
+Stop if:
+
+``` text
+WP02 is not Closed/Done
+#123 is not Open/Backlog at start
+#124 has already started
+milestone #53 is not the authoritative open Release 1.2 milestone
+repository state contains unexplained material drift
+Release 1.3 implementation has started
+the manifest provides no authorized location for required WP03 output
+authorities materially conflict
+baseline restore/build/test/architecture/canonical verification fails
+WP02 semantics are insufficient or contradictory for deterministic identity
+a required decision would necessarily preempt WP04+ implementation rather than specify semantics
+```
+
+Report:
+
+``` text
+blocker ID
+evidence
+authority violated
+smallest corrective authority required
+repository/GitHub mutations avoided
+safe resume point
+```
+
+Do not create a recursive authority chain for ordinary wording or
+whitespace findings. Correct findings inside WP03-authorized artifacts
+before acceptance when the correction stays within this authority.
+
+------------------------------------------------------------------------
+
+## 34. Required Execution Report
+
+Produce a structured report containing at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Predecessor / Lifecycle Gates
+7.  Issue #123 Lifecycle
+8.  Initial Technical Baseline
+9.  WP02 Semantics Reconciled
+10. Identity Vocabulary
+11. Identity-Layer Model
+12. Dataset Definition Identity
+13. Research Dataset Logical Identity
+14. Source-State Identity
+15. Snapshot Identity
+16. Dataset Version Semantics
+17. Equivalent Re-materialization
+18. Changed Source-State Semantics
+19. Canonical Semantic Representation
+20. Digest / Fingerprint Decision
+21. Algorithm / Representation Evolution
+22. Provenance Semantics
+23. Lineage Semantics
+24. Empty Materialization Identity
+25. Identity / Immutability Invariants
+26. Collision / Integrity Semantics
+27. Metadata / Catalog Boundary
+28. Application Contract Boundary
+29. Physical Storage Boundary
+30. Alternatives and Decisions
+31. WP04 Handoff
+32. Exact Files Added / Modified
+33. Production / Test Delta
+34. Package / Reference Delta
+35. Security / Offline Evidence
+36. Whitespace / Link Evidence
+37. Restore / Build / Test Evidence
+38. Canonical Verification
+39. Architecture Validation
+40. Mutation Accounting
+41. Git / GitHub Protection
+42. Findings / Blockers
+43. Semantic Acceptance Matrix
+44. Final Repository / GitHub State
+45. Final Decision
+46. Next Authorized Work Package
+
+Use actual observed evidence, not assumed values.
+
+------------------------------------------------------------------------
+
+## 35. Required Terminal Summary
+
+If successful, end exactly with:
+
+``` text
+RELEASE 1.2 WP03 COMPLETE
+
+DATASET IDENTITY, VERSION & PROVENANCE SEMANTICS:
+Dataset definition identity: PASS
+Research dataset identity model: PASS
+Source-state identity: PASS
+Snapshot identity: PASS
+Dataset version semantics: PASS
+Equivalent re-materialization semantics: PASS
+Relevant source-change distinguishability: PASS
+Operational metadata excluded from semantic identity: PASS
+Empty materialization identity: PASS
+Canonical semantic representation: PASS
+Digest/fingerprint decision: PASS
+Identity scheme evolution: PASS
+Provenance semantics: PASS
+Lineage semantics: PASS
+Snapshot immutability: PASS
+Identity reassignment prohibited: PASS
+Timestamp/offset/decimal fidelity: PASS
+WP04 contract handoff: PASS
+Production code delta: 0
+Permanent test delta: 0
+Package/reference delta: 0/0
+WP04 started: NO
+Release 1.3 implementation started: NO
+Issue #123: CLOSED / DONE
+
+NEXT AUTHORIZED WORK PACKAGE:
+WP04 — Application Dataset Contracts
+GitHub issue #124
+```
+
+If the accepted authority explicitly defers a digest choice, replace
+only the digest terminal row with:
+
+``` text
+Digest/fingerprint decision: AUTHORITY-DEFERRED
+```
+
+If blocked, end exactly with:
+
+``` text
+RELEASE 1.2 WP03 BLOCKED
+```
+
+Do not print the success marker unless every mandatory gate passes.
+
+------------------------------------------------------------------------
+
+## 36. Final Constraint
+
+WP03 is the semantic bridge between WP02 reproducibility and all later
+Release 1.2 contracts and persistence.
+
+Prefer **deterministic semantic identity over operational identity**,
+preserve immutable research evidence, and ensure equivalent
+re-materializations do not become falsely distinct because of execution
+circumstances.
+
+Do not optimize for SQLite. Do not design APIs. Do not create pipeline
+behavior.
+
+**Identity must explain meaning, version must explain semantic change,
+provenance must explain origin, and lineage must explain derivation.**

--- a/docs/roadmap/release-1.2/prompts/04-application-dataset-contracts-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/04-application-dataset-contracts-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Use GPT-5.6 Terra and execute `04-application-dataset-contracts-codex-prompt.md` as the authoritative Release 1.2 WP04 contract.
+Read all mandatory authorities and accepted WP02/WP03 evidence before mutation; verify #123 is Closed/Done, #124 is Open/Backlog, and #125 remains Open/Backlog.
+Perform only manifest-authorized Application dataset-contract work; preserve the settled identity/version/provenance semantics and do not implement WP05+, Infrastructure, Worker, tests, packages, or Release 1.3 behavior.
+Run every required baseline, semantic, scope, architecture, security, whitespace, and final validation gate; stop on any material authority conflict or unexplained drift.
+If all gates pass, close #124 as Done, leave #125 untouched, and end with the exact `RELEASE 1.2 WP04 COMPLETE` terminal summary.

--- a/docs/roadmap/release-1.2/prompts/04-application-dataset-contracts-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/04-application-dataset-contracts-codex-prompt.md
@@ -1,0 +1,1220 @@
+# Release 1.2 WP04 — Application Dataset Contracts — Codex Prompt
+
+## Role
+
+Act as the **WP04 Application Dataset Contracts Executor** for Release 1.2 of
+`AIQuantTradingResearch`.
+
+This is a bounded **Application contract engineering** work package. Its purpose
+is to translate the accepted WP02 dataset/reproducibility model and the accepted
+WP03 identity/version/provenance semantics into the smallest precise,
+provider-independent and storage-independent Application contract surface needed
+by WP05–WP14.
+
+Use **GPT-5.6 Terra** for this work package.
+
+The foundational semantic decisions are already settled. Do not reopen them.
+Do not implement materialization orchestration, catalog modeling, SQLite
+persistence, Worker execution, or permanent tests. Do not start WP05.
+
+---
+
+## 1. Mandatory Authorities
+
+Read completely before acting:
+
+```text
+RELEASE_1.2_EXECUTION_PLAN.md
+RELEASE_1.2_FILE_MANIFEST.md
+release-1.2-github-planning-codex-prompt.md
+release-1.2-github-planning-codex-prompt-chat.md
+01-release-repository-preflight-codex-prompt.md
+01-release-repository-preflight-codex-prompt-chat.md
+02-research-dataset-definition-reproducibility-model-codex-prompt.md
+02-research-dataset-definition-reproducibility-model-codex-prompt-chat.md
+03-dataset-identity-version-provenance-semantics-codex-prompt.md
+03-dataset-identity-version-provenance-semantics-codex-prompt-chat.md
+04-application-dataset-contracts-codex-prompt.md
+04-application-dataset-contracts-codex-prompt-chat.md
+docs/architecture/data/RESEARCH_DATASET_DEFINITION.md
+docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md
+```
+
+Also inspect:
+
+```text
+accepted WP01 execution result
+accepted WP02 execution result
+accepted WP03 execution result
+accepted Release 1.1 persistence contracts and semantics
+current Domain/Application/Infrastructure/Worker source
+current Application contract and use-case conventions
+current dependency-injection conventions
+current data architecture, catalog, glossary, versioning, and public-contract documentation
+current permanent tests and architecture tests
+GitHub milestone #53
+GitHub issue #124
+GitHub issue #125
+GitHub issue #126
+Project #2
+```
+
+Authority precedence:
+
+```text
+1. RELEASE_1.2_EXECUTION_PLAN.md
+2. RELEASE_1.2_FILE_MANIFEST.md
+3. Accepted Release 1.2 GitHub planning state
+4. Accepted WP03 result and DATASET_IDENTITY_VERSION_PROVENANCE.md
+5. Accepted WP02 result and RESEARCH_DATASET_DEFINITION.md
+6. Accepted WP01 result
+7. Accepted Release 1.1 repository truth
+8. Existing repository architecture/governance conventions
+9. This execution prompt
+```
+
+If authorities materially conflict, stop and report the smallest precise
+blocker. Do not silently reinterpret an accepted semantic decision.
+
+---
+
+## 2. Accepted Starting Baseline
+
+Treat the accepted WP03 result as the starting baseline unless current evidence
+proves drift:
+
+```text
+Repository: samuel-santos-engineer/AIQuantTradingResearch
+Branch: main
+WP03 accepted HEAD: 3ae8ba300fcd356b71fb4fdef5258dc23a99abeb
+local main = origin/main at WP03 completion
+ahead/behind: 0/0
+staged paths: 0
+tracked modifications: 0
+
+Release 1.2:
+  milestone #53: OPEN
+  issue #121: CLOSED / DONE
+  issue #122: CLOSED / DONE
+  issue #123: CLOSED / DONE
+  issue #124: OPEN / BACKLOG
+  issue #125: OPEN / BACKLOG
+  issue #126: OPEN / BACKLOG
+  WP04 dependency: exactly #123
+  Release 1.3 implementation: NOT STARTED
+
+Permanent baseline:
+  Domain.Tests: 11/11
+  Application.Tests: 42/42
+  Infrastructure.Tests: 79/79
+  Architecture.Tests: 13/13
+  Total: 145/145
+```
+
+At WP03 completion, accepted cumulative untracked Release 1.2
+governance/semantic files totaled 12 and no unexpected change existed. Recount
+and classify the actual current working tree; do not assume the count remains
+12.
+
+Do not treat accepted uncommitted Release 1.2 artifacts as drift merely because
+they are untracked. Conversely, do not automatically bless a path merely
+because it resembles Release 1.2 work.
+
+---
+
+## 3. Starting-State Gate — Mandatory Before Mutation
+
+Before editing production code:
+
+1. authenticate GitHub without exposing credentials;
+2. verify repository identity;
+3. verify current branch and exact local/remote SHAs;
+4. verify ahead/behind;
+5. verify staged, tracked-modified, and untracked paths;
+6. classify every existing change against accepted cumulative Release 1.2 work;
+7. verify #121–#123 are Closed/Done;
+8. verify #124 is Open/Backlog;
+9. verify #125 remains Open/Backlog;
+10. verify #126 remains Open/Backlog;
+11. verify milestone #53 remains Open;
+12. verify WP04 depends exactly on #123;
+13. verify no WP05+ lifecycle was advanced;
+14. verify no Release 1.3 implementation has started;
+15. verify the accepted WP02 and WP03 semantic artifacts are present;
+16. verify no existing Application dataset-contract implementation has appeared
+    outside accepted authority.
+
+If unexplained drift exists, stop before mutation and report it.
+
+Do not move #124 to In Progress until the starting-state and baseline validation
+gates pass.
+
+---
+
+## 4. Initial Technical Baseline — Mandatory
+
+Before WP04 production mutation, run the repository's canonical baseline,
+including at minimum:
+
+```text
+dotnet restore AIQuantTradingResearch.slnx
+dotnet format AIQuantTradingResearch.slnx --verify-no-changes
+dotnet build AIQuantTradingResearch.slnx --no-restore
+dotnet test / canonical permanent test execution
+eng/verify.ps1
+git diff --check
+git diff --cached --check
+```
+
+Use repository-owned scripts/conventions when they are more authoritative than
+the illustrative commands above.
+
+Record exact:
+
+- build warnings/errors;
+- Domain/Application/Infrastructure/Architecture counts;
+- total permanent tests;
+- canonical verification result;
+- secret-scan result if part of canonical verification;
+- architecture-test result;
+- temporary database residue;
+- whitespace status.
+
+Baseline failure is a blocker unless it is clearly caused only by already
+accepted uncommitted Release 1.2 authority artifacts and can be demonstrated as
+non-semantic. Do not fix unrelated failures under WP04 authority.
+
+After the baseline passes, move issue #124 from Backlog to In Progress.
+
+---
+
+## 5. WP02 Semantic Contract — Preserve Exactly
+
+WP04 must preserve the accepted WP02 model:
+
+```text
+Research Dataset
+  immutable, research-owned deterministic materialization of explicitly
+  selected accepted observations plus explanatory semantic metadata
+
+Dataset Definition
+  exact single target
+  required [from, to) semantic-instant boundaries
+  explicit inclusion/selection rules
+  deterministic ordering
+  explicitly authorized parameters
+
+Materialization
+  deterministic resolution of a definition against a fixed relevant
+  source-observation state
+
+Snapshot
+  durable immutable evidence from one successful materialization
+
+Selection
+  exact target
+  [from, to)
+  ascending semantic instant
+
+Empty result
+  valid and successful
+
+Fidelity
+  original DateTimeOffset offset representation
+  exact decimal value
+  no conversion, rounding, or truncation
+```
+
+Do not change single-target scope into multi-target scope.
+Do not change `[from, to)` semantics.
+Do not make provider/database ordering authoritative.
+Do not make empty materialization a failure.
+
+---
+
+## 6. WP03 Semantic Contract — Preserve Exactly
+
+WP03 settled the foundational semantics. WP04 translates them into Application
+contracts; it does not redesign them.
+
+Preserve:
+
+```text
+Identity layers:
+  Dataset Definition Identity
+  logical Research Dataset Identity
+  Source State Identity
+  Dataset Snapshot Identity
+
+Dataset Version:
+  immutable deterministic Snapshot Identity
+  not a timestamp
+  not a database-generated sequence
+
+Equivalent re-materialization:
+  same semantic identities/version when definition and relevant source state
+  are equivalent
+  operational execution may still be a distinct event
+
+Relevant change:
+  selected membership/content, original offset, decimal value, or definition
+  semantics change => distinguishable semantic identity
+
+Operational metadata:
+  excluded from semantic identity
+
+Identity scheme:
+  aiq-dataset-identity-v1
+
+Digest:
+  SHA-256
+  64 lowercase hexadecimal characters
+
+Canonical semantic representation:
+  versioned
+  type-separated
+  length-delimited
+  culture-independent UTF-8
+
+Collision/integrity:
+  contradictory content under equal fingerprint is an integrity conflict
+  never overwrite or silently alias
+
+Empty materialization:
+  deterministic zero-count Source State Identity and Snapshot Identity
+
+Immutability:
+  accepted snapshot/version identity cannot be reassigned
+  prior snapshots cannot be overwritten
+
+Provenance:
+  explains definition, source authority/state, identities, target,
+  boundaries, count, scheme, and materialized result
+
+Lineage:
+  one snapshot -> one definition + one relevant source state
+  source state contains zero or more accepted observations
+```
+
+### Important separation
+
+The Application layer may expose the **semantic identity scheme name and
+validated identity/fingerprint values** because they are part of the accepted
+contract.
+
+Do **not** make Application contracts responsible for:
+
+- invoking SHA-256;
+- byte-level canonical serialization;
+- selecting cryptographic libraries;
+- SQLite representation;
+- persistence encoding;
+- database-generated identifiers.
+
+If a minimal Application value must validate the accepted external form, it may
+validate invariants such as scheme name and 64-character lowercase hexadecimal
+shape. Hash computation mechanics remain outside this WP unless an existing
+Application convention makes a pure deterministic helper unavoidable. Prefer
+values/contracts over hashing implementation.
+
+---
+
+## 7. Objective
+
+Create the **minimum coherent Application seam** that allows later work to:
+
+1. express a deterministic dataset definition/materialization request;
+2. carry typed semantic identities and Dataset Version;
+3. describe a materialized snapshot without storage technology;
+4. carry coverage, provenance, and lineage facts required by WP03;
+5. represent a snapshot candidate/result needed by WP05;
+6. abstract immutable snapshot persistence needed by WP08;
+7. abstract catalog registration and deterministic lookup needed by WP09;
+8. represent bounded failures/outcomes without storage/provider leakage.
+
+The result must be sufficient for later work but no broader.
+
+Avoid speculative abstractions and generic repository/CRUD patterns.
+
+---
+
+## 8. Authorized Production Surface
+
+Per the authoritative file manifest, WP04 may modify only:
+
+```text
+src/AIQuantTradingResearch.Application/**
+```
+
+Authorized classes/concepts include only what is required for the minimum
+contract surface:
+
+```text
+dataset definition / materialization request
+snapshot / descriptor / snapshot candidate
+identity / version supporting values where Domain does not already own them
+coverage
+provenance
+lineage
+materialization result / failure
+snapshot-store abstraction
+catalog registration / lookup abstraction
+deterministic lookup criteria
+minimal supporting Application values
+```
+
+Before adding any type, inspect whether Domain or existing Application code
+already owns the semantic value.
+
+Prefer focused namespaces and capability-oriented names consistent with the
+repository.
+
+---
+
+## 9. Strictly Prohibited Scope
+
+WP04 must not change or add:
+
+```text
+src/AIQuantTradingResearch.Domain/**
+src/AIQuantTradingResearch.Infrastructure/**
+src/AIQuantTradingResearch.Worker/**
+tests/**
+Directory.Packages.props
+project references
+solution files
+eng/**
+GitHub Actions
+SQLite schema/model/bootstrap
+SQL
+ORM mappings
+filesystem/database paths
+database files
+catalog persistence implementation
+snapshot persistence implementation
+materialization orchestration
+historical-observation acquisition orchestration
+Worker execution
+scheduler/DAG/streaming/refresh behavior
+retry/resilience policy
+Release 1.3 pipeline behavior
+```
+
+Also prohibited:
+
+- provider DTOs or HTTP types in Application contracts;
+- SQLite or `Microsoft.Data.Sqlite` types;
+- storage exceptions;
+- physical table/column/index concepts;
+- database-generated semantic IDs;
+- generic `IRepository<T>`;
+- generic CRUD abstractions;
+- mutable "latest dataset" semantics;
+- automatic refresh semantics;
+- permanent tests.
+
+If a required contract cannot compile without changing a prohibited surface,
+stop and report the smallest corrective authority needed.
+
+---
+
+## 10. Contract Design Principles
+
+Use the current repository's Application conventions unless they conflict with
+accepted WP02/WP03 semantics.
+
+The contract surface must be:
+
+- provider-independent;
+- storage-independent;
+- deterministic;
+- explicit rather than magic-string-heavy where semantic values exist;
+- immutable/read-only at public boundaries;
+- minimal;
+- focused on Release 1.2;
+- synchronous if current Application boundaries remain synchronous;
+- free of `CancellationToken` unless current accepted Application conventions
+  already justify it;
+- free of implementation-side effects.
+
+Do not introduce async merely because persistence may later be I/O-bound.
+WP04 owns contracts within the current architecture, not a broad concurrency
+redesign.
+
+---
+
+## 11. Dataset Definition / Request Contract
+
+Create the minimum Application representation needed to request deterministic
+materialization.
+
+It must preserve:
+
+- exact opaque target;
+- inclusive `from` semantic instant;
+- exclusive `to` semantic instant;
+- valid `[from, to)` ordering;
+- deterministic selection semantics;
+- deterministic ascending ordering rule;
+- explicitly authorized semantic parameters, if any are already defined by
+  WP02/WP03.
+
+Do not trim, uppercase, lowercase, parse, alias, or otherwise normalize the
+target.
+
+Do not silently substitute local time or UTC for the original semantic values.
+Boundary instants may be compared by semantic instant, but their contract
+meaning must remain explicit.
+
+Reject invalid definitions deterministically at the appropriate Application
+boundary. Do not invent storage failures for definition validation.
+
+Do not add optional parameters merely for extensibility.
+
+---
+
+## 12. Identity Contract Surface
+
+Represent the four accepted identity concepts so they cannot be casually
+confused:
+
+```text
+Dataset Definition Identity
+Research Dataset Identity
+Source State Identity
+Dataset Snapshot Identity
+```
+
+Prefer distinct strongly typed Application values rather than four unqualified
+strings.
+
+Each identity value must:
+
+- be immutable;
+- carry or unambiguously associate with the accepted scheme
+  `aiq-dataset-identity-v1`;
+- preserve the accepted 64-lowercase-hex fingerprint representation;
+- reject structurally invalid values deterministically;
+- have value semantics suitable for equality;
+- not generate itself from time/randomness/database state.
+
+Do not make the four identity types implicitly interchangeable.
+
+---
+
+## 13. Dataset Version Contract
+
+Dataset Version must represent the accepted WP03 meaning:
+
+```text
+Dataset Version == immutable deterministic Dataset Snapshot Identity
+```
+
+Do not create:
+
+- an integer version counter;
+- a timestamp version;
+- an auto-incrementing version;
+- a mutable revision;
+- "latest" as a semantic version.
+
+The Application contract may use a distinct `DatasetVersion` value for clarity,
+but it must preserve an explicit one-to-one semantic relationship with Snapshot
+Identity and must not introduce an independent identity source.
+
+If a distinct wrapper adds no clarity in the actual repository, document and
+use the smallest representation that still makes version semantics explicit.
+
+---
+
+## 14. Snapshot / Candidate / Descriptor Contract
+
+WP05 needs an Application-owned representation of the deterministic result
+before Infrastructure persistence exists.
+
+Design the minimum immutable snapshot candidate/descriptor surface that can
+carry:
+
+- Dataset Definition;
+- Definition Identity;
+- Research Dataset Identity;
+- Source State Identity;
+- Snapshot Identity / Dataset Version;
+- exact target;
+- selection boundaries;
+- ordered observations;
+- coverage;
+- provenance;
+- lineage;
+- count.
+
+Use existing Domain `PriceObservation` values where appropriate. Do not invent
+Application transport DTOs for timestamp/price merely to avoid using Domain
+values.
+
+Observation collection semantics:
+
+- non-null;
+- read-only from the contract consumer's perspective;
+- strictly ascending semantic instant;
+- no duplicate semantic instant;
+- exact timestamp/offset/decimal fidelity;
+- empty collection valid.
+
+Do not create a persisted-record type in Application.
+
+---
+
+## 15. Coverage Contract
+
+Define only semantic coverage needed to explain the materialized snapshot.
+
+Coverage must be able to explain at least:
+
+- requested `[from, to)` boundaries;
+- observation count;
+- successful empty materialization;
+- when non-empty, the actual first and last selected semantic instants if
+  required to explain observed coverage.
+
+Do not infer that requested boundaries equal observed data coverage.
+Do not fabricate a first/last observation for an empty snapshot.
+
+Do not add quality scoring, gap repair, completeness percentages, market
+calendar logic, or data-quality pipelines. Those are outside WP04.
+
+---
+
+## 16. Provenance Contract
+
+The Application provenance representation must be sufficient to preserve the
+accepted WP03 facts without storage mechanics.
+
+It must be able to explain:
+
+- source authority: accepted Release 1.1 historical observations;
+- Dataset Definition / Definition Identity;
+- relevant Source State / Source State Identity;
+- Research Dataset Identity;
+- Snapshot Identity / Dataset Version;
+- exact target;
+- `[from, to)` selection;
+- selected observation count;
+- identity scheme;
+- materialized snapshot/result.
+
+Do not include operational metadata in semantic identity.
+
+Do not require:
+
+- machine name;
+- process ID;
+- wall-clock execution time;
+- filesystem path;
+- database path;
+- connection string;
+- provider response ordering;
+- random execution identifier.
+
+If operational evidence already exists elsewhere, keep it separate from
+semantic provenance.
+
+---
+
+## 17. Lineage Contract
+
+Represent the accepted lineage relationship explicitly:
+
+```text
+one snapshot
+  -> one dataset definition
+  -> one relevant source state
+  -> zero or more accepted PriceObservation values
+```
+
+The lineage contract must not imply:
+
+- multiple parent datasets;
+- DAG execution;
+- transformations/features;
+- pipeline stages;
+- scheduled refresh;
+- streaming lineage.
+
+Release 1.2 lineage is intentionally narrow.
+
+---
+
+## 18. Materialization Result / Failure Boundary
+
+WP04 may define the result/failure vocabulary needed by WP05, but must not
+implement materialization.
+
+Separate:
+
+- invalid Application request/definition;
+- successful materialization, including successful empty materialization;
+- semantic/integrity conflict where accepted identity/content facts
+  contradict;
+- source-history/storage availability failures only if the Application
+  boundary genuinely needs to express them for later orchestration.
+
+Do not leak Release 1.1 `PersistenceFailure` mechanically into dataset contracts
+unless semantic reconciliation proves it is the correct Application vocabulary.
+Reuse concepts when correct; do not couple unrelated boundaries just to reduce
+type count.
+
+Do not create an oversized failure taxonomy in anticipation of WP11.
+WP11 owns final dataset validation/failure mapping.
+
+The contract must leave WP11 room to map Infrastructure failures without public
+SQLite exception leakage.
+
+---
+
+## 19. Snapshot Store Abstraction
+
+Define only the capability required by later immutable snapshot persistence.
+
+The abstraction must be dataset-specific, not generic CRUD.
+
+It must support the accepted semantics necessary for WP08, such as:
+
+- accepting an immutable snapshot candidate/descriptor;
+- preserving snapshot identity/version;
+- recognizing equivalent already-accepted snapshot evidence without creating a
+  semantically new version;
+- exposing deterministic integrity conflict when equal identity contradicts
+  content;
+- retrieving accepted snapshot evidence by deterministic semantic identity when
+  required by later work.
+
+Do not decide:
+
+- SQLite schema;
+- SQL;
+- transactions;
+- file layout;
+- serialization;
+- physical duplicate strategy;
+- indexes;
+- migration framework.
+
+If write outcome vocabulary is required, make it semantic and minimal.
+Do not use `Created/Updated/Deleted` CRUD vocabulary.
+
+No update/delete/replace operation is authorized.
+
+---
+
+## 20. Catalog Registration / Lookup Abstraction
+
+WP04 may establish the Application seam required for later catalog work, but
+WP06 still owns the metadata/catalog model and WP09 owns persistence/lookup
+implementation.
+
+Therefore define only the minimum capability-level abstraction and lookup
+criteria that are already semantically determined.
+
+Allowed deterministic criteria may include accepted typed values such as:
+
+- exact Research Dataset Identity;
+- exact Snapshot Identity / Dataset Version;
+- exact Definition Identity;
+- exact target plus deterministic definition boundaries where required.
+
+Do not invent rich catalog search/filter/pagination/tagging/query DSLs.
+Do not create physical catalog records.
+Do not define SQL-oriented lookup objects.
+Do not make "latest" a semantic identity operation.
+
+If a catalog method would require WP06 metadata decisions that are not yet
+settled, keep the abstraction narrower and explicitly hand the unresolved model
+to WP06 rather than guessing.
+
+---
+
+## 21. Catalog Registration Semantics
+
+Any Application catalog-registration contract created in WP04 must preserve:
+
+- immutable accepted snapshot identity;
+- no identity reassignment;
+- no silent overwrite;
+- equivalent registration may be idempotent;
+- contradictory content under an equal semantic identity is a deterministic
+  integrity conflict;
+- lookup result absence is distinguishable from storage failure.
+
+Do not implement catalog behavior.
+
+---
+
+## 22. Domain Delta Gate
+
+The authoritative WP04 surface is Application only.
+
+Expected Domain delta:
+
+```text
+0
+```
+
+Inspect existing Domain values and use them when they already own the invariant.
+
+If WP04 appears to require a Domain modification, stop. Do not modify Domain
+under this authority. Report the exact missing Domain semantic and why the
+Application layer cannot safely own it.
+
+---
+
+## 23. Infrastructure and Worker Protection
+
+Expected deltas:
+
+```text
+Infrastructure: 0
+Worker: 0
+```
+
+WP04 must not:
+
+- register services;
+- bind configuration;
+- create SQLite connections;
+- create database files;
+- write/read snapshots;
+- register/look up catalog records physically;
+- execute materialization;
+- invoke providers;
+- modify Worker composition.
+
+These belong to later WPs.
+
+---
+
+## 24. Package / Project Reference Gate
+
+Expected:
+
+```text
+new packages: 0
+package version changes: 0
+new project references: 0
+```
+
+WP04 should compile using the existing dependency graph.
+
+Any need for a new package or project reference is a blocker requiring separate
+authority.
+
+---
+
+## 25. Permanent Test Gate
+
+Expected permanent test delta:
+
+```text
+0
+```
+
+WP13 owns Domain/Application dataset tests.
+
+You may use a narrowly scoped temporary compile/probe artifact only when
+necessary to prove a contract invariant that cannot be demonstrated otherwise.
+It must:
+
+- remain offline;
+- use no provider;
+- use no database;
+- contain no secret;
+- be removed before final validation;
+- leave zero residue.
+
+Prefer static inspection plus normal build validation.
+
+---
+
+## 26. Application Architecture Gate
+
+After implementation, prove:
+
+```text
+Domain -> none
+Application -> Domain
+Infrastructure -> Application
+Worker -> Application, Infrastructure
+```
+
+WP04 must not introduce:
+
+- Infrastructure reference from Application;
+- SQLite reference from Application;
+- provider/HTTP mechanics into Application dataset contracts;
+- cyclic project references;
+- public Infrastructure physical types.
+
+Run all existing architecture tests.
+
+---
+
+## 27. API Surface Quality Gate
+
+Inspect every new public Application type.
+
+Require:
+
+- one clear responsibility;
+- no storage/provider terminology unless it is an abstract capability name;
+- immutable/read-only semantics;
+- deterministic validation;
+- no nullable ambiguity where success/failure/result invariants can be explicit;
+- no unnecessary inheritance hierarchy;
+- no generic repository abstraction;
+- no speculative extension points;
+- no public mutable collection;
+- no physical path/connection/SQL types;
+- no hidden target normalization;
+- no wall-clock/random identity generation.
+
+Use repository naming and namespace conventions.
+
+---
+
+## 28. Semantic Validation Matrix
+
+Before acceptance, explicitly prove each row:
+
+| Requirement | Required result |
+|---|---|
+| WP02 dataset definition preserved | PASS |
+| Single exact target preserved | PASS |
+| `[from, to)` preserved | PASS |
+| Deterministic ascending ordering preserved | PASS |
+| Successful empty materialization representable | PASS |
+| Timestamp/offset/decimal fidelity representable | PASS |
+| Four WP03 identity concepts distinct | PASS |
+| `aiq-dataset-identity-v1` preserved | PASS |
+| 64-lowercase-hex identity form preserved | PASS |
+| Dataset Version = Snapshot Identity semantics | PASS |
+| Equivalent re-materialization representable | PASS |
+| Relevant source change distinguishable | PASS |
+| Operational metadata excluded from identity | PASS |
+| Empty source/snapshot identity representable | PASS |
+| Snapshot immutability representable | PASS |
+| Identity reassignment prohibited | PASS |
+| Provenance facts representable | PASS |
+| Narrow lineage representable | PASS |
+| Coverage semantics representable | PASS |
+| Snapshot candidate/descriptor available to WP05 | PASS |
+| Snapshot-store abstraction storage-independent | PASS |
+| Catalog seam storage-independent | PASS |
+| Deterministic absence distinguishable from failure where applicable | PASS |
+| Integrity conflict representable | PASS |
+| SQLite/SQL/ORM/filesystem leakage | 0 |
+| Provider/HTTP leakage | 0 |
+| Generic CRUD repository introduced | NO |
+| Materialization implementation | NO |
+| Catalog model implementation from WP06 | NO |
+| Snapshot persistence implementation | NO |
+| Permanent test delta | 0 |
+| Package/reference delta | 0/0 |
+| WP05 started | NO |
+| Release 1.3 implementation started | NO |
+
+If a row cannot be proven, WP04 is not complete.
+
+---
+
+## 29. Security and Offline Gate
+
+WP04 must remain fully offline.
+
+Verify:
+
+- provider calls: 0;
+- network calls required by WP04 implementation: 0;
+- live credentials: 0;
+- connection strings: 0;
+- database paths: 0;
+- secret material: 0;
+- sensitive logging: 0.
+
+Run canonical secret scanning if repository verification includes it.
+
+---
+
+## 30. Whitespace and Artifact Integrity
+
+Before completion run:
+
+```text
+git diff --check
+git diff --cached --check
+```
+
+Because accepted Release 1.2 work may remain untracked, also directly validate
+all WP04-created untracked files for trailing whitespace and malformed final
+line endings according to repository conventions.
+
+Do not normalize unrelated accepted files.
+
+If whitespace findings occur in WP04-created files, correct exactly those
+findings and revalidate. No recursive authority chain is required for
+whitespace-only corrections inside files created by this WP.
+
+---
+
+## 31. Final Technical Validation
+
+After the exact WP04 candidate is complete, run the full required validation
+again:
+
+```text
+restore
+format verification
+build
+Domain.Tests
+Application.Tests
+Infrastructure.Tests
+Architecture.Tests
+eng/verify.ps1
+git diff --check
+git diff --cached --check
+```
+
+Expected permanent counts remain:
+
+```text
+Domain.Tests: 11
+Application.Tests: 42
+Infrastructure.Tests: 79
+Architecture.Tests: 13
+Total: 145
+```
+
+If current accepted repository truth has legitimately changed these counts
+before WP04, report the actual baseline and prove WP04 itself did not change
+permanent test count.
+
+Build must finish with zero warnings and zero errors.
+
+No temporary artifact or database residue may remain.
+
+---
+
+## 32. Mutation Accounting
+
+At finalization, enumerate exactly:
+
+- Application files added;
+- Application files modified;
+- files deleted;
+- Domain delta;
+- Infrastructure delta;
+- Worker delta;
+- permanent test delta;
+- package delta;
+- project-reference delta;
+- solution/build/script delta;
+- temporary artifacts created/removed;
+- unexpected paths.
+
+Every production mutation must map directly to an authorized WP04 contract.
+
+Do not stage or commit.
+
+---
+
+## 33. Git / GitHub Protection
+
+Repository/Git transport prohibited:
+
+```text
+git add
+git commit
+git push
+new branch
+pull request
+merge
+tag
+release
+reset/rebase/history rewrite
+```
+
+GitHub mutation allowed only for issue #124 lifecycle and evidence after gates
+pass.
+
+Do not modify:
+
+- issue #125 or later issues;
+- issue dependencies;
+- milestone definition;
+- Project field schema/options;
+- Release 1.1 planning;
+- Release 1.3 planning.
+
+---
+
+## 34. Issue Lifecycle
+
+Only after starting-state and initial baseline gates pass:
+
+```text
+#124 Backlog -> In Progress
+```
+
+Only after every WP04 acceptance gate passes:
+
+1. post concise completion evidence to #124;
+2. close #124;
+3. set its Project status to Done;
+4. verify #125 remains Open/Backlog;
+5. verify #126 remains Open/Backlog;
+6. leave milestone #53 Open.
+
+Do not start WP05.
+
+If blocked after #124 was moved In Progress, report the blocker precisely and
+do not falsely close the issue.
+
+---
+
+## 35. WP05 Handoff Requirements
+
+The WP04 report must give WP05 an exact implementation handoff, including:
+
+- exact Application dataset-definition/request type;
+- exact identity/version types;
+- exact snapshot candidate/descriptor type;
+- exact coverage/provenance/lineage types;
+- exact materialization result/failure vocabulary;
+- exact snapshot-store abstraction;
+- exact catalog abstraction/lookup criteria introduced;
+- validation invariants WP05 may rely on;
+- explicit unresolved matters still owned by WP06+;
+- confirmation that WP05 must not redesign WP02/WP03 semantics.
+
+WP05 should be able to implement deterministic materialization without guessing
+what WP04 meant.
+
+---
+
+## 36. Required Execution Report
+
+Produce a structured report containing at least:
+
+1. Executive Summary
+2. Authorities Reviewed
+3. Repository Context
+4. Initial Git State
+5. Working-Tree Classification
+6. Predecessor / Lifecycle Gates
+7. Issue Lifecycle
+8. Initial Baseline
+9. Existing Application Convention Reconciliation
+10. WP02 Semantic Reconciliation
+11. WP03 Identity / Version / Provenance Reconciliation
+12. Contract Surface Design
+13. Dataset Definition / Request Contract
+14. Identity Contract Model
+15. Dataset Version Contract
+16. Snapshot Candidate / Descriptor Contract
+17. Coverage Contract
+18. Provenance Contract
+19. Lineage Contract
+20. Materialization Result / Failure Contract
+21. Snapshot Store Abstraction
+22. Catalog Registration / Lookup Abstraction
+23. Validation / Invariant Decisions
+24. Domain Delta
+25. Infrastructure / Worker Delta
+26. Exact Files Added / Modified
+27. Package / Reference Delta
+28. Permanent Test Delta
+29. WP05 / WP06+ Protection
+30. Security / Offline Evidence
+31. Whitespace / Diff Evidence
+32. Restore / Build Evidence
+33. Permanent Test Evidence
+34. Canonical Verification
+35. Architecture Validation
+36. Semantic Acceptance Matrix
+37. Mutation Accounting
+38. Git / GitHub Protection
+39. Planning Protection
+40. Findings / Blockers
+41. Final Repository / GitHub State
+42. WP05 Handoff
+43. Final Decision
+44. Next Authorized Work Package
+
+Use actual observed evidence. Do not copy expected values as though observed.
+
+---
+
+## 37. Required Terminal Summary
+
+If successful, end exactly with:
+
+```text
+RELEASE 1.2 WP04 COMPLETE
+
+APPLICATION DATASET CONTRACTS:
+WP02 dataset-definition semantics preserved: PASS
+WP03 identity/version/provenance semantics preserved: PASS
+Provider-independent: PASS
+Storage-independent: PASS
+Dataset definition/request contract: PASS
+Four typed identity concepts: PASS
+Dataset Version semantics: PASS
+Snapshot candidate/descriptor contract: PASS
+Coverage contract: PASS
+Provenance contract: PASS
+Lineage contract: PASS
+Successful empty materialization representable: PASS
+Timestamp/offset/decimal fidelity representable: PASS
+Equivalent re-materialization representable: PASS
+Integrity conflict representable: PASS
+Snapshot-store abstraction: PASS
+Catalog registration/lookup seam: PASS
+SQLite/SQL/ORM/filesystem leakage: 0
+Provider/HTTP leakage: 0
+Domain delta: 0
+Infrastructure delta: 0
+Worker delta: 0
+Permanent test delta: 0
+Package/reference delta: 0/0
+WP05 started: NO
+Release 1.3 implementation started: NO
+Issue #124: CLOSED / DONE
+
+NEXT AUTHORIZED WORK PACKAGE:
+WP05 — Dataset Materialization Use Case
+GitHub issue #125
+```
+
+If blocked, end exactly with:
+
+```text
+RELEASE 1.2 WP04 BLOCKED
+```
+
+Do not print the success marker unless every mandatory gate passes.
+
+---
+
+## 38. Final Constraint
+
+WP04 is the **Application semantic seam**, not an implementation package.
+
+Translate accepted meaning into the smallest explicit contracts that later work
+can depend on. Preserve typed identity, deterministic definition, immutable
+snapshot semantics, provenance, lineage, and storage/provider independence.
+
+Do not solve WP05 orchestration, WP06 catalog modeling, WP07 physical storage,
+WP08/WP09 persistence, WP11 failure mapping, WP12 execution, or WP13 tests.
+
+**The contract must express the accepted dataset semantics precisely without
+letting storage technology, provider mechanics, or operational execution become
+part of dataset meaning.**

--- a/docs/roadmap/release-1.2/prompts/05-dataset-materialization-use-case-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/05-dataset-materialization-use-case-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Use GPT-5.6 Terra and execute `05-dataset-materialization-use-case-codex-prompt.md` as the authoritative Release 1.2 WP05 contract.
+Read all mandatory authorities and accepted WP02–WP04 evidence before mutation; verify #124 is Closed/Done, #125 is Open/Backlog, and #126 remains Open/Backlog.
+Implement only the deterministic Application dataset-materialization use case over accepted Release 1.1 historical observations; preserve canonical identity semantics and do not invoke snapshot persistence, catalog, Infrastructure, Worker, permanent tests, or Release 1.3 behavior.
+Run every required baseline, determinism, canonicalization, semantic, architecture, security, whitespace, scope, and final validation gate; stop on material authority conflict or unexplained drift.
+If all gates pass, close #125 as Done, leave #126 untouched, and end with the exact `RELEASE 1.2 WP05 COMPLETE` terminal summary.

--- a/docs/roadmap/release-1.2/prompts/05-dataset-materialization-use-case-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/05-dataset-materialization-use-case-codex-prompt.md
@@ -1,0 +1,1372 @@
+# Release 1.2 WP05 — Dataset Materialization Use Case — Codex Prompt
+
+## Role
+
+Act as the **WP05 Dataset Materialization Use Case Executor** for Release 1.2 of
+`samuel-santos-engineer/AIQuantTradingResearch`.
+
+Use **GPT-5.6 Terra** for this work package.
+
+WP05 is a bounded **Application orchestration** package. The dataset definition,
+identity/version/provenance semantics, and Application dataset contracts are
+already accepted. Your task is to implement the smallest deterministic
+Application use case that materializes a research dataset from accepted
+Release 1.1 historical observations.
+
+Do not redesign WP02–WP04 semantics. Do not implement snapshot persistence,
+catalog persistence/modeling, SQLite dataset storage, DI/Worker execution,
+final failure mapping, or permanent tests. Do not start WP06.
+
+---
+
+## 1. Mandatory Authorities
+
+Read completely before acting:
+
+```text
+RELEASE_1.2_EXECUTION_PLAN.md
+RELEASE_1.2_FILE_MANIFEST.md
+
+release-1.2-github-planning-codex-prompt.md
+release-1.2-github-planning-codex-prompt-chat.md
+
+01-release-repository-preflight-codex-prompt.md
+01-release-repository-preflight-codex-prompt-chat.md
+
+02-research-dataset-definition-reproducibility-model-codex-prompt.md
+02-research-dataset-definition-reproducibility-model-codex-prompt-chat.md
+
+03-dataset-identity-version-provenance-semantics-codex-prompt.md
+03-dataset-identity-version-provenance-semantics-codex-prompt-chat.md
+
+04-application-dataset-contracts-codex-prompt.md
+04-application-dataset-contracts-codex-prompt-chat.md
+
+05-dataset-materialization-use-case-codex-prompt.md
+05-dataset-materialization-use-case-codex-prompt-chat.md
+
+docs/architecture/data/RESEARCH_DATASET_DEFINITION.md
+docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md
+```
+
+Also inspect completely:
+
+```text
+accepted WP01 execution result
+accepted WP02 execution result
+accepted WP03 execution result
+accepted WP04 execution result
+
+current Release 1.1 Application persistence contracts
+current Release 1.1 historical-observation retrieval boundary
+current Domain PriceObservation / observation semantics
+current Application use-case conventions
+current Application dataset-contract implementation from WP04
+current Infrastructure implementation only as needed to understand the
+  existing Application abstraction — do not couple WP05 to Infrastructure
+current architecture and dependency documentation
+current permanent tests and architecture tests
+
+GitHub milestone #53
+GitHub issue #125
+GitHub issue #126
+Project #2
+```
+
+Authority precedence:
+
+```text
+1. RELEASE_1.2_EXECUTION_PLAN.md
+2. RELEASE_1.2_FILE_MANIFEST.md
+3. Accepted Release 1.2 GitHub planning state
+4. Accepted WP04 contracts/result
+5. Accepted WP03 identity/version/provenance semantics
+6. Accepted WP02 dataset/reproducibility semantics
+7. Accepted WP01 baseline
+8. Accepted Release 1.1 repository truth
+9. Existing repository architecture/conventions
+10. This execution prompt
+```
+
+If authorities materially conflict, stop and report the smallest precise
+blocker. Never silently reinterpret an accepted decision.
+
+---
+
+## 2. Accepted Starting Baseline
+
+Treat the accepted WP04 report as the expected starting state unless current
+evidence proves legitimate drift:
+
+```text
+Repository: samuel-santos-engineer/AIQuantTradingResearch
+Branch: main
+Accepted HEAD/origin at WP04 completion:
+  3ae8ba300fcd356b71fb4fdef5258dc23a99abeb
+Ahead/behind: 0/0
+Staged paths: 0
+Tracked modifications: 0
+
+Release 1.2 lifecycle:
+  #121: CLOSED / DONE
+  #122: CLOSED / DONE
+  #123: CLOSED / DONE
+  #124: CLOSED / DONE
+  #125: OPEN / BACKLOG
+  #126: OPEN / BACKLOG
+  milestone #53: OPEN
+  WP05 dependency: exactly #124
+  Release 1.3 implementation: NOT STARTED
+
+Permanent baseline:
+  Domain.Tests: 11/11
+  Application.Tests: 42/42
+  Infrastructure.Tests: 79/79
+  Architecture.Tests: 13/13
+  Total: 145/145
+```
+
+Accepted WP04 Application dataset seam:
+
+```text
+AIQuantTradingResearch.Application.Datasets
+
+DatasetIdentity.cs
+  DatasetDefinitionIdentity
+  ResearchDatasetIdentity
+  SourceStateIdentity
+  DatasetSnapshotIdentity
+  DatasetVersion
+  identity scheme: aiq-dataset-identity-v1
+  accepted fingerprint representation: 64 lowercase hexadecimal characters
+
+DatasetDefinition.cs
+  exact target
+  explicit valid [from, to)
+  deterministic semantic-instant ascending ordering
+
+DatasetSnapshotCandidate.cs
+  immutable candidate
+  coverage
+  provenance
+  lineage
+  source authority
+  ordered PriceObservation values
+  valid empty snapshots
+  cross-contract consistency validation
+
+DatasetContracts.cs
+  bounded materialization result/failure vocabulary
+  IDatasetSnapshotStore
+  IDatasetCatalog
+```
+
+At WP04 completion the working tree contained 18 accepted cumulative untracked
+paths. Recount and classify the actual current state. The number itself is not
+authority.
+
+---
+
+## 3. Starting-State Gate
+
+Before any mutation:
+
+1. authenticate GitHub without exposing credentials;
+2. verify repository identity;
+3. verify current branch;
+4. fetch/inspect remote state without changing history;
+5. record local HEAD and `origin/main`;
+6. verify ahead/behind;
+7. enumerate staged, tracked-modified, and untracked paths;
+8. classify every existing change against accepted Release 1.2 work;
+9. verify #121–#124 are Closed/Done;
+10. verify #125 is Open/Backlog;
+11. verify #126 is Open/Backlog;
+12. verify milestone #53 remains Open;
+13. verify WP05 depends exactly on #124;
+14. verify no WP06+ lifecycle has advanced;
+15. verify Release 1.3 implementation remains unstarted;
+16. verify all accepted WP02–WP04 artifacts exist;
+17. verify the WP04 dataset contract files match accepted semantics;
+18. verify no unauthorized dataset-materialization implementation already
+    exists.
+
+If unexplained drift exists, stop before mutation.
+
+Do not move #125 to In Progress until the starting-state and initial technical
+baseline gates both pass.
+
+---
+
+## 4. Initial Technical Baseline
+
+Before production mutation, run the canonical repository validation, including
+at minimum:
+
+```text
+dotnet restore AIQuantTradingResearch.slnx
+dotnet format AIQuantTradingResearch.slnx --verify-no-changes
+dotnet build AIQuantTradingResearch.slnx --no-restore
+permanent tests
+Architecture.Tests
+eng/verify.ps1
+git diff --check
+git diff --cached --check
+```
+
+Use repository-owned scripts when more authoritative.
+
+Record actual:
+
+- warnings/errors;
+- suite counts;
+- total tests;
+- architecture result;
+- canonical verification;
+- secret scan;
+- whitespace status;
+- temporary SQLite residue.
+
+Expected permanent baseline is 145/145. If legitimate accepted repository
+changes have altered it, report actual values and prove WP05 does not change
+permanent tests.
+
+Do not repair unrelated baseline failures.
+
+After the gate passes, move issue #125 Backlog → In Progress.
+
+---
+
+## 5. WP05 Objective
+
+Implement the smallest deterministic Application use case that:
+
+```text
+DatasetDefinition
+        |
+        v
+accepted Release 1.1 historical observations
+        |
+        v
+deterministic [from, to) selection
+        |
+        v
+strict ascending semantic-instant ordering
+        |
+        v
+source-state semantic representation
+        |
+        v
+deterministic identities/version
+        |
+        v
+coverage + provenance + lineage
+        |
+        v
+DatasetSnapshotCandidate
+        |
+        v
+DatasetMaterializationResult
+```
+
+WP05 owns **materialization**, not durable dataset persistence.
+
+The successful output must be suitable for WP08 snapshot persistence and later
+catalog integration without those behaviors occurring in WP05.
+
+---
+
+## 6. Core Architectural Boundary
+
+The use case must live in:
+
+```text
+src/AIQuantTradingResearch.Application/**
+```
+
+Expected production deltas:
+
+```text
+Domain: 0
+Application: minimal WP05 implementation
+Infrastructure: 0
+Worker: 0
+```
+
+The use case may depend on:
+
+- Domain values;
+- accepted Application dataset contracts;
+- an existing Application-owned historical-observation abstraction from
+  Release 1.1;
+- a minimal Application-owned deterministic identity computation seam/helper
+  only if needed to implement the already-settled WP03 identity semantics.
+
+It must not depend on:
+
+- Infrastructure;
+- SQLite;
+- `Microsoft.Data.Sqlite`;
+- provider clients;
+- HTTP;
+- Worker;
+- filesystem/database paths;
+- wall-clock services;
+- random-number services.
+
+---
+
+## 7. Source-of-Truth Boundary
+
+Release 1.1 accepted historical observations are the authoritative source.
+
+Inspect the existing Application boundary carefully.
+
+Prefer reuse of the existing Application abstraction rather than introducing a
+second observation repository/source abstraction.
+
+The materialization use case must not:
+
+- call Twelve Data;
+- acquire new market data;
+- invoke provider DTOs;
+- use provider ordering;
+- read SQLite directly;
+- reference Infrastructure;
+- mutate Release 1.1 historical observations.
+
+It must consume accepted observations through the existing Application seam.
+
+If the current Release 1.1 Application abstraction cannot express the exact
+required bounded read without changing its contract, do not silently redesign
+Release 1.1. Determine whether deterministic in-memory filtering over the
+existing target-scoped retrieval is sufficient for Release 1.2.
+
+Prefer bounded Application orchestration over broad predecessor-contract
+mutation.
+
+---
+
+## 8. Dataset Definition Semantics
+
+The input is the accepted WP04 `DatasetDefinition`.
+
+Preserve exactly:
+
+```text
+single exact opaque target
+[from, to)
+from inclusive
+to exclusive
+semantic-instant comparison
+deterministic ascending order
+```
+
+Do not:
+
+- normalize target;
+- change case;
+- trim whitespace;
+- reinterpret the target;
+- widen/narrow boundaries;
+- use local timezone;
+- infer missing boundaries;
+- introduce open-ended definitions;
+- introduce multi-target datasets.
+
+WP04 already validates the definition. WP05 may defensively enforce
+cross-boundary invariants where required, but do not duplicate an independent
+definition model.
+
+---
+
+## 9. Observation Selection
+
+From the accepted target-scoped Release 1.1 history:
+
+1. preserve only observations whose semantic instant satisfies:
+
+```text
+instant >= from
+instant < to
+```
+
+2. ensure deterministic strict ascending semantic-instant ordering;
+3. ensure no duplicate semantic instant appears in the selected materialization;
+4. preserve each selected `PriceObservation` exactly.
+
+Do not mutate or reconstruct values unnecessarily.
+
+Fidelity must preserve:
+
+- exact `DateTimeOffset` semantic instant;
+- original offset representation;
+- exact `decimal` value.
+
+No floating-point conversion.
+No rounding.
+No timestamp truncation.
+No offset normalization.
+
+---
+
+## 10. Successful Empty Materialization
+
+A valid definition that selects zero accepted observations is a successful
+materialization.
+
+It must produce a valid `DatasetSnapshotCandidate` with:
+
+```text
+observation count = 0
+non-null empty observations
+valid requested coverage
+no fabricated first observation
+no fabricated last observation
+deterministic zero-count Source State Identity
+deterministic Snapshot Identity / Dataset Version
+valid provenance
+valid lineage
+```
+
+Do not map empty selection to:
+
+- NotFound;
+- InvalidData;
+- failure;
+- conflict.
+
+---
+
+## 11. Deterministic Identity Computation
+
+WP03 already fixed the semantic identity model:
+
+```text
+scheme: aiq-dataset-identity-v1
+canonical representation:
+  versioned
+  type-separated
+  length-delimited
+  culture-independent UTF-8
+digest:
+  SHA-256
+output:
+  64 lowercase hexadecimal characters
+```
+
+WP05 must implement only the minimum deterministic computation needed to
+materialize the accepted WP04 identity values.
+
+Do not redesign the scheme.
+
+Do not substitute:
+
+- JSON serialization whose formatting/property behavior becomes identity;
+- `GetHashCode`;
+- database IDs;
+- GUIDs;
+- timestamps;
+- random values;
+- machine/process values;
+- culture-sensitive formatting.
+
+### Type separation
+
+Definition, logical dataset, source state, and snapshot identity inputs must be
+type/domain separated exactly enough that equal raw component bytes from
+different identity concepts cannot be silently interpreted as the same semantic
+identity.
+
+### Length delimiting
+
+Variable-length semantic fields must be encoded unambiguously. Do not rely on
+separator characters that may appear in target/parameter values.
+
+### Culture independence
+
+All canonical numeric/text representation involved in identity must be
+culture-independent.
+
+### Version inclusion
+
+The semantic identity scheme/model version must be explicit in canonical
+identity computation so future schemes cannot reinterpret v1 evidence.
+
+---
+
+## 12. Definition Identity
+
+Compute `DatasetDefinitionIdentity` from the accepted definition semantics.
+
+The identity input must cover exactly the WP03-authorized semantic facts,
+including as applicable:
+
+- exact target;
+- `[from, to)` boundary semantic instants;
+- selection semantics;
+- deterministic ordering semantics;
+- explicitly authorized definition parameters;
+- semantic-model/identity-scheme version.
+
+Do not include operational execution facts.
+
+If WP04's definition surface has no additional parameters, do not invent any.
+
+Equivalent definitions must produce equal Definition Identity.
+
+Semantically different definitions must be distinguishable.
+
+---
+
+## 13. Research Dataset Identity
+
+Compute the logical `ResearchDatasetIdentity` according to WP03:
+
+- stable for the same semantic dataset definition;
+- distinct concept from a snapshot;
+- not a mutable "latest" pointer;
+- not derived from operational execution.
+
+Do not let source-state changes silently redefine the logical dataset identity
+if WP03 says the logical identity is definition-stable.
+
+Use the accepted semantic relationship rather than inventing a new formula.
+
+---
+
+## 14. Source State Identity
+
+Compute `SourceStateIdentity` from the **relevant selected source state**, not
+from unrelated database history.
+
+It must cover:
+
+- exact target;
+- selected observation count;
+- selected observations in deterministic ascending semantic-instant order;
+- each selected observation's semantic instant;
+- original offset representation;
+- exact decimal value.
+
+An empty selected state must have a deterministic valid Source State Identity.
+
+Do not include:
+
+- database row IDs;
+- insertion order;
+- database path;
+- source query timing;
+- provider name/order unless explicitly part of accepted semantic source
+  authority;
+- unrelated observations outside the definition.
+
+Equivalent relevant source state must yield equal Source State Identity.
+
+Any relevant membership/value/offset change must be distinguishable.
+
+---
+
+## 15. Snapshot Identity and Dataset Version
+
+Compute `DatasetSnapshotIdentity` from the accepted typed relationship between:
+
+```text
+DatasetDefinitionIdentity
+SourceStateIdentity
+```
+
+and any other semantic component explicitly required by WP03.
+
+Do not introduce operational metadata.
+
+`DatasetVersion` must preserve WP04/WP03 semantics:
+
+```text
+Dataset Version == immutable deterministic Snapshot Identity
+```
+
+Equivalent re-materialization must therefore yield the same semantic Snapshot
+Identity and Dataset Version.
+
+---
+
+## 16. Collision / Contradiction Boundary
+
+SHA-256 is compact identity evidence, not proof that contradictory content is
+impossible.
+
+WP05 must not:
+
+- claim collision impossibility;
+- overwrite evidence;
+- silently alias contradictory semantic content;
+- use digest equality to justify mutation.
+
+The existing WP04 contracts must remain capable of representing integrity
+conflict for later persistence/catalog work.
+
+WP05 itself normally materializes one candidate from one source state and
+should not invent a conflict merely because a store/catalog is not consulted.
+
+Do not call `IDatasetSnapshotStore` or `IDatasetCatalog` just to manufacture a
+collision check. Persistence/catalog consistency belongs to later WPs.
+
+---
+
+## 17. Coverage Construction
+
+Construct the accepted WP04 coverage representation deterministically.
+
+It must preserve:
+
+- requested `from`;
+- requested `to`;
+- selected count;
+- successful empty semantics;
+- actual first selected semantic instant when non-empty and required by the
+  WP04 contract;
+- actual last selected semantic instant when non-empty and required by the
+  WP04 contract.
+
+Do not confuse requested interval with observed data coverage.
+
+Do not calculate:
+
+- quality score;
+- expected candle count;
+- market-calendar completeness;
+- gap repair;
+- interpolation;
+- resampling.
+
+---
+
+## 18. Provenance Construction
+
+Construct WP04 `DatasetProvenance` using only accepted semantic facts.
+
+It must explain, as represented by the accepted contract:
+
+- accepted Release 1.1 historical observations as source authority;
+- definition;
+- Definition Identity;
+- Research Dataset Identity;
+- Source State Identity;
+- Snapshot Identity / Dataset Version;
+- exact target;
+- requested boundaries;
+- selected count;
+- identity scheme;
+- materialized result.
+
+Do not add operational identity inputs such as:
+
+- current time;
+- host/machine;
+- process;
+- user;
+- path;
+- connection string;
+- random execution ID.
+
+If an operational materialization timestamp is not already part of the accepted
+WP04 semantic contract, do not add one.
+
+---
+
+## 19. Lineage Construction
+
+Construct the narrow accepted lineage:
+
+```text
+snapshot
+  -> one definition
+  -> one relevant source state
+  -> zero or more selected accepted observations
+```
+
+Do not introduce:
+
+- parent dataset graphs;
+- transformation DAGs;
+- pipeline stage IDs;
+- feature lineage;
+- scheduling;
+- refresh chains.
+
+Release 1.3 owns pipeline behavior.
+
+---
+
+## 20. Materialization Use-Case API
+
+Follow existing Application use-case conventions.
+
+Create the minimum clear surface, expected conceptually to resemble:
+
+```text
+IMaterializeDatasetUseCase
+MaterializeDatasetRequest   (only if DatasetDefinition alone is insufficient)
+MaterializeDatasetUseCase
+```
+
+Do not force these exact names if repository conventions or the manifest define
+different authoritative names.
+
+Prefer using `DatasetDefinition` directly when a wrapper request adds no
+semantic value.
+
+Constructor dependencies must be minimal.
+
+The use case must not depend on:
+
+```text
+IDatasetSnapshotStore
+IDatasetCatalog
+IServiceProvider
+IConfiguration
+ILogger (unless current Application use-case convention makes logging an
+  already-established dependency and it remains semantically irrelevant)
+Infrastructure concrete types
+```
+
+Snapshot persistence/catalog registration is not WP05.
+
+---
+
+## 21. Materialization Result / Failure Handling
+
+Return the accepted WP04 `DatasetMaterializationResult` and failure vocabulary
+without redesigning it.
+
+Map only failures that belong at the Application materialization boundary.
+
+Examples to reconcile against actual WP04 contracts:
+
+```text
+invalid definition/request
+source history unavailable
+source history invalid/inconsistent
+integrity/semantic contradiction
+```
+
+Do not invent a broad WP11 failure taxonomy.
+
+If Release 1.1 retrieval returns an existing `PersistenceFailure`, translate it
+at the dataset Application boundary only as necessary; do not expose storage
+technology.
+
+Preserve:
+
+- success with empty candidate;
+- success with non-empty candidate;
+- no null-success ambiguity;
+- no partial successful snapshot after a failed source read.
+
+---
+
+## 22. Snapshot Store Protection
+
+`IDatasetSnapshotStore` exists for later work.
+
+WP05 must **not** invoke it.
+
+Specifically, WP05 must not:
+
+- persist a snapshot;
+- detect persisted duplicates;
+- retrieve persisted snapshots;
+- overwrite snapshots;
+- create storage transactions;
+- interpret physical persistence errors.
+
+WP08 owns snapshot persistence.
+
+---
+
+## 23. Catalog Protection
+
+`IDatasetCatalog` exists as a later seam.
+
+WP05 must **not** invoke it.
+
+Do not:
+
+- register the materialized snapshot;
+- query catalog state;
+- implement "latest";
+- implement catalog search;
+- create metadata records;
+- perform catalog consistency checks.
+
+WP06 owns catalog metadata/model semantics.
+WP09 owns catalog persistence/lookup.
+WP10 owns materialization integration across these capabilities.
+
+---
+
+## 24. WP06 Protection
+
+WP06 — Dataset Metadata & Catalog Model — must remain unstarted.
+
+WP05 may populate only the provenance/coverage/lineage values already accepted
+by WP04.
+
+Do not add speculative catalog metadata such as:
+
+- title;
+- description;
+- tags;
+- status;
+- owner;
+- creation timestamp;
+- update timestamp;
+- physical location;
+- storage format;
+- arbitrary metadata dictionary;
+- search facets.
+
+If materialization needs a fact not representable by WP04 and that fact is
+clearly catalog metadata, stop rather than stealing WP06 scope.
+
+---
+
+## 25. Domain Delta
+
+Expected:
+
+```text
+Domain production delta: 0
+```
+
+Use existing Domain `PriceObservation` and semantic-instant behavior.
+
+Do not move dataset orchestration into Domain.
+
+If a missing invariant genuinely requires Domain ownership, stop and report the
+smallest authority gap.
+
+---
+
+## 26. Infrastructure / Worker Delta
+
+Expected:
+
+```text
+Infrastructure production delta: 0
+Worker production delta: 0
+```
+
+No:
+
+- SQLite;
+- SQL;
+- schema;
+- files;
+- database;
+- provider;
+- HTTP;
+- DI registration;
+- configuration binding;
+- Worker invocation.
+
+---
+
+## 27. Package / Reference Delta
+
+Expected:
+
+```text
+new package delta: 0
+package-version delta: 0
+project-reference delta: 0
+```
+
+Use .NET platform cryptography APIs if deterministic SHA-256 computation is
+needed; do not add a hashing package.
+
+Any new package/reference requirement is a blocker.
+
+---
+
+## 28. Permanent Test Delta
+
+Expected:
+
+```text
+permanent test delta: 0
+```
+
+WP13 owns Domain/Application dataset tests.
+
+You may create a temporary offline Application-focused probe only if necessary
+to validate difficult deterministic identity/materialization behavior before
+WP13.
+
+Any temporary probe must:
+
+- use no network/provider;
+- use no SQLite/database;
+- use synthetic observations;
+- contain no secret;
+- be removed completely before final validation.
+
+Prefer compile/build plus a narrowly scoped disposable probe rather than
+modifying permanent tests.
+
+---
+
+## 29. Determinism Proof
+
+Before acceptance, explicitly prove at least these cases using static reasoning
+and, where useful, a temporary offline probe:
+
+1. same definition + same relevant observations → same:
+   - Definition Identity;
+   - Research Dataset Identity;
+   - Source State Identity;
+   - Snapshot Identity;
+   - Dataset Version;
+   - ordered content;
+   - semantic provenance/lineage;
+2. same semantic inputs under a different current culture → same identities;
+3. same observations supplied/retrieved in a different non-authoritative input
+   order → same deterministic materialization if the existing source contract
+   permits such input;
+4. observation outside `[from, to)` → excluded and does not affect relevant
+   Source State Identity;
+5. selected price change → Source State/Snapshot identity changes;
+6. selected original offset representation change at the same semantic instant
+   → Source State/Snapshot identity changes;
+7. selected membership change → Source State/Snapshot identity changes;
+8. definition boundary/target change → Definition/Research Dataset/Snapshot
+   identity changes as semantically required;
+9. valid zero-row selection → deterministic successful empty candidate;
+10. no wall-clock/random/machine/path/database/provider-order input affects
+    semantic identity.
+
+Do not weaken accepted semantics merely to simplify the implementation.
+
+---
+
+## 30. Canonicalization Inspection Gate
+
+Because identity computation is high-impact, inspect the implementation
+line-by-line before final acceptance.
+
+Prove:
+
+- UTF-8 explicitly used;
+- type/domain separation explicit;
+- length delimiting unambiguous;
+- invariant/culture-independent representation;
+- scheme/version explicit;
+- target preserved exactly;
+- semantic instants represented deterministically;
+- original offset included where required;
+- decimal represented exactly and invariantly;
+- no floating-point intermediary;
+- SHA-256 used;
+- lowercase 64-hex output;
+- no `GetHashCode`;
+- no JSON serializer as canonical identity authority;
+- no current-time/random inputs;
+- no filesystem/database/provider transport inputs.
+
+If any of these are ambiguous, WP05 is not complete.
+
+---
+
+## 31. Application Architecture Gate
+
+After implementation prove the production graph remains:
+
+```text
+Domain -> none
+Application -> Domain
+Infrastructure -> Application
+Worker -> Application, Infrastructure
+```
+
+Require:
+
+```text
+Application -> Infrastructure: 0
+Application SQLite references: 0
+Application provider/HTTP mechanics: 0
+new dependency cycles: 0
+```
+
+Run all Architecture.Tests.
+
+---
+
+## 32. Security / Offline Gate
+
+WP05 execution must remain offline except for GitHub lifecycle inspection.
+
+Implementation/probes must use:
+
+```text
+provider calls: 0
+market-data network calls: 0
+live credentials: 0
+database calls: 0
+database files: 0
+connection strings: 0
+machine-specific paths in production: 0
+secret material: 0
+```
+
+Run canonical secret scanning when included in `eng/verify.ps1`.
+
+---
+
+## 33. Whitespace / Artifact Integrity
+
+Run:
+
+```text
+git diff --check
+git diff --cached --check
+```
+
+Accepted Release 1.2 files may remain untracked, so directly validate every
+WP05-created untracked file for trailing whitespace and repository final-line
+conventions.
+
+Whitespace-only findings inside WP05-created files may be corrected directly
+and revalidated. Do not create another authority chain for such corrections.
+
+Do not normalize unrelated accepted files.
+
+---
+
+## 34. Semantic Acceptance Matrix
+
+Explicitly report each row:
+
+| Requirement | Required |
+|---|---|
+| WP02 semantics preserved | PASS |
+| WP03 semantics preserved | PASS |
+| WP04 contracts reused | PASS |
+| Existing Release 1.1 Application source boundary reused | PASS |
+| Exact target | PASS |
+| `[from, to)` | PASS |
+| Strict ascending materialization | PASS |
+| Successful empty materialization | PASS |
+| Timestamp semantic instant fidelity | PASS |
+| Original offset fidelity | PASS |
+| Decimal fidelity | PASS |
+| Definition Identity deterministic | PASS |
+| Research Dataset Identity deterministic | PASS |
+| Source State Identity deterministic | PASS |
+| Snapshot Identity deterministic | PASS |
+| Dataset Version semantics preserved | PASS |
+| Equivalent re-materialization deterministic | PASS |
+| Relevant source changes distinguishable | PASS |
+| Empty source-state identity deterministic | PASS |
+| Canonical v1 representation | PASS |
+| SHA-256 / 64 lowercase hex | PASS |
+| Culture independence | PASS |
+| Type separation / length delimiting | PASS |
+| Operational metadata excluded | PASS |
+| Coverage deterministic | PASS |
+| Provenance deterministic | PASS |
+| Lineage deterministic | PASS |
+| Snapshot persistence invoked | NO |
+| Catalog invoked | NO |
+| SQLite/SQL/filesystem leakage | 0 |
+| Provider/HTTP leakage | 0 |
+| Domain delta | 0 |
+| Infrastructure delta | 0 |
+| Worker delta | 0 |
+| Permanent test delta | 0 |
+| Package/reference delta | 0/0 |
+| WP06 started | NO |
+| Release 1.3 started | NO |
+
+---
+
+## 35. Final Technical Validation
+
+After implementation and after removing all temporary probes/residue, rerun:
+
+```text
+dotnet restore AIQuantTradingResearch.slnx
+dotnet format AIQuantTradingResearch.slnx --verify-no-changes
+dotnet build AIQuantTradingResearch.slnx --no-restore
+all permanent tests
+Architecture.Tests
+eng/verify.ps1
+git diff --check
+git diff --cached --check
+```
+
+Expected unchanged permanent counts:
+
+```text
+Domain.Tests: 11/11
+Application.Tests: 42/42
+Infrastructure.Tests: 79/79
+Architecture.Tests: 13/13
+Total: 145/145
+```
+
+Require:
+
+```text
+warnings: 0
+errors: 0
+failed tests: 0
+skipped tests: 0
+temporary database residue: 0
+temporary probe residue: 0
+```
+
+If accepted baseline counts have legitimately changed, use actual evidence and
+prove WP05's permanent test delta remains zero.
+
+---
+
+## 36. Exact Mutation Accounting
+
+At finalization enumerate:
+
+- Application files added;
+- Application files modified;
+- Application files deleted;
+- Domain delta;
+- Infrastructure delta;
+- Worker delta;
+- permanent tests changed;
+- packages changed;
+- project references changed;
+- solution/build/scripts changed;
+- temporary probes created/removed;
+- generated/temp files created/removed;
+- unexpected paths.
+
+Every WP05 production mutation must map directly to deterministic
+materialization.
+
+Do not stage the candidate.
+
+---
+
+## 37. Git / GitHub Protection
+
+Do not:
+
+```text
+git add
+git commit
+git push
+create branch
+create PR
+merge
+tag
+release
+reset
+rebase
+rewrite history
+```
+
+GitHub mutations are limited to issue #125 lifecycle/evidence after gates pass.
+
+Do not alter:
+
+- #126 or later issues;
+- dependencies;
+- milestone #53 definition;
+- Project field schema/options;
+- Release 1.1 objects;
+- Release 1.3 objects.
+
+---
+
+## 38. Issue Lifecycle
+
+Only after starting-state and baseline validation:
+
+```text
+#125 Backlog -> In Progress
+```
+
+Only after every acceptance gate passes:
+
+1. post concise completion evidence to #125;
+2. close #125;
+3. set #125 Project status to Done;
+4. verify #126 remains Open/Backlog;
+5. leave milestone #53 Open;
+6. do not start WP06.
+
+If blocked after moving #125 In Progress, report the blocker and leave the issue
+truthful. Never close it on partial completion.
+
+---
+
+## 39. WP06 Handoff
+
+The execution report must tell WP06 exactly what materialization now produces.
+
+Include:
+
+- exact materialization use-case/interface names;
+- constructor dependencies;
+- exact source-history abstraction reused;
+- exact input;
+- exact success result;
+- exact failure vocabulary;
+- selection/filtering behavior;
+- ordering behavior;
+- empty behavior;
+- identity computation ownership/location;
+- canonicalization algorithm shape;
+- coverage fields populated;
+- provenance fields populated;
+- lineage fields populated;
+- what metadata remains intentionally undefined for WP06;
+- confirmation snapshot store/catalog were not invoked;
+- confirmation no physical storage design was introduced.
+
+WP06 must be able to design metadata/catalog semantics from concrete
+materialization output without guessing.
+
+---
+
+## 40. Required Execution Report
+
+Produce a structured report with at least:
+
+1. Executive Summary
+2. Authorities Reviewed
+3. Repository Context
+4. Initial Git State
+5. Working-Tree Classification
+6. Predecessor / Lifecycle Gates
+7. Issue Lifecycle
+8. Initial Baseline
+9. Existing Application Convention Reconciliation
+10. Release 1.1 Source-Boundary Reconciliation
+11. WP02 Semantic Reconciliation
+12. WP03 Identity / Version / Provenance Reconciliation
+13. WP04 Contract Reconciliation
+14. Materialization Use-Case Design
+15. Input / Definition Handling
+16. Source Retrieval Design
+17. Selection Semantics
+18. Ordering Semantics
+19. Empty Materialization
+20. Definition Identity Computation
+21. Research Dataset Identity Computation
+22. Source State Identity Computation
+23. Snapshot Identity / Dataset Version Computation
+24. Canonical Representation
+25. Coverage Construction
+26. Provenance Construction
+27. Lineage Construction
+28. Result / Failure Handling
+29. Snapshot Store Protection
+30. Catalog Protection
+31. Exact Files Added / Modified
+32. Domain / Infrastructure / Worker Delta
+33. Package / Reference Delta
+34. Permanent Test / Temporary Probe Delta
+35. Determinism Evidence
+36. Security / Offline Evidence
+37. Whitespace / Diff Evidence
+38. Restore / Build Evidence
+39. Permanent Test Evidence
+40. Canonical Verification
+41. Architecture Validation
+42. Semantic Acceptance Matrix
+43. Mutation Accounting
+44. Git / GitHub Protection
+45. Planning Protection
+46. Findings / Blockers
+47. Final Repository / GitHub State
+48. WP06 Handoff
+49. Final Decision
+50. Next Authorized Work Package
+
+Use observed facts, not expected values presented as observations.
+
+---
+
+## 41. Required Terminal Summary
+
+If successful, end exactly with:
+
+```text
+RELEASE 1.2 WP05 COMPLETE
+
+DATASET MATERIALIZATION USE CASE:
+WP02 dataset semantics preserved: PASS
+WP03 identity/version/provenance semantics preserved: PASS
+WP04 contracts reused: PASS
+Release 1.1 historical observations reused as source truth: PASS
+Application orchestration: PASS
+Exact target selection: PASS
+[from, to) selection: PASS
+Deterministic ascending ordering: PASS
+Successful empty materialization: PASS
+Timestamp/offset/decimal fidelity: PASS
+Definition Identity computation: PASS
+Research Dataset Identity computation: PASS
+Source State Identity computation: PASS
+Snapshot Identity computation: PASS
+Dataset Version semantics: PASS
+Canonical identity representation: PASS
+SHA-256 / 64 lowercase hex: PASS
+Equivalent re-materialization determinism: PASS
+Relevant source-change distinguishability: PASS
+Coverage construction: PASS
+Provenance construction: PASS
+Lineage construction: PASS
+Snapshot persistence invoked: NO
+Catalog invoked: NO
+SQLite/SQL/filesystem leakage: 0
+Provider/HTTP leakage: 0
+Domain delta: 0
+Infrastructure delta: 0
+Worker delta: 0
+Permanent test delta: 0
+Package/reference delta: 0/0
+WP06 started: NO
+Release 1.3 implementation started: NO
+Issue #125: CLOSED / DONE
+
+NEXT AUTHORIZED WORK PACKAGE:
+WP06 — Dataset Metadata & Catalog Model
+GitHub issue #126
+```
+
+If blocked, end exactly with:
+
+```text
+RELEASE 1.2 WP05 BLOCKED
+```
+
+Do not emit the success marker unless all mandatory gates pass.
+
+---
+
+## 42. Final Constraint
+
+WP05 is where accepted dataset semantics become **deterministic Application
+behavior**, but it is not where a dataset becomes durable.
+
+The use case must produce the same semantic snapshot candidate whenever the
+same Dataset Definition is materialized against the same relevant accepted
+Release 1.1 source state.
+
+The implementation must make identity computation explicit, deterministic,
+culture-independent, and faithful to WP03 while keeping provider mechanics,
+SQLite, catalog persistence, snapshot persistence, Worker execution, and
+Release 1.3 pipelines completely outside the boundary.
+
+**Materialize meaning; do not persist it yet.**

--- a/docs/roadmap/release-1.2/prompts/06-dataset-metadata-catalog-model-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/06-dataset-metadata-catalog-model-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read `06-dataset-metadata-catalog-model-codex-prompt.md` completely and treat it as the authoritative Release 1.2 WP06 execution contract.
+Execute only WP06 — Dataset Metadata & Catalog Model for GitHub issue #126, preserving accepted WP02–WP05 semantics and the Release 1.1 foundation.
+Keep the work Application-owned and storage/provider independent; do not implement physical storage, snapshot persistence, catalog persistence/lookup, Worker execution, or Release 1.3 behavior.
+Run every governance, architecture, security, build, test, whitespace, and lifecycle gate required by the authority; stop on any unresolved authority or starting-state conflict.
+Finish only with the authority's required WP06 execution report and terminal marker; leave WP07 issue #127 Open / Backlog and do not stage, commit, push, branch, or open a PR.

--- a/docs/roadmap/release-1.2/prompts/06-dataset-metadata-catalog-model-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/06-dataset-metadata-catalog-model-codex-prompt.md
@@ -1,0 +1,633 @@
+# Release 1.2 WP06 — Dataset Metadata & Catalog Model — Codex Execution Authority
+
+## 1. Authority
+
+You are executing **Release 1.2 WP06 — Dataset Metadata & Catalog Model** for:
+
+- Repository: `samuel-santos-engineer/AIQuantTradingResearch`
+- Release: `Phase 3 - Release 1.2: Research Dataset Foundation`
+- GitHub issue: `#126`
+- Predecessors: WP03 `#123` and WP04 `#124`, both must be Closed / Done.
+- WP05 `#125` is accepted implementation context and must be reconciled, but do not change its semantics.
+- Next package: WP07 — Dataset Physical Storage Model, issue `#127`.
+
+This file is the authoritative WP06 execution instruction. Read it completely before mutation.
+
+Also read and reconcile, at minimum:
+
+- `RELEASE_1.2_EXECUTION_PLAN.md`
+- `RELEASE_1.2_FILE_MANIFEST.md`
+- accepted Release 1.2 WP01–WP05 prompt/result artifacts
+- `docs/architecture/data/RESEARCH_DATASET_DEFINITION.md`
+- `docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md`
+- current Application dataset contracts and materialization implementation
+- existing Release 1.1 persistence/catalog/data architecture documentation
+- current Domain/Application/Infrastructure/Worker source and tests
+- GitHub issue #126, its dependencies, milestone #53, and Project #2 state
+
+Repository truth wins over assumptions. If authority, repository state, manifest, or accepted predecessor semantics conflict materially, stop and report the smallest corrective authority required.
+
+## 2. Objective
+
+Define the **logical dataset metadata and catalog model** required to describe, register, and later discover immutable Release 1.2 dataset snapshots.
+
+WP06 must establish a precise, storage-independent model that answers:
+
+- What metadata belongs to a dataset snapshot's catalog representation?
+- Which facts are identity-bearing versus descriptive/catalog-visible?
+- How is an immutable snapshot represented as a catalog entry?
+- Which metadata is required for exact lookup, explanation, filtering, and future persistence?
+- How are definition, version, coverage, provenance, lineage, and source-state facts exposed without duplicating or contradicting WP03/WP05 semantics?
+- What invariants make a catalog entry internally consistent?
+- What is intentionally deferred to WP07–WP09?
+
+WP06 is a **modeling package**, not a persistence package.
+
+## 3. Required starting-state gates
+
+Before implementation:
+
+1. Confirm repository identity and authentication without exposing credentials.
+2. Confirm branch is `main`.
+3. Fetch/reconcile `origin/main`; report HEAD, origin SHA, ahead/behind, staged, tracked, and untracked state.
+4. Classify every existing working-tree path. Preserve accepted cumulative Release 1.2 artifacts byte-for-byte unless WP06 explicitly owns them.
+5. Confirm:
+   - Release 1.1 is closed.
+   - milestone #53 is authoritative and Open.
+   - #123 and #124 are Closed / Done.
+   - #126 is Open / Backlog.
+   - #127 remains Open / Backlog.
+   - dependency graph for #126 matches the Release 1.2 plan.
+   - no Release 1.3 implementation is active.
+6. Confirm WP05 materialization artifacts exist and match the accepted handoff.
+7. Run the unchanged baseline:
+   - restore
+   - format verification
+   - build
+   - all permanent tests
+   - architecture tests
+   - `eng/verify.ps1`
+   - `git diff --check`
+   - `git diff --cached --check`
+8. Do not move #126 to In Progress until all starting gates pass.
+
+If a starting gate fails, do not mutate production/test/documentation code and do not progress #126.
+
+## 4. Accepted semantic authorities that MUST NOT be redesigned
+
+### WP02
+
+Preserve:
+
+- immutable Research Dataset semantics
+- exact single target
+- explicit `[from, to)` selection
+- deterministic ascending semantic-instant ordering
+- successful empty materialization
+- original timestamp offset and decimal fidelity
+- immutable snapshot evidence
+- deterministic reproducibility
+
+### WP03
+
+Preserve:
+
+- four distinct identities:
+  - Dataset Definition Identity
+  - Research Dataset Identity
+  - Source State Identity
+  - Dataset Snapshot Identity
+- Dataset Version = immutable deterministic Snapshot Identity
+- identity scheme `aiq-dataset-identity-v1`
+- SHA-256 / 64 lowercase hexadecimal representation
+- canonical semantic representation
+- provenance and narrow lineage semantics
+- identity reassignment prohibited
+- collision/integrity-conflict semantics
+- operational metadata excluded from semantic identity
+
+Do **not** invent another identity scheme, version model, digest, or canonicalization.
+
+### WP04
+
+Reuse the existing Application dataset contracts. Inspect their exact names and signatures before design.
+
+In particular reconcile:
+
+- `DatasetIdentity.cs`
+- `DatasetDefinition.cs`
+- `DatasetSnapshotCandidate.cs`
+- `DatasetContracts.cs`
+- `IDatasetCatalog`
+
+Do not casually break or replace accepted public contracts.
+
+### WP05
+
+Treat `DatasetSnapshotCandidate` emitted by `IMaterializeDatasetUseCase` as the deterministic semantic input.
+
+Preserve:
+
+- exact selected observations
+- coverage
+- provenance
+- lineage
+- identities
+- version
+- source authority
+- deterministic empty candidate
+- bounded materialization failures
+
+WP06 must not recompute identities differently or introduce a second materialization model.
+
+## 5. Core design principle
+
+Separate three concepts rigorously:
+
+### A. Semantic identity/provenance facts
+
+Already defined by WP03/WP05. They explain **what the snapshot is and where it came from**.
+
+### B. Catalog metadata
+
+Logical, storage-independent facts required to represent and discover an immutable accepted snapshot in a catalog.
+
+### C. Physical catalog persistence
+
+Tables, columns, indexes, SQL, SQLite layout, serialization, filesystem layout, and persistence mechanics.
+
+**WP06 owns B. WP03/WP05 own A. WP07–WP09 own C and its persistence behavior.**
+
+Do not blur these boundaries.
+
+## 6. Required WP06 model
+
+Inspect the existing WP04 `IDatasetCatalog` seam and determine the smallest Application-owned model needed to make that seam semantically complete for later implementation.
+
+The expected direction is a capability-focused model such as a dataset catalog entry/descriptor plus query/lookup semantics, but exact type names must follow repository conventions and the manifest.
+
+The model MUST expose enough information to explain an accepted snapshot without accessing SQLite or re-materializing it.
+
+At minimum, reconcile representation of:
+
+- Dataset Definition Identity
+- Research Dataset Identity
+- Source State Identity
+- Dataset Snapshot Identity
+- Dataset Version
+- exact target
+- requested `[from, to)` boundaries
+- selected observation count
+- first/last selected semantic instant when non-empty
+- explicit empty-state semantics
+- identity scheme
+- source authority
+- provenance facts already carried by the candidate
+- narrow lineage facts already carried by the candidate
+
+Prefer composition/reuse of existing WP04 types over copying the same facts into parallel primitive fields.
+
+## 7. Metadata taxonomy
+
+For every proposed field/property, classify it explicitly in the execution report as one of:
+
+1. **Identity-bearing semantic input** — already governed by WP03; catalog merely exposes/reuses it.
+2. **Deterministic descriptive metadata** — derived from accepted semantic content and safe to catalog.
+3. **Operational metadata** — e.g. wall-clock creation time, machine, process, path. Exclude from semantic identity; add only if explicitly required by accepted authority.
+4. **Physical-storage metadata** — table IDs, row IDs, database paths, filenames, offsets, SQL keys. Prohibited in WP06.
+
+Default to excluding operational metadata unless the Release 1.2 authorities explicitly require it.
+
+Do not introduce `CreatedAt`, `UpdatedAt`, random IDs, database-generated IDs, mutable status, "latest" pointers, or machine-specific metadata merely because catalogs commonly have them.
+
+## 8. Catalog entry invariants
+
+The logical catalog model must enforce or make explicit, as appropriate to repository conventions:
+
+- snapshot identity and Dataset Version agree exactly
+- definition identity agrees with the represented definition
+- research dataset identity is the correct logical identity concept
+- source-state identity is present
+- exact target is preserved
+- requested boundaries are valid `[from, to)`
+- count is non-negative
+- empty snapshot:
+  - count = 0
+  - first/last actual observation instant absent
+- non-empty snapshot:
+  - count > 0
+  - first and last actual observation instants present
+  - first <= last
+  - actual instants lie within requested boundaries
+- coverage/provenance/lineage cannot contradict the entry
+- identity scheme remains `aiq-dataset-identity-v1`
+- immutable accepted snapshot metadata cannot be mutated into a different snapshot
+
+Reuse existing validated value objects/contracts wherever possible rather than duplicating validation.
+
+## 9. Catalog semantics
+
+Define the logical behavior expected from the catalog seam sufficiently for WP09 to implement it without semantic invention.
+
+The accepted model should support **exact immutable snapshot registration and lookup**, not a general search engine.
+
+At minimum determine semantics for:
+
+### Registration
+
+- registering a previously unknown snapshot catalog entry
+- registering semantically equivalent evidence again
+- attempting to register contradictory metadata for the same Snapshot Identity
+- prohibition on overwrite/reassignment
+- distinction between idempotent equivalent registration and integrity conflict
+
+Do not implement registration persistence in WP06.
+
+### Exact lookup
+
+The catalog must be capable of exact lookup by the strongest accepted immutable identity: Dataset Snapshot Identity / Dataset Version.
+
+If WP04 already fixed the exact lookup signature, preserve it.
+
+Define:
+
+- found semantics
+- not-found semantics
+- invalid input semantics
+- integrity failure boundary as representable by existing/authorized vocabulary
+
+Do not add broad filtering/search APIs unless the execution plan explicitly requires them for WP06.
+
+### Logical-dataset/version relationship
+
+A Research Dataset Identity may have multiple immutable Snapshot Identities/Versions when relevant source state changes.
+
+Do not model a mutable "current version" or overwrite prior versions.
+
+If version enumeration is not explicitly required by the WP04 seam/manifest, document it as later capability rather than expanding scope.
+
+## 10. Metadata vs provenance
+
+Avoid a second provenance model.
+
+Where `DatasetSnapshotCandidate`, `DatasetProvenance`, `DatasetCoverage`, or `DatasetLineage` already contain the required facts:
+
+- reuse them directly when appropriate; or
+- define a deliberately minimal immutable catalog descriptor that composes them.
+
+Any duplication must have a clear contract reason and must be protected by consistency invariants.
+
+Do not create competing definitions of:
+
+- source authority
+- source state
+- coverage
+- lineage
+- identity scheme
+- definition identity
+- snapshot version
+
+## 11. Application-layer ownership
+
+WP06 logical catalog types belong in the **Application dataset boundary** unless the accepted manifest says otherwise.
+
+Requirements:
+
+- provider-independent
+- storage-independent
+- no SQLite types
+- no SQL
+- no ORM annotations
+- no filesystem paths
+- no connection strings
+- no provider DTOs
+- no HTTP types
+- no Infrastructure references
+- no Worker references
+
+Domain delta should remain zero unless a genuine Domain-owned invariant is impossible to express with current Domain values. If a Domain delta appears necessary, stop and justify before mutation.
+
+## 12. Scope expected from the manifest
+
+Read `RELEASE_1.2_FILE_MANIFEST.md` and obey its exact WP06 path authorization.
+
+Do not create files merely because this prompt suggests conceptual names.
+
+If the manifest authorizes Application files for WP06, use the smallest set necessary. Keep naming consistent with the current `AIQuantTradingResearch.Application.Datasets` namespace and repository conventions.
+
+Do not modify WP02/WP03 architecture artifacts unless the manifest explicitly assigns such alignment to WP06. WP15 owns broad documentation alignment.
+
+## 13. Explicit non-goals
+
+WP06 MUST NOT implement:
+
+- SQLite schema or DDL
+- physical dataset storage
+- snapshot persistence
+- catalog persistence
+- SQL queries
+- catalog lookup implementation
+- connection/configuration behavior
+- migrations
+- filesystem layout
+- serialization format for persistence
+- ORM entities
+- Worker execution
+- DI registration
+- materialization orchestration changes
+- source-history retrieval changes
+- identity canonicalization redesign
+- identity digest redesign
+- permanent tests assigned to WP13/WP14
+- Release 1.3 pipelines, scheduling, refresh, streaming, DAGs, monitoring, or resilience
+
+WP07 owns physical storage modeling.
+WP08 owns snapshot persistence.
+WP09 owns catalog persistence and lookup.
+WP10 owns materialization integration.
+WP11 owns validation/failure mapping.
+WP12 owns DI/bounded execution.
+WP13/WP14 own permanent tests.
+WP15 owns architecture/documentation alignment.
+WP16 owns full integration.
+
+## 14. Implementation approach
+
+After starting gates pass:
+
+1. Move issue #126 from Backlog to In Progress.
+2. Inspect exact WP04 catalog contract and candidate model.
+3. Produce a concise design matrix before coding:
+   - required catalog fact
+   - existing owner/type
+   - reuse vs new representation
+   - identity-bearing?
+   - catalog-visible?
+   - physical?
+4. Select the smallest model consistent with the manifest.
+5. Implement only WP06-owned logical metadata/catalog types or contract refinements.
+6. Preserve public API compatibility where possible.
+7. If WP04's seam is insufficient and the manifest permits refinement, make only the minimum change necessary and explain why.
+8. Do not implement any Infrastructure behavior.
+9. Do not add permanent tests unless the manifest explicitly assigns them to WP06.
+10. Temporary offline probes are allowed only when necessary to prove invariants; remove them completely before final accounting.
+
+## 15. Required semantic scenarios to validate
+
+Even if permanent tests are deferred, reason through and, where useful, prove temporarily:
+
+1. Non-empty catalog entry from a valid WP05 candidate.
+2. Empty candidate produces a valid catalog representation with count zero and absent actual first/last instant.
+3. Snapshot Identity equals Dataset Version.
+4. Exact target including case/whitespace remains unchanged.
+5. Requested boundaries remain exact.
+6. Coverage count and actual bounds remain consistent.
+7. Original observation offset/decimal semantics are not rewritten by catalog modeling.
+8. Equivalent re-materialization can map to equivalent catalog metadata.
+9. Same Research Dataset Identity may coexist conceptually with a distinguishable Snapshot Identity after relevant source-state change.
+10. Contradictory metadata cannot silently claim the same Snapshot Identity.
+11. No wall-clock/random/path/database value is required to construct semantic catalog metadata.
+12. No mutable "latest" semantics are introduced.
+
+## 16. Failure and outcome vocabulary
+
+Do not casually create a large new public failure taxonomy.
+
+First inspect WP04's existing `DatasetMaterializationResult`, `DatasetMaterializationFailure`, `IDatasetSnapshotStore`, and `IDatasetCatalog` contracts.
+
+For catalog semantics, introduce/refine outcome vocabulary only if the manifest and existing seam require it.
+
+Any catalog registration model must be able to distinguish conceptually:
+
+- newly registered
+- equivalent/idempotent existing entry
+- integrity conflict
+
+Any lookup model must distinguish conceptually:
+
+- found
+- not found
+- invalid/integrity failure as appropriate
+
+But **WP06 defines logical representation; WP09 implements persistence behavior**.
+
+Do not reuse Release 1.1 persistence outcomes blindly if dataset-specific semantics warrant bounded dataset vocabulary. Conversely, do not proliferate types when existing WP04 types already represent the required states.
+
+## 17. Immutability
+
+Catalog entries represent immutable snapshot evidence.
+
+Prohibit semantics equivalent to:
+
+- update snapshot metadata in place
+- change version of an existing snapshot
+- reassign Snapshot Identity
+- replace provenance/lineage under the same identity
+- delete-and-reinsert to hide conflict
+- mutable "current snapshot" state
+
+WP06 does not need to design retention/deletion policy.
+
+## 18. Security and privacy
+
+No secrets, API keys, connection strings, credentials, tokens, personal paths, machine identifiers, or database contents may enter catalog metadata.
+
+Do not log sensitive values.
+
+Run the repository's canonical security verification unchanged.
+
+## 19. Architecture protection
+
+Final production graph must remain:
+
+- Domain → none
+- Application → Domain
+- Infrastructure → Application
+- Worker → Application, Infrastructure
+
+Expected WP06:
+
+- Domain production delta: 0
+- Infrastructure production delta: 0
+- Worker production delta: 0
+- package delta: 0
+- project-reference delta: 0
+
+If any of those become non-zero, treat it as a scope alarm and justify against explicit authority before proceeding.
+
+## 20. Validation gates
+
+After implementation, run at minimum:
+
+- restore
+- format verification
+- build
+- Domain.Tests
+- Application.Tests
+- Infrastructure.Tests
+- Architecture.Tests
+- `eng/verify.ps1`
+- `git diff --check`
+- `git diff --cached --check`
+
+For untracked authorized WP06 files, perform direct whitespace validation because ordinary `git diff --check` does not inspect untracked files.
+
+Also verify:
+
+- build warnings = 0
+- build errors = 0
+- skipped tests = 0 unless pre-existing and explicitly explained
+- provider/network calls = 0
+- temporary database residue = 0
+- temporary probe residue = 0
+- SQLite/SQL/filesystem leakage into Domain/Application = 0
+- Release 1.3 implementation = 0
+
+## 21. Git and GitHub protection
+
+WP06 may mutate only the authorized issue lifecycle and repository files allowed by the manifest.
+
+Do NOT:
+
+- stage files
+- commit
+- push
+- create/switch branches for integration
+- open a PR
+- merge
+- tag
+- release
+- rewrite history
+
+Do not modify #127 or later issues.
+
+After all acceptance gates pass:
+
+1. post concise evidence to #126;
+2. close #126;
+3. set its Project status to Done;
+4. leave #127 Open / Backlog.
+
+## 22. Required final report
+
+Produce a structured execution report containing at least:
+
+1. Executive Summary
+2. Authorities Reviewed
+3. Repository Context
+4. Initial Git State
+5. Working-Tree Classification
+6. Predecessor/Lifecycle Gates
+7. Issue Lifecycle
+8. Initial Baseline
+9. WP02 Reconciliation
+10. WP03 Reconciliation
+11. WP04 Contract Reconciliation
+12. WP05 Candidate Reconciliation
+13. Catalog Model Design
+14. Metadata Taxonomy
+15. Catalog Entry Invariants
+16. Registration Semantics
+17. Exact Lookup Semantics
+18. Logical Dataset / Version Relationship
+19. Empty Snapshot Semantics
+20. Coverage Semantics
+21. Provenance/Lineage Reuse
+22. Identity Consistency
+23. Operational-Metadata Exclusions
+24. Application Ownership
+25. Exact Files Added/Modified
+26. Domain Delta
+27. Infrastructure Delta
+28. Worker Delta
+29. Package/Reference Delta
+30. Permanent Test Delta
+31. Temporary Probe Evidence
+32. WP07/WP08/WP09 Protection
+33. Release 1.3 Protection
+34. Security/Offline Evidence
+35. Whitespace/Diff Evidence
+36. Restore/Build Evidence
+37. Permanent Test Evidence
+38. Canonical Verification
+39. Architecture Validation
+40. Semantic Acceptance Matrix
+41. Mutation Accounting
+42. Git/GitHub Protection
+43. Planning Protection
+44. Findings/Blockers
+45. Final Repository/GitHub State
+46. WP07 Handoff
+47. Final Decision
+48. Next Authorized Work Package
+
+## 23. Acceptance criteria
+
+WP06 is complete only if all are true:
+
+- #126 predecessor and lifecycle gates pass.
+- WP02/WP03 semantics remain unchanged.
+- WP04 contracts are reused/refined minimally.
+- WP05 deterministic candidate is treated as source semantic input.
+- logical catalog metadata is explicitly defined.
+- identity-bearing facts are distinguished from descriptive metadata.
+- operational/physical metadata does not contaminate semantic identity.
+- exact immutable Snapshot Identity / Dataset Version is central to catalog representation.
+- Research Dataset Identity and Snapshot Identity remain distinct.
+- empty snapshot metadata is valid and deterministic.
+- coverage/provenance/lineage are reused without competing models.
+- equivalent re-materialization remains representable as equivalent evidence.
+- contradictory same-identity metadata is an integrity conflict, never overwrite.
+- no mutable "latest" semantics are introduced.
+- Domain/Application remain SQLite/provider/filesystem independent.
+- no physical storage/catalog persistence is implemented.
+- no WP07+ work is started.
+- production graph remains valid.
+- package/reference delta is zero unless explicit authority proves otherwise.
+- all validation gates pass.
+- issue #126 ends Closed / Done.
+- issue #127 remains Open / Backlog.
+- working tree remains uncommitted and unstaged.
+
+## 24. Terminal marker
+
+On success, end exactly with:
+
+RELEASE 1.2 WP06 COMPLETE
+
+DATASET METADATA & CATALOG MODEL:
+WP02 dataset semantics preserved: PASS
+WP03 identity/version/provenance semantics preserved: PASS
+WP04 dataset contracts reconciled: PASS
+WP05 materialization candidate reconciled: PASS
+Logical catalog metadata model: PASS
+Identity-bearing vs descriptive metadata separation: PASS
+Research Dataset / Snapshot identity separation: PASS
+Dataset Version consistency: PASS
+Exact target/boundary metadata: PASS
+Coverage metadata: PASS
+Successful empty snapshot metadata: PASS
+Provenance reuse: PASS
+Lineage reuse: PASS
+Equivalent re-materialization semantics: PASS
+Integrity-conflict semantics: PASS
+Immutable catalog evidence: PASS
+Mutable latest semantics introduced: NO
+Operational metadata in semantic identity: 0
+Physical-storage metadata leakage: 0
+SQLite/SQL/filesystem leakage: 0
+Provider/HTTP leakage: 0
+Domain delta: 0
+Infrastructure delta: 0
+Worker delta: 0
+Permanent test delta: <report>
+Package/reference delta: 0/0
+WP07 started: NO
+Release 1.3 implementation started: NO
+Issue #126: CLOSED / DONE
+
+NEXT AUTHORIZED WORK PACKAGE:
+WP07 — Dataset Physical Storage Model
+GitHub issue #127
+
+If blocked, do not emit the success marker. Emit `RELEASE 1.2 WP06 BLOCKED` and state the smallest corrective authority required.

--- a/docs/roadmap/release-1.2/prompts/07-dataset-physical-storage-model-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/07-dataset-physical-storage-model-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read `07-dataset-physical-storage-model-codex-prompt.md` completely as the sole WP07 authority and reconcile accepted WP01-WP06 state before mutation.
+Implement only the Infrastructure-owned SQLite schema-v2 physical dataset/catalog model and deterministic v1-to-v2 evolution while preserving Release 1.1 history and semantics.
+Do not implement WP08+ persistence/retrieval, add packages, tests, DI, Worker behavior, Release 1.3, or alter contracts; run all required schema, regression, architecture, security, whitespace, build, and lifecycle gates.
+Do not stage, commit, push, branch, or open a PR; leave WP08/#128 Open/Backlog and finish only with the full WP07 report and its prescribed terminal.
+If every gate passes close #127/mark Done; otherwise stop with the precise blocker and smallest corrective authority required.

--- a/docs/roadmap/release-1.2/prompts/07-dataset-physical-storage-model-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/07-dataset-physical-storage-model-codex-prompt.md
@@ -1,0 +1,988 @@
+# Release 1.2 WP07 --- Dataset Physical Storage Model --- Codex Execution Authority
+
+## 1. Authority
+
+You are executing **Release 1.2 WP07 --- Dataset Physical Storage
+Model** for:
+
+-   Repository: `samuel-santos-engineer/AIQuantTradingResearch`
+-   Release: `Phase 3 - Release 1.2: Research Dataset Foundation`
+-   GitHub issue: `#127`
+-   Required predecessors: WP05 `#125` and WP06 `#126`, both must be
+    Closed / Done.
+-   Next package: WP08 --- Dataset Snapshot Persistence, issue `#128`.
+
+This file is the authoritative WP07 execution instruction. Read it
+completely before mutation.
+
+Also read and reconcile, at minimum:
+
+-   `RELEASE_1.2_EXECUTION_PLAN.md`
+-   `RELEASE_1.2_FILE_MANIFEST.md`
+-   accepted Release 1.2 WP01--WP06 prompt/result artifacts
+-   `docs/architecture/data/RESEARCH_DATASET_DEFINITION.md`
+-   `docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md`
+-   current Application dataset contracts, materialization
+    implementation, and catalog metadata model
+-   existing Release 1.1 SQLite schema/bootstrap/connection/store
+    implementation
+-   current Domain/Application/Infrastructure/Worker source and tests
+-   existing data-storage architecture documentation
+-   GitHub issue #127, its dependencies, milestone #53, and Project #2
+    state
+
+Repository truth wins over assumptions. If authority, repository state,
+manifest, accepted predecessor semantics, or the existing Release 1.1
+SQLite boundary conflict materially, stop and report the smallest
+corrective authority required.
+
+## 2. Objective
+
+Define the **minimum Infrastructure-owned physical storage model**
+capable of durably representing accepted Release 1.2 dataset snapshots
+and their exact catalog metadata while preserving Release 1.1
+persistence behavior.
+
+WP07 must settle the physical representation sufficiently that WP08 and
+WP09 can implement persistence and lookup without inventing schema
+semantics.
+
+WP07 must answer:
+
+-   Which SQLite tables/records represent an immutable dataset snapshot?
+-   Which table/record represents its catalog-visible descriptor?
+-   How are Snapshot Identity / Dataset Version and the other WP03
+    identities stored losslessly?
+-   How are Dataset Definition, coverage, provenance, lineage, source
+    authority, and empty snapshots represented?
+-   How are selected `PriceObservation` values associated with a
+    snapshot while preserving exact timestamp/offset/decimal fidelity
+    and deterministic ordering?
+-   Which keys, uniqueness constraints, checks, and indexes enforce the
+    accepted immutable identity model?
+-   How does schema evolution coexist with Release 1.1 schema version 1
+    and existing `historical_observations` data?
+-   What remains explicitly deferred to WP08 and WP09?
+
+WP07 is a **physical-model and schema-evolution package**, not a
+persistence-behavior package.
+
+## 3. Required starting-state gates
+
+Before implementation:
+
+1.  Confirm repository identity and GitHub authentication without
+    exposing credentials.
+2.  Confirm branch is `main`.
+3.  Fetch/reconcile `origin/main`; report HEAD, origin SHA,
+    ahead/behind, staged, tracked, and untracked state.
+4.  Classify every existing working-tree path. Preserve accepted
+    cumulative Release 1.2 artifacts byte-for-byte unless WP07
+    explicitly owns them.
+5.  Confirm:
+    -   Release 1.1 is closed.
+    -   milestone #53 is authoritative and Open.
+    -   #125 and #126 are Closed / Done.
+    -   #127 is Open / Backlog.
+    -   #128 remains Open / Backlog.
+    -   #127 depends exactly on #125 and #126.
+    -   no Release 1.3 implementation is active.
+6.  Confirm accepted WP05 materialization artifacts and WP06 catalog
+    model exist and match their handoffs.
+7.  Reconcile the existing Release 1.1 SQLite boundary, including schema
+    versioning, bootstrap, connection factory, mapper, store, and
+    `historical_observations`.
+8.  Run the unchanged baseline:
+    -   restore
+    -   format verification
+    -   build
+    -   all permanent tests
+    -   architecture tests
+    -   `eng/verify.ps1`
+    -   `git diff --check`
+    -   `git diff --cached --check`
+9.  Do not move #127 to In Progress until every starting gate passes.
+
+If a starting gate fails, do not mutate production/test/documentation
+code and do not progress #127.
+
+## 4. Manifest authority and mutation boundary
+
+`RELEASE_1.2_FILE_MANIFEST.md` authorizes WP07 changes only under:
+
+`src/AIQuantTradingResearch.Infrastructure/**`
+
+Allowed WP07 concerns include:
+
+-   snapshot physical records
+-   catalog physical records
+-   mappings
+-   schema representation
+-   minimal schema-version evolution
+-   SQLite constraints/indexes required by approved exact lookup
+    semantics
+
+Existing Release 1.1 SQLite bootstrap/schema files may change **only**
+to add Release 1.2 schema while preserving `historical_observations`
+behavior and existing data.
+
+Default production package delta is **0**.
+
+Do not add a package merely for convenience. If a package appears
+genuinely required, stop and report the exact evidence and smallest
+separate authority required rather than adding it.
+
+## 5. Accepted semantic authorities that MUST NOT be redesigned
+
+### WP02 --- Dataset definition/reproducibility
+
+Preserve:
+
+-   immutable deterministic research datasets
+-   exact single target
+-   explicit `[from, to)` boundaries
+-   deterministic ascending semantic-instant ordering
+-   successful empty materialization
+-   original `DateTimeOffset` offset representation
+-   exact decimal fidelity
+-   immutable snapshot evidence
+-   deterministic reproducibility
+
+### WP03 --- Identity/version/provenance
+
+Preserve exactly:
+
+-   Dataset Definition Identity
+-   Research Dataset Identity
+-   Source State Identity
+-   Dataset Snapshot Identity
+-   Dataset Version = immutable Snapshot Identity
+-   identity scheme `aiq-dataset-identity-v1`
+-   SHA-256 represented as exactly 64 lowercase hexadecimal characters
+-   canonical semantic representation already implemented/accepted
+-   provenance and narrow lineage semantics
+-   identity reassignment prohibited
+-   contradictory content under the same fingerprint is integrity
+    conflict
+-   operational metadata excluded from semantic identity
+
+WP07 stores accepted identity values. It does **not** recompute,
+reinterpret, shorten, re-hash, or redesign them.
+
+### WP04 --- Application contracts
+
+Application contracts remain storage-independent.
+
+No SQLite type, SQL term, row identifier, storage path, ORM annotation,
+or physical schema concept may leak into Domain or Application.
+
+### WP05 --- Materialization
+
+`DatasetSnapshotCandidate` is the accepted semantic input for later
+persistence.
+
+WP07 must make every required candidate fact physically representable
+without changing materialization behavior.
+
+### WP06 --- Catalog metadata
+
+`DatasetCatalogEntry` is the accepted logical catalog representation.
+
+Preserve:
+
+-   immutable exact snapshot catalog evidence
+-   identity-bearing versus deterministic descriptive metadata
+    separation
+-   Research Dataset Identity distinct from Snapshot Identity / Dataset
+    Version
+-   exact target/boundaries
+-   coverage
+-   provenance
+-   lineage
+-   successful empty snapshot metadata
+-   `NewlyRegistered`, `EquivalentExisting`, `IntegrityConflict`
+    semantics
+-   exact lookup by Snapshot Identity
+-   no mutable `latest`
+-   no operational metadata
+-   no physical metadata in Application contracts
+
+## 6. Existing Release 1.1 SQLite boundary
+
+SQLite is already selected and integrated. WP07 does not reselect the
+storage engine.
+
+Inspect repository truth before designing.
+
+Preserve at minimum:
+
+-   existing `historical_observations` table semantics and data
+-   existing Release 1.1 identity `(target, instant_utc_ticks)`
+-   exact target behavior
+-   timestamp/offset/decimal fidelity
+-   existing connection factory ownership/lifetime
+-   existing schema bootstrap behavior
+-   clean-checkout database bootstrap
+-   existing persistence/retrieval behavior
+-   existing permanent tests
+
+Do not destructively reset an existing Release 1.1 database.
+
+Do not replace the current schema strategy with a generalized migration
+framework.
+
+## 7. Core physical-model principle
+
+The physical model must separate:
+
+1.  **Dataset snapshot descriptor/catalog evidence** --- one immutable
+    accepted snapshot and its semantic metadata.
+2.  **Snapshot observation membership/content** --- zero or more
+    selected observations belonging to that exact snapshot.
+3.  **Release 1.1 source observations** --- existing accepted
+    `historical_observations`, which remain independently authoritative
+    source history.
+
+Do not collapse these into one mutable table.
+
+Do not make dataset snapshot existence depend on at least one
+observation: **empty snapshots are valid and must be physically
+representable**.
+
+## 8. Required physical facts
+
+The model must be capable of losslessly representing, at minimum:
+
+### Snapshot/catalog facts
+
+-   Dataset Snapshot Identity
+-   Dataset Version
+-   Dataset Definition Identity
+-   Research Dataset Identity
+-   Source State Identity
+-   identity scheme
+-   exact target
+-   requested `from` instant
+-   requested `to` instant
+-   selected observation count
+-   first selected semantic instant when non-empty
+-   last selected semantic instant when non-empty
+-   source authority
+-   provenance facts required by accepted Application contracts
+-   lineage facts required by accepted Application contracts
+
+### Definition facts
+
+The physical representation must preserve the accepted definition
+semantics sufficiently to reconstruct the accepted Application
+representation, including:
+
+-   exact target
+-   exact `[from, to)` semantic boundaries
+-   accepted ordering semantics
+-   semantic-model/identity-scheme facts that are part of the existing
+    contracts
+
+Do not invent provider or operational fields.
+
+### Snapshot observation facts
+
+For every selected observation:
+
+-   snapshot identity association
+-   deterministic ordinal or another explicit physical ordering
+    mechanism
+-   semantic instant identity
+-   original offset representation
+-   exact decimal price representation
+
+The model must permit exact reconstruction of the ordered
+`PriceObservation` sequence.
+
+## 9. Identity representation
+
+All accepted WP03 digest identities are fixed semantic values.
+
+Requirements:
+
+-   store them losslessly
+-   preserve lowercase 64-hex validation semantics
+-   do not truncate
+-   do not reinterpret as database-generated IDs
+-   do not replace them with integer surrogate identities
+-   do not use wall-clock timestamps as versions
+-   do not create mutable version sequences
+
+A physical surrogate may be introduced only if repository evidence
+proves it necessary and it cannot become semantic identity. Prefer the
+accepted immutable digest identity directly when practical.
+
+Dataset Version and Snapshot Identity are semantically one-to-one. Avoid
+storing contradictory independent values unless the physical model has a
+constraint that makes disagreement impossible. Prefer a representation
+that cannot drift.
+
+## 10. Timestamp and offset representation
+
+Follow the proven Release 1.1 fidelity model unless concrete evidence
+requires another compatible representation.
+
+The model must preserve:
+
+-   absolute semantic instant identity/order
+-   original `DateTimeOffset` offset representation
+-   deterministic reconstruction
+-   minute-granular offset validity
+-   no local-time or culture dependence
+
+For requested boundaries, preserve their semantic instant and any
+Application-contract representation needed for exact reconstruction.
+
+For observation values, reuse the accepted Release 1.1
+representation/mapping strategy where appropriate rather than inventing
+a second incompatible timestamp model.
+
+## 11. Decimal representation
+
+Do not use SQLite `REAL` for `decimal` values.
+
+Preserve exact .NET decimal semantics without floating-point
+intermediates, rounding, truncation, or culture dependence.
+
+Prefer reuse of the accepted Release 1.1 invariant decimal
+representation/mapping strategy.
+
+The physical model must support high-precision decimal values and
+`decimal.MaxValue` to the extent already supported by accepted Release
+1.1 semantics.
+
+## 12. Target representation
+
+Target remains an opaque exact value.
+
+Requirements:
+
+-   no trimming
+-   no case folding
+-   no parsing
+-   no normalization
+-   no locale-sensitive comparison
+-   exact binary comparison semantics compatible with Release 1.1
+
+If target is duplicated between descriptor and observation-related
+physical structures, define how consistency is guaranteed or avoid
+unnecessary duplication.
+
+## 13. Empty snapshot representation
+
+A valid successful empty snapshot must be physically representable
+without synthetic observations.
+
+Required semantics:
+
+-   snapshot/catalog row exists
+-   selected count = 0
+-   first actual observation instant absent
+-   last actual observation instant absent
+-   zero snapshot-observation rows
+-   definition/source-state/snapshot identities remain present and
+    deterministic
+-   provenance and lineage remain reconstructable
+
+Do not use sentinel timestamps, sentinel prices, fake rows, or null
+identity values to represent emptiness.
+
+## 14. Snapshot observation ordering and identity
+
+The physical model must make deterministic ascending reconstruction
+explicit.
+
+Choose the smallest robust strategy consistent with accepted semantics.
+
+Possible mechanisms include:
+
+-   explicit ordinal constrained to the snapshot; or
+-   semantic-instant key/order if it completely captures accepted
+    sequence semantics.
+
+Whatever strategy is selected, prove:
+
+-   one snapshot cannot contain duplicate semantic instants
+-   retrieval can deterministically reconstruct ascending
+    semantic-instant order
+-   ordering does not depend on SQLite natural row order
+-   cross-snapshot membership cannot leak
+-   observation content cannot silently mutate under the same snapshot
+    identity
+
+Do not implement WP08 insertion/query behavior.
+
+## 15. Immutability and uniqueness constraints
+
+Design physical constraints that support later immutable persistence.
+
+At minimum evaluate and explicitly decide:
+
+-   primary key for snapshot/catalog evidence
+-   uniqueness of Dataset Snapshot Identity
+-   relationship between Snapshot Identity and Dataset Version
+-   uniqueness of observation membership within a snapshot
+-   duplicate semantic-instant prevention within a snapshot
+-   count/empty coverage consistency that can reasonably be enforced
+    physically
+-   foreign-key relationship, if appropriate, between snapshot content
+    and descriptor
+-   delete/update policy compatibility with immutable evidence
+
+Do not add triggers or complex database logic unless simpler schema
+constraints cannot represent the accepted invariants.
+
+WP07 defines compatibility with immutability. WP08 implements write
+behavior.
+
+## 16. Catalog exact-lookup support
+
+WP09 will implement exact catalog lookup by Dataset Snapshot Identity.
+
+WP07 must ensure the physical model supports this efficiently and
+deterministically.
+
+Add only indexes required by accepted lookup semantics.
+
+Do not add:
+
+-   full-text indexes
+-   semantic/vector indexes
+-   generalized search indexes
+-   ranking
+-   mutable latest-version indexes
+-   speculative target/time-range discovery indexes unless explicitly
+    required by accepted WP06 contracts
+
+If the primary key already supplies exact Snapshot Identity lookup, do
+not add a redundant index.
+
+## 17. Provenance and lineage physical representation
+
+Prefer a minimal representation that can reconstruct the accepted
+Application `DatasetProvenance` and `DatasetLineage`.
+
+Do not create a generic provenance graph, DAG, event log, or pipeline
+lineage system.
+
+The accepted lineage is narrow:
+
+-   one snapshot
+-   one definition
+-   one relevant source state
+-   zero or more accepted selected observations
+
+If some provenance/lineage facts are derivable exactly from other stored
+immutable fields, avoid gratuitous duplication. If stored redundantly,
+define consistency constraints or mapper validation.
+
+## 18. Physical records and mappings
+
+Infrastructure-owned records/mappers may be introduced as authorized by
+the manifest.
+
+Requirements:
+
+-   internal unless repository conventions strongly require otherwise
+-   no Infrastructure record leakage into Application/Domain public APIs
+-   mapping must be lossless
+-   mapping must not recompute semantic identities
+-   mapping must not normalize target/timestamps/decimals
+-   mapping must reject physically malformed values rather than silently
+    repair them
+-   physical records should be purpose-specific rather than a
+    generalized persistence abstraction
+
+WP07 may use temporary focused probes to prove round-trip fidelity and
+schema invariants. Remove all temporary probes before final accounting.
+
+Permanent tests remain WP14-owned unless the manifest explicitly says
+otherwise.
+
+## 19. Schema evolution strategy
+
+Release 1.1 currently owns an existing SQLite schema/version bootstrap.
+Reconcile its exact implementation before mutation.
+
+WP07 must implement the **smallest deterministic schema evolution**
+needed to add Release 1.2 physical structures.
+
+Requirements:
+
+-   preserve `historical_observations`
+-   preserve existing Release 1.1 data
+-   preserve clean empty-database bootstrap
+-   support an existing accepted Release 1.1 schema upgrading to the
+    Release 1.2 schema
+-   repeated bootstrap at the new version is idempotent
+-   reject unsupported future/unknown versions
+-   reject incompatible/corrupt expected schema rather than destructive
+    reset
+-   perform schema transition atomically where the current bootstrap
+    design permits
+-   no generalized migration framework
+-   no downgrade logic
+-   no destructive drop/recreate of Release 1.1 data
+
+Choose the next schema version according to existing repository
+convention. Do not invent an independent dataset-only version marker if
+the repository already has one authoritative SQLite schema marker.
+
+## 20. Bootstrap scenarios that MUST be designed/proved
+
+At minimum validate, preferably with a temporary offline probe if
+permanent tests are deferred:
+
+1.  Brand-new database bootstraps with Release 1.1 + Release 1.2 schema.
+2.  Existing valid Release 1.1 schema upgrades without losing
+    `historical_observations`.
+3.  Existing Release 1.1 observation rows survive
+    byte/semantic-equivalent retrieval after upgrade.
+4.  Repeated bootstrap at the new schema version is idempotent.
+5.  Unsupported schema version is rejected.
+6.  Incompatible prior schema is not destructively replaced.
+7.  Release 1.2 tables/constraints match the selected physical model.
+8.  Empty snapshot representation is structurally possible.
+9.  Non-empty snapshot records can round-trip through physical mappers
+    without SQLite write orchestration.
+10. Exact target, identity, timestamp/offset, decimal, coverage,
+    provenance, and lineage representation is lossless.
+11. Temporary database residue is zero after validation.
+
+Do not implement WP08 snapshot persistence to prove these scenarios.
+Schema-level inserts used solely inside a disposable probe are allowed
+only if necessary and must not become production behavior.
+
+## 21. Failure-boundary protection
+
+WP11 owns final Dataset validation/failure mapping.
+
+WP07 may throw/reject invalid physical representation during
+mapping/bootstrap according to existing Infrastructure conventions, but
+must not create the final public failure classifier.
+
+Do not redesign Application failure vocabulary.
+
+Do not add retry/resilience policy.
+
+Do not catch broad `Exception` merely to hide schema/mapping defects.
+
+## 22. WP08 protection
+
+WP08 owns **Dataset Snapshot Persistence**.
+
+WP07 MUST NOT implement:
+
+-   `IDatasetSnapshotStore` concrete behavior
+-   snapshot insert orchestration
+-   idempotent persistence classification
+-   conflict lookup/classification
+-   atomic snapshot write transactions as runtime store behavior
+-   snapshot retrieval behavior
+-   overwrite prevention logic beyond physical constraints/model
+    compatibility
+-   persistence result mapping
+
+The schema may contain constraints required for those later behaviors,
+but WP08 must remain clearly unstarted.
+
+Issue #128 must remain Open / Backlog.
+
+## 23. WP09 protection
+
+WP09 owns **Dataset Catalog Persistence & Lookup**.
+
+WP07 MUST NOT implement:
+
+-   `IDatasetCatalog` concrete persistence
+-   catalog registration runtime behavior
+-   exact lookup runtime queries
+-   found/not-found behavior
+-   catalog result/failure mapping
+-   generalized search/filtering
+
+The schema may support exact Snapshot Identity lookup, but WP09 must
+remain clearly unstarted.
+
+## 24. WP10--WP12 and Release 1.3 protection
+
+Do not implement:
+
+-   materialization-to-persistence integration
+-   dataset validation/failure mapping
+-   DI registration
+-   configuration binding
+-   Worker execution
+-   scheduling
+-   automatic refresh
+-   streaming
+-   pipelines/DAGs
+-   monitoring
+-   resilience orchestration
+-   Release 1.3 behavior
+
+## 25. Architecture protection
+
+Final production graph must remain:
+
+-   Domain → none
+-   Application → Domain
+-   Infrastructure → Application
+-   Worker → Application, Infrastructure
+
+Expected WP07:
+
+-   Domain production delta: 0
+-   Application production delta: 0
+-   Worker production delta: 0
+-   Infrastructure production delta: authorized
+-   package delta: 0
+-   project-reference delta: 0
+
+SQLite/SQL/filesystem physical concepts must remain confined to
+Infrastructure.
+
+If Domain, Application, Worker, package, or project-reference delta
+becomes non-zero, treat it as a scope alarm and stop unless explicit
+authority proves it necessary.
+
+## 26. Security and privacy
+
+No credentials, API keys, tokens, connection secrets, personal machine
+paths, or sensitive database contents may be introduced.
+
+Do not log secrets or full connection strings.
+
+Use only synthetic data for probes.
+
+Provider/network calls during WP07 validation must be zero.
+
+Run the repository's canonical security verification unchanged.
+
+## 27. Implementation approach
+
+After all starting gates pass:
+
+1.  Move issue #127 from Backlog to In Progress.
+2.  Inspect the exact Release 1.1 SQLite schema/bootstrap
+    implementation.
+3.  Inspect WP05 candidate and WP06 catalog entry contracts.
+4.  Produce a concise pre-code physical-model matrix:
+    -   semantic fact
+    -   Application owner/type
+    -   physical representation
+    -   key/constraint
+    -   mapper strategy
+    -   empty-state behavior
+    -   later WP consumer
+5.  Produce a schema-evolution matrix:
+    -   current schema version/state
+    -   target schema version/state
+    -   transition
+    -   preserved Release 1.1 objects/data
+    -   incompatibility behavior
+6.  Select the smallest schema satisfying WP05/WP06 semantics.
+7.  Implement only manifest-authorized Infrastructure
+    records/mappers/schema evolution.
+8.  Prefer existing Release 1.1 mapping patterns for
+    timestamp/offset/decimal fidelity.
+9.  Add only indexes required for exact approved lookup semantics.
+10. Do not implement snapshot/catalog runtime persistence.
+11. Use temporary offline probes only when needed; remove them
+    completely.
+12. Re-run every final validation gate.
+13. Only after all gates pass, post concise evidence to #127 and close
+    it Done.
+
+## 28. Required physical-model decision matrix
+
+The execution report must explicitly state the chosen representation and
+rationale for:
+
+-   schema version
+-   snapshot/catalog table(s)
+-   snapshot observation table
+-   primary keys
+-   foreign keys
+-   identity storage
+-   Dataset Version representation
+-   target collation
+-   requested boundary representation
+-   actual coverage-bound representation
+-   selected count representation
+-   source authority representation
+-   provenance representation
+-   lineage representation
+-   observation ordinal/order strategy
+-   semantic instant representation
+-   original offset representation
+-   decimal representation
+-   empty snapshot representation
+-   uniqueness constraints
+-   exact lookup index strategy
+-   update/delete/overwrite compatibility
+-   mapper ownership
+-   bootstrap/evolution strategy
+
+Do not leave any of these to WP08/WP09 if they are required to interpret
+the schema.
+
+## 29. Required validation gates
+
+After implementation, run at minimum:
+
+-   restore
+-   format verification
+-   build
+-   Domain.Tests
+-   Application.Tests
+-   Infrastructure.Tests
+-   Architecture.Tests
+-   `eng/verify.ps1`
+-   `git diff --check`
+-   `git diff --cached --check`
+
+For untracked authorized WP07 files, perform direct whitespace
+validation because ordinary `git diff --check` does not inspect
+untracked files.
+
+Also verify:
+
+-   build warnings = 0
+-   build errors = 0
+-   skipped tests = 0 unless pre-existing and explicitly explained
+-   package vulnerability/security verification passes
+-   provider/network calls = 0
+-   temporary probe residue = 0
+-   temporary database residue = 0
+-   Domain/Application SQLite leakage = 0
+-   Release 1.1 persistence regression = PASS
+-   Release 1.3 implementation = 0
+
+## 30. Required focused physical validation
+
+Even if permanent tests are deferred to WP14, WP07 must obtain
+sufficient evidence for the selected model.
+
+At minimum prove:
+
+-   physical round-trip of all four identities
+-   Dataset Version / Snapshot Identity consistency
+-   exact target including case/whitespace
+-   requested boundary fidelity
+-   successful empty snapshot representation
+-   non-empty coverage representation
+-   source authority fidelity
+-   provenance/lineage reconstruction
+-   timestamp semantic instant + original offset fidelity
+-   high-precision decimal fidelity
+-   deterministic observation ordering representation
+-   duplicate semantic instant cannot be represented as valid membership
+-   same Research Dataset Identity can coexist with distinct Snapshot
+    Identities
+-   contradictory same-Snapshot-Identity physical evidence cannot
+    silently overwrite
+-   exact Snapshot Identity lookup is structurally supported
+-   Release 1.1 `historical_observations` survives schema evolution
+-   repeated bootstrap is idempotent
+
+If proving any row-level property would require implementing WP08/WP09
+production behavior, use a disposable schema/mapping probe rather than
+crossing the work-package boundary.
+
+## 31. Git and GitHub protection
+
+WP07 may mutate only:
+
+-   manifest-authorized Infrastructure files
+-   issue #127 lifecycle/evidence
+
+Do NOT:
+
+-   stage files
+-   commit
+-   push
+-   create/switch integration branches
+-   open a PR
+-   merge
+-   tag
+-   release
+-   rewrite history
+
+Do not modify #128 or later issues.
+
+After every acceptance gate passes:
+
+1.  post concise evidence to #127;
+2.  close #127;
+3.  set its Project status to Done;
+4.  leave #128 Open / Backlog.
+
+## 32. Required final report
+
+Produce a structured execution report containing at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Predecessor/Lifecycle Gates
+7.  Issue Lifecycle
+8.  Initial Baseline
+9.  WP02 Reconciliation
+10. WP03 Reconciliation
+11. WP04 Contract Reconciliation
+12. WP05 Candidate Reconciliation
+13. WP06 Catalog Reconciliation
+14. Release 1.1 SQLite Reconciliation
+15. Physical Model Design
+16. Schema Version Decision
+17. Snapshot/Catalog Table Design
+18. Snapshot Observation Table Design
+19. Identity/Version Representation
+20. Target Representation
+21. Boundary/Coverage Representation
+22. Provenance/Lineage Representation
+23. Observation Ordering Strategy
+24. Timestamp/Offset Representation
+25. Decimal Representation
+26. Empty Snapshot Representation
+27. Keys/Constraints/Indexes
+28. Immutability Compatibility
+29. Schema Evolution / Bootstrap Strategy
+30. Exact Files Added/Modified
+31. Domain Delta
+32. Application Delta
+33. Infrastructure Delta
+34. Worker Delta
+35. Package/Reference Delta
+36. Permanent Test Delta
+37. Temporary Probe Evidence
+38. WP08 Protection
+39. WP09 Protection
+40. WP10--WP12 / Release 1.3 Protection
+41. Security/Offline Evidence
+42. Whitespace/Diff Evidence
+43. Restore/Build Evidence
+44. Permanent Test Evidence
+45. Canonical Verification
+46. Architecture Validation
+47. Release 1.1 Persistence Regression
+48. Physical Validation Matrix
+49. Mutation Accounting
+50. Git/GitHub Protection
+51. Planning Protection
+52. Findings/Blockers
+53. Final Repository/GitHub State
+54. WP08 Handoff
+55. Final Decision
+56. Next Authorized Work Package
+
+## 33. Acceptance criteria
+
+WP07 is complete only if all are true:
+
+-   #125 and #126 predecessor gates pass.
+-   issue #127 lifecycle is correctly executed.
+-   accepted WP02--WP06 semantics remain unchanged.
+-   Release 1.1 `historical_observations` behavior/data are preserved.
+-   SQLite remains the storage engine.
+-   minimum Infrastructure-owned dataset/catalog physical model is
+    defined.
+-   every accepted identity/version value is losslessly representable.
+-   exact target is losslessly representable.
+-   requested boundaries and coverage are losslessly representable.
+-   provenance and narrow lineage are reconstructable without a
+    competing model.
+-   snapshot observations preserve semantic instant, original offset,
+    decimal value, and deterministic order.
+-   successful empty snapshots are physically representable without
+    sentinel observations.
+-   uniqueness/constraints support immutable snapshot semantics.
+-   exact Snapshot Identity lookup is structurally supported without
+    generalized search.
+-   schema evolution supports clean bootstrap and upgrade from accepted
+    Release 1.1 state.
+-   schema evolution is non-destructive and idempotent.
+-   unsupported/incompatible schema is rejected rather than reset.
+-   no generalized migration framework is introduced.
+-   no WP08 snapshot persistence behavior is implemented.
+-   no WP09 catalog persistence/lookup behavior is implemented.
+-   no WP10--WP12 or Release 1.3 behavior is implemented.
+-   Domain/Application remain free of SQLite/SQL/filesystem physical
+    concepts.
+-   Domain/Application/Worker production delta is zero.
+-   package/reference delta is `0/0`.
+-   permanent tests remain unchanged unless explicit manifest authority
+    proves otherwise.
+-   all validation gates pass.
+-   temporary probe/database residue is zero.
+-   issue #127 ends Closed / Done.
+-   issue #128 remains Open / Backlog.
+-   working tree remains uncommitted and unstaged.
+
+## 34. WP08 handoff
+
+The final report must give WP08 an exact implementation handoff
+containing:
+
+-   target schema version
+-   exact table names
+-   exact column names/types/nullability
+-   primary/foreign/unique/check constraints
+-   exact identity representation
+-   exact Dataset Version representation
+-   target collation
+-   timestamp/offset representation
+-   decimal representation
+-   observation ordering/membership representation
+-   empty snapshot representation
+-   mapper/record types to reuse
+-   bootstrap guarantees
+-   indexes available
+-   explicit statement that WP08 must not redesign the physical model
+    unless a proven blocker requires new authority
+
+WP08 owns runtime snapshot persistence, transaction semantics,
+idempotency/conflict classification, and durable reconstruction.
+
+## 35. Terminal marker
+
+On success, end exactly with:
+
+RELEASE 1.2 WP07 COMPLETE
+
+DATASET PHYSICAL STORAGE MODEL: WP02 dataset semantics preserved: PASS
+WP03 identity/version/provenance semantics preserved: PASS WP04
+Application contracts preserved: PASS WP05 materialization candidate
+representable: PASS WP06 catalog metadata representable: PASS Release
+1.1 historical_observations preserved: PASS SQLite storage engine
+preserved: PASS Schema evolution: PASS Clean bootstrap: PASS Release 1.1
+→ Release 1.2 upgrade: PASS Snapshot/catalog physical model: PASS
+Snapshot observation physical model: PASS Four identity representations:
+PASS Dataset Version / Snapshot Identity consistency: PASS Exact target
+representation: PASS Requested boundary representation: PASS Coverage
+representation: PASS Provenance representation: PASS Lineage
+representation: PASS Successful empty snapshot representation: PASS
+Timestamp/offset fidelity: PASS Decimal fidelity: PASS Deterministic
+observation-order representation: PASS Immutable-history compatibility:
+PASS Exact Snapshot Identity lookup support: PASS Generalized migration
+framework introduced: NO Snapshot persistence implemented: NO Catalog
+persistence/lookup implemented: NO Domain SQLite/SQL leakage: 0
+Application SQLite/SQL leakage: 0 Domain delta: 0 Application delta: 0
+Worker delta: 0 Package/reference delta: 0/0 Permanent test delta:
+`<report>`{=html} Temporary SQLite residue: 0 WP08 started: NO Release
+1.3 implementation started: NO Issue #127: CLOSED / DONE
+
+NEXT AUTHORIZED WORK PACKAGE: WP08 --- Dataset Snapshot Persistence
+GitHub issue #128
+
+If blocked, do not emit the success marker. Emit
+`RELEASE 1.2 WP07 BLOCKED` and state the smallest corrective authority
+required.

--- a/docs/roadmap/release-1.2/prompts/07-dataset-physical-storage-model-resume-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/07-dataset-physical-storage-model-resume-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read this resume authority and the complete original `07-dataset-physical-storage-model-codex-prompt.md`; the original controls except for the explicit test-scope correction.
+Resume WP07 for #127 with only test-count-neutral alignment of schema-v1-to-v2 and unsupported-v2-to-v3 bootstrap expectations, preserving all accepted WP01-WP06 semantics.
+Complete only the authorized physical model and migration work; do not add/delete permanent tests, weaken Release 1.1 coverage, begin WP08+, or introduce Release 1.3 behavior.
+Do not stage, commit, push, branch, or open a PR; run every required governance, migration, fidelity, regression, architecture, security, cleanup, and lifecycle gate and leave #128 Open/Backlog.
+Close #127/mark Done only after every gate passes; otherwise report the exact blocker and required correction.

--- a/docs/roadmap/release-1.2/prompts/07-dataset-physical-storage-model-resume-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/07-dataset-physical-storage-model-resume-codex-prompt.md
@@ -1,0 +1,568 @@
+# Release 1.2 WP07 --- Dataset Physical Storage Model --- Corrective Resume Authority
+
+## 1. Authority
+
+You are resuming **Release 1.2 WP07 --- Dataset Physical Storage Model**
+for:
+
+-   Repository: `samuel-santos-engineer/AIQuantTradingResearch`
+-   Release: `Phase 3 - Release 1.2: Research Dataset Foundation`
+-   GitHub issue: `#127`
+-   Next work package: WP08 --- Dataset Snapshot Persistence, issue
+    `#128`
+
+This is a **narrow corrective/resumption authority** for the previously
+blocked WP07 execution.
+
+The original authority remains controlling:
+
+-   `07-dataset-physical-storage-model-codex-prompt.md`
+
+The accepted blocked execution report remains historical evidence:
+
+-   `RELEASE 1.2 WP07 BLOCKED`
+
+This resume authority changes **exactly one scope rule** from the
+original WP07 authority: it permits test-count-neutral alignment of the
+existing permanent SQLite bootstrap tests where they encode Release 1.1
+schema version 1 as permanently current and schema version 2 as
+permanently unsupported.
+
+All other original WP07 requirements, prohibitions, semantic
+authorities, validation gates, lifecycle rules, Git protections,
+WP08/WP09 protections, and terminal-report requirements remain in force.
+
+Read this file and the complete original WP07 authority before any
+mutation.
+
+## 2. Reason for corrective authority
+
+The first WP07 execution correctly stopped before mutation because it
+discovered a direct authority conflict:
+
+-   Release 1.1 SQLite currently uses `PRAGMA user_version = 1`.
+-   WP07 must evolve the repository-owned SQLite schema to the next
+    version in order to add Release 1.2 dataset physical structures.
+-   Therefore the target schema version is `2`.
+-   An existing permanent Infrastructure test asserts that the current
+    schema is exactly version `1`.
+-   Another existing permanent Infrastructure test uses version `2` as
+    the unsupported-future-version fixture.
+-   The original WP07 authority prohibited permanent-test changes.
+
+Those assertions were correct for Release 1.1 but necessarily become
+stale when the authoritative repository schema advances to version 2.
+
+This authority resolves only that contradiction.
+
+## 3. Explicit corrective authorization
+
+WP07 is now authorized to modify the **existing permanent Infrastructure
+SQLite bootstrap tests only where required to align their schema-version
+expectations with the accepted v1 → v2 evolution**.
+
+The permitted alignment is:
+
+1.  Change the existing current-schema assertion from:
+
+    -   `PRAGMA user_version = 1` to:
+    -   `PRAGMA user_version = 2`
+
+2.  Rename the affected existing test if its name explicitly states
+    `VersionOne`, `Version1`, or equivalent current-version wording, so
+    the name accurately reflects schema version 2.
+
+3.  Change the existing unsupported-future-version fixture from:
+
+    -   version `2` to:
+    -   version `3`
+
+4.  Update only directly coupled expected values/messages in those same
+    existing tests if the production bootstrap reports the current or
+    unsupported schema version and the assertion must change
+    mechanically from 1/2 to 2/3.
+
+No other permanent-test semantic change is authorized by this
+correction.
+
+## 4. Test-count-neutral requirement
+
+This correction MUST be test-count neutral.
+
+Required:
+
+-   tests added: `0`
+-   tests deleted: `0`
+-   existing test cases converted into new coverage areas: `0`
+-   Infrastructure permanent test count remains `79`
+-   total permanent test count remains `145`
+
+This is **maintenance alignment of existing bootstrap assertions**, not
+WP14 dataset-test implementation.
+
+Do not add permanent tests for:
+
+-   dataset schema
+-   snapshot mappings
+-   dataset persistence
+-   catalog persistence
+-   v1 → v2 migration
+-   empty dataset snapshots
+-   identity round trips
+-   dataset fidelity
+-   WP08/WP09 behavior
+
+Use temporary focused offline probes, removed before final accounting,
+for WP07-specific physical-model evidence not already covered by
+existing permanent tests.
+
+## 5. Existing Release 1.1 behavioral protection
+
+Changing the schema-version expectations does not authorize weakening
+Release 1.1 persistence regression coverage.
+
+The existing Infrastructure test suite must continue to prove all
+pre-existing Release 1.1 behavior it proved before WP07, including as
+applicable:
+
+-   `historical_observations` existence and accepted structure
+-   strict / without-rowid characteristics
+-   exact target behavior
+-   composite observation identity
+-   timestamp/offset fidelity
+-   decimal fidelity
+-   connection/bootstrap behavior
+-   repeated bootstrap behavior
+-   unsupported future-version rejection
+-   incompatible-schema rejection
+-   observation persistence/retrieval
+-   idempotency/conflict behavior
+-   failure mapping
+-   DI/configuration
+
+Do not delete, skip, relax, broadly rewrite, or disable Release 1.1
+assertions merely to make WP07 pass.
+
+After schema evolution, Release 1.1 behavior must remain valid under
+schema version 2.
+
+## 6. Starting-state reconciliation
+
+Resume from current repository truth rather than assuming the exact
+state captured by the blocked report.
+
+Before mutation:
+
+1.  Confirm repository identity.
+2.  Confirm branch `main`.
+3.  Fetch/reconcile `origin/main`.
+4.  Report HEAD, origin SHA, ahead/behind, staged, tracked, and
+    untracked state.
+5.  Classify all working-tree paths.
+6.  Confirm the cumulative accepted Release 1.2 WP01--WP06 artifacts
+    remain present.
+7.  Confirm the original WP07 authority and this resume authority are
+    present.
+8.  Confirm:
+    -   #125 Closed / Done
+    -   #126 Closed / Done
+    -   #127 Open / Backlog
+    -   #128 Open / Backlog
+    -   #127 dependency exactly #125 and #126
+    -   milestone #53 Open
+    -   no Release 1.3 implementation active
+9.  Confirm no partial WP07 production mutation exists from the blocked
+    run.
+10. Re-run the unchanged baseline:
+    -   restore
+    -   format verification
+    -   build
+    -   all permanent tests
+    -   architecture tests
+    -   `eng/verify.ps1`
+    -   `git diff --check`
+    -   `git diff --cached --check`
+
+If repository truth has materially changed or a new unrelated blocker
+exists, stop and report it.
+
+## 7. Lifecycle resumption
+
+Because the prior run performed zero GitHub lifecycle mutation, issue
+#127 should still be Open / Backlog.
+
+Only after the resumed starting-state and baseline gates pass:
+
+-   move #127 Backlog → In Progress;
+-   execute WP07 under the original authority plus this narrow
+    correction.
+
+Do not modify #128.
+
+## 8. Schema-version decision now authorized
+
+The accepted target is:
+
+-   Release 1.1 schema: version `1`
+-   Release 1.2 WP07 schema: version `2`
+-   first unsupported future-version fixture for the existing bootstrap
+    test: version `3`
+
+This does not predetermine the physical table design. GPT-5.6 Sol must
+still reason through and implement the smallest correct WP07 physical
+model under the original authority.
+
+Do not create an independent dataset schema-version mechanism if
+repository truth continues to use `PRAGMA user_version` as the
+authoritative SQLite schema marker.
+
+## 9. Required v1 → v2 evolution behavior
+
+The completed WP07 implementation must still satisfy the original
+authority's schema-evolution requirements.
+
+At minimum:
+
+-   a new empty database reaches schema version 2;
+-   the Release 1.1 `historical_observations` schema remains present;
+-   an existing valid version-1 database upgrades to version 2;
+-   accepted Release 1.1 observation rows survive the upgrade;
+-   Release 1.1 observation retrieval remains semantically equivalent
+    after upgrade;
+-   version-2 bootstrap is idempotent;
+-   version 3 is rejected as unsupported by the current implementation;
+-   incompatible expected schema is rejected rather than destructively
+    reset;
+-   no downgrade logic is added;
+-   no generalized migration framework is introduced;
+-   schema transition is atomic according to the existing bootstrap
+    strategy;
+-   no Release 1.1 table/data is dropped or recreated destructively.
+
+## 10. Physical-model authority remains unchanged
+
+After applying this correction, continue the original WP07 design work
+completely.
+
+The original authority still governs:
+
+-   snapshot/catalog physical representation
+-   snapshot-observation physical representation
+-   four identity representations
+-   Dataset Version / Snapshot Identity consistency
+-   exact target representation
+-   requested boundaries
+-   coverage
+-   provenance
+-   lineage
+-   successful empty snapshots
+-   timestamp/offset fidelity
+-   decimal fidelity
+-   deterministic observation ordering
+-   keys
+-   constraints
+-   foreign keys where appropriate
+-   indexes
+-   immutability compatibility
+-   Infrastructure-owned physical records/mappers
+-   exact Snapshot Identity lookup support
+-   schema bootstrap/evolution
+
+Do not treat this resume authority as permission to simplify or bypass
+those requirements.
+
+## 11. WP08 protection remains unchanged
+
+WP08 --- issue #128 --- owns Dataset Snapshot Persistence.
+
+WP07 still MUST NOT implement production:
+
+-   `IDatasetSnapshotStore` concrete behavior
+-   snapshot persistence orchestration
+-   snapshot insertion workflow
+-   runtime persistence transactions
+-   idempotent persistence classification
+-   persistence conflict classification
+-   durable snapshot reconstruction
+-   persistence result mapping
+
+Physical constraints and disposable direct-SQL probes remain allowed
+only as defined by the original authority.
+
+WP08 must remain Open / Backlog.
+
+## 12. WP09 protection remains unchanged
+
+WP09 owns Dataset Catalog Persistence & Lookup.
+
+WP07 still MUST NOT implement production:
+
+-   `IDatasetCatalog` concrete persistence
+-   catalog registration
+-   exact lookup runtime queries
+-   found/not-found behavior
+-   catalog failure mapping
+-   generalized dataset discovery/search
+
+WP07 may create only the physical structures/indexes necessary to
+support the already accepted exact lookup semantics.
+
+## 13. WP10--WP12 and Release 1.3 protection
+
+No change from the original authority.
+
+Do not implement:
+
+-   materialization/persistence integration
+-   final dataset validation/failure mapping
+-   DI registration
+-   configuration binding
+-   Worker dataset execution
+-   scheduling
+-   refresh
+-   streaming
+-   pipeline orchestration
+-   Release 1.3 behavior
+
+## 14. Architecture and production scope
+
+Expected final production deltas remain:
+
+-   Domain: `0`
+-   Application: `0`
+-   Infrastructure: authorized WP07 changes
+-   Worker: `0`
+-   packages: `0`
+-   project references: `0`
+
+Additional authorized test delta:
+
+-   existing Infrastructure test files may be modified only for the
+    schema-version alignment in Section 3
+-   permanent test count delta: `0`
+
+SQLite/SQL/filesystem concepts remain confined to Infrastructure.
+
+## 15. Temporary proof strategy
+
+Because WP14 owns comprehensive permanent Infrastructure/Dataset tests,
+use temporary focused offline probes for new WP07 evidence where
+required.
+
+Temporary probes may validate:
+
+-   v1 → v2 upgrade
+-   preservation of Release 1.1 observations
+-   v2 idempotent bootstrap
+-   v3 rejection
+-   dataset physical schema
+-   mapper round trips
+-   empty snapshot representation
+-   identity fidelity
+-   target fidelity
+-   boundary/coverage fidelity
+-   provenance/lineage reconstruction
+-   timestamp/offset fidelity
+-   decimal fidelity
+-   observation ordering constraints
+-   immutable/conflicting physical evidence behavior
+
+All temporary test files, databases, WAL/SHM/journal files, directories,
+and other probe residue must be removed before final acceptance.
+
+## 16. Validation after implementation
+
+Run all original WP07 final gates plus explicit test-count verification.
+
+Required:
+
+-   restore: PASS
+-   format verification: PASS
+-   build: PASS
+-   build warnings/errors: `0/0`
+-   Domain.Tests: `11/11`
+-   Application.Tests: `42/42`
+-   Infrastructure.Tests: `79/79`
+-   Architecture.Tests: `13/13`
+-   total permanent tests: `145/145`
+-   skipped: `0`
+-   `eng/verify.ps1`: PASS
+-   canonical secret scan: PASS
+-   `git diff --check`: PASS
+-   `git diff --cached --check`: PASS
+-   direct whitespace checks for authorized untracked files: PASS
+-   package/security verification: PASS
+-   provider/network calls: `0`
+-   temporary SQLite residue: `0`
+-   temporary probe residue: `0`
+-   Domain/Application SQLite leakage: `0`
+-   Release 1.1 persistence regression: PASS
+
+Explicitly verify the existing test modifications are limited to the
+authorized schema-version alignment.
+
+## 17. Mutation accounting
+
+The final report must separately account for:
+
+### Production
+
+-   files added
+-   files modified
+-   files deleted
+-   Domain/Application/Infrastructure/Worker delta
+-   packages/references
+
+### Existing permanent-test alignment
+
+-   exact existing test file(s) modified
+-   exact test names/assertions changed
+-   old expected schema version
+-   new expected schema version
+-   old unsupported fixture
+-   new unsupported fixture
+-   tests added: 0
+-   tests deleted: 0
+-   Infrastructure count: 79
+-   total count: 145
+
+### Temporary evidence
+
+-   probe files created/removed
+-   temporary databases created/removed
+-   final residue
+
+No authorized change may be hidden inside aggregate counts.
+
+## 18. Git/GitHub protection
+
+The original protection remains.
+
+Do NOT:
+
+-   stage
+-   commit
+-   push
+-   create/switch an integration branch
+-   create a PR
+-   merge
+-   tag
+-   release
+-   rewrite history
+
+Only issue #127 lifecycle/evidence may be changed.
+
+After every acceptance gate passes:
+
+1.  post concise completion evidence to #127;
+2.  close #127;
+3.  set Project status to Done;
+4.  leave #128 Open / Backlog.
+
+## 19. Required final execution report
+
+Use the original WP07 report structure, but add a dedicated section:
+
+**Corrective Test Alignment**
+
+That section must state:
+
+-   why the original run blocked;
+-   that this resume authority permitted the narrow correction;
+-   exact existing test file(s) changed;
+-   exact current-version assertion/name change;
+-   exact unsupported-version fixture change;
+-   test count before/after;
+-   confirmation that no WP14 dataset coverage was added;
+-   confirmation that Release 1.1 behavior remains protected.
+
+The report must also explicitly distinguish:
+
+-   original blocked execution: historical / no mutation;
+-   resumed execution: authoritative completed attempt.
+
+## 20. Acceptance criteria
+
+In addition to every original WP07 acceptance criterion, completion now
+requires:
+
+-   the prior authority conflict is resolved only through the permitted
+    test alignment;
+-   schema version 2 is the current accepted SQLite schema;
+-   version 3 is the unsupported-future-version test fixture;
+-   no existing permanent test is deleted;
+-   no permanent test is added;
+-   Infrastructure.Tests remains 79;
+-   total permanent tests remains 145;
+-   Release 1.1 behavioral coverage is not weakened;
+-   WP14 coverage is not pulled forward;
+-   all original WP07 physical-model and schema-evolution gates pass;
+-   #127 ends Closed / Done;
+-   #128 remains Open / Backlog.
+
+## 21. WP08 handoff
+
+The original WP07 handoff requirement remains fully applicable.
+
+The completed report must give WP08 exact repository truth for:
+
+-   schema version 2
+-   exact table names
+-   columns/types/nullability
+-   primary/foreign/unique/check constraints
+-   indexes
+-   identity representation
+-   Dataset Version representation
+-   target collation
+-   requested boundaries
+-   coverage
+-   provenance/lineage representation
+-   timestamp/offset representation
+-   decimal representation
+-   observation ordering/membership representation
+-   empty snapshot representation
+-   Infrastructure records/mappers
+-   bootstrap guarantees
+-   v1 → v2 upgrade guarantees
+
+WP08 must consume this model rather than redesign it.
+
+## 22. Terminal marker
+
+On successful resumed completion, use the original WP07 success marker:
+
+RELEASE 1.2 WP07 COMPLETE
+
+DATASET PHYSICAL STORAGE MODEL: WP02 dataset semantics preserved: PASS
+WP03 identity/version/provenance semantics preserved: PASS WP04
+Application contracts preserved: PASS WP05 materialization candidate
+representable: PASS WP06 catalog metadata representable: PASS Release
+1.1 historical_observations preserved: PASS SQLite storage engine
+preserved: PASS Schema version: 2 Schema evolution: PASS Clean
+bootstrap: PASS Release 1.1 → Release 1.2 upgrade: PASS Snapshot/catalog
+physical model: PASS Snapshot observation physical model: PASS Four
+identity representations: PASS Dataset Version / Snapshot Identity
+consistency: PASS Exact target representation: PASS Requested boundary
+representation: PASS Coverage representation: PASS Provenance
+representation: PASS Lineage representation: PASS Successful empty
+snapshot representation: PASS Timestamp/offset fidelity: PASS Decimal
+fidelity: PASS Deterministic observation-order representation: PASS
+Immutable-history compatibility: PASS Exact Snapshot Identity lookup
+support: PASS Existing bootstrap-test alignment: PASS Tests
+added/deleted: 0/0 Infrastructure.Tests: 79/79 Permanent tests: 145/145
+Generalized migration framework introduced: NO Snapshot persistence
+implemented: NO Catalog persistence/lookup implemented: NO Domain
+SQLite/SQL leakage: 0 Application SQLite/SQL leakage: 0 Domain delta: 0
+Application delta: 0 Worker delta: 0 Package/reference delta: 0/0
+Permanent test count delta: 0 Temporary SQLite residue: 0 WP08 started:
+NO Release 1.3 implementation started: NO Issue #127: CLOSED / DONE
+
+NEXT AUTHORIZED WORK PACKAGE: WP08 --- Dataset Snapshot Persistence
+GitHub issue #128
+
+If a new blocker is discovered, do not weaken this or the original
+authority. End with:
+
+RELEASE 1.2 WP07 BLOCKED
+
+and state the smallest new corrective authority required.

--- a/docs/roadmap/release-1.2/prompts/08-dataset-snapshot-persistence-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/08-dataset-snapshot-persistence-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read `08-dataset-snapshot-persistence-codex-prompt.md` completely as the sole WP08 authority and reconcile accepted WP01-WP07/schema-v2 state before mutation.
+Implement only bounded Infrastructure immutable snapshot persistence with exact metadata, identity, provenance, lineage, atomicity, equivalent, and conflict semantics.
+Do not begin WP09+, add tests/packages, redesign contracts/schema, change Worker/DI, or introduce Release 1.3; run all required lifecycle, fidelity, atomicity, regression, architecture, security, cleanup, and canonical gates.
+Do not stage, commit, push, branch, or create a PR; leave #129 Open/Backlog and preserve all predecessor behavior.
+Close #128/mark Done only after every gate passes; otherwise stop with the smallest corrective authority required.

--- a/docs/roadmap/release-1.2/prompts/08-dataset-snapshot-persistence-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/08-dataset-snapshot-persistence-codex-prompt.md
@@ -1,0 +1,906 @@
+# Release 1.2 WP08 --- Dataset Snapshot Persistence --- Codex Execution Authority
+
+## 1. Purpose
+
+Execute **Release 1.2 WP08 --- Dataset Snapshot Persistence** for:
+
+`samuel-santos-engineer/AIQuantTradingResearch`
+
+GitHub issue: **#128**
+
+This work package implements the Infrastructure-owned persistence
+boundary for immutable Release 1.2 dataset snapshots using the
+**accepted WP07 SQLite schema version 2 and physical model**.
+
+WP08 must consume the accepted WP02--WP07 semantics and physical
+representation. It must **not redesign dataset identity, catalog
+semantics, schema structure, schema versioning, materialization, lookup,
+failure classification, dependency registration, Worker execution, or
+Release 1.3 behavior**.
+
+This prompt is execution authority for WP08 only.
+
+------------------------------------------------------------------------
+
+## 2. Required Model
+
+Execute this work package using **GPT-5.6 Terra**.
+
+WP07 already resolved the architecture-heavy physical-storage decisions.
+WP08 is a bounded implementation work package and should prefer direct,
+minimal implementation over architectural reconsideration.
+
+Do not switch models merely to broaden or redesign the scope.
+
+------------------------------------------------------------------------
+
+## 3. Controlling Authorities
+
+Before mutation, read and reconcile completely:
+
+1.  `RELEASE_1.2_EXECUTION_PLAN.md`
+2.  `RELEASE_1.2_FILE_MANIFEST.md`
+3.  Release 1.2 GitHub-planning authority and accepted planning result
+4.  WP01--WP07 prompt pairs and accepted execution results
+5.  `docs/architecture/data/RESEARCH_DATASET_DEFINITION.md`
+6.  `docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md`
+7.  Current Application dataset contracts and materialization
+    implementation
+8.  Current Release 1.1 SQLite persistence implementation
+9.  Current WP07 SQLite dataset physical model
+10. Existing permanent tests and architecture rules
+11. GitHub issue #128, milestone #53, and Project #2 state
+
+If repository truth and this prompt appear inconsistent, stop before
+mutation and report the smallest corrective authority required.
+
+Do not silently reinterpret accepted WP02--WP07 decisions.
+
+------------------------------------------------------------------------
+
+## 4. Mandatory Starting-State Gates
+
+Before changing any repository file:
+
+### 4.1 Repository identity
+
+Verify:
+
+-   repository is `samuel-santos-engineer/AIQuantTradingResearch`;
+-   current branch is `main`;
+-   local `main` and `origin/main` are synchronized;
+-   ahead/behind is `0/0`;
+-   staged paths are `0`.
+
+### 4.2 Working-tree classification
+
+The repository may contain accepted cumulative uncommitted/untracked
+Release 1.2 artifacts.
+
+Classify every existing path before mutation as:
+
+-   accepted cumulative Release 1.2 governance/implementation work;
+-   authorized WP08 authority artifacts;
+-   unexpected/ambiguous.
+
+Do not delete, normalize, stage, or rewrite accepted cumulative
+artifacts.
+
+If any unexpected or ambiguous path could overlap WP08, stop.
+
+### 4.3 Lifecycle
+
+Verify:
+
+-   WP07 issue #127 is **Closed / Done**;
+-   WP08 issue #128 is **Open / Backlog**;
+-   WP09 issue #129 is **Open / Backlog**;
+-   milestone #53 is open;
+-   WP08 dependencies match the authoritative Release 1.2 dependency
+    graph;
+-   no Release 1.3 implementation has started.
+
+Do not move #128 to In Progress until all starting-state and baseline
+gates pass.
+
+### 4.4 WP07 physical-model gate
+
+Verify the accepted WP07 state exists:
+
+-   SQLite schema version = **2**;
+-   Release 1.1 `historical_observations` remains intact;
+-   `dataset_snapshots` exists in the accepted physical model;
+-   `dataset_snapshot_observations` exists in the accepted physical
+    model;
+-   `SqliteDatasetSnapshotRecord` exists;
+-   `SqliteDatasetObservationRecord` exists;
+-   `SqliteDatasetMapper` exists;
+-   clean bootstrap supports version 2;
+-   v1 → v2 upgrade is non-destructive;
+-   version 2 bootstrap is idempotent;
+-   version 3 is unsupported;
+-   permanent baseline remains 145 tests unless repository truth has
+    legitimately advanced.
+
+If this physical model is absent or materially different, stop.
+
+------------------------------------------------------------------------
+
+## 5. Baseline Validation
+
+Before implementation run the repository's normal validation path.
+
+At minimum:
+
+-   restore;
+-   format verification;
+-   build;
+-   Domain tests;
+-   Application tests;
+-   Infrastructure tests;
+-   Architecture tests;
+-   `eng/verify.ps1`;
+-   `git diff --check`;
+-   `git diff --cached --check`.
+
+Expected accepted baseline at WP07 handoff:
+
+-   Domain.Tests: 11
+-   Application.Tests: 42
+-   Infrastructure.Tests: 79
+-   Architecture.Tests: 13
+-   permanent total: 145
+-   warnings/errors: 0/0
+
+If repository truth has legitimately advanced, reconcile and report it.
+Do not manufacture old counts.
+
+After the baseline passes, move issue #128 from Backlog to In Progress.
+
+------------------------------------------------------------------------
+
+## 6. Accepted Semantic Model --- Do Not Redesign
+
+WP08 must preserve the following accepted semantics.
+
+### 6.1 Dataset semantics
+
+A Research Dataset Snapshot is immutable evidence of one deterministic
+materialization.
+
+The definition is:
+
+-   one exact target;
+-   explicit `[from, to)` semantic-instant boundaries;
+-   deterministic ascending semantic-instant ordering;
+-   valid even when zero observations are selected.
+
+### 6.2 Identity semantics
+
+Keep distinct:
+
+-   Dataset Definition Identity;
+-   Research Dataset Identity;
+-   Source State Identity;
+-   Dataset Snapshot Identity.
+
+Dataset Version remains the immutable Snapshot Identity representation.
+
+Identity scheme remains:
+
+`aiq-dataset-identity-v1`
+
+Identity values remain validated 64-character lowercase hexadecimal
+SHA-256 fingerprints.
+
+WP08 must **not recompute identities**. It persists the already accepted
+candidate.
+
+### 6.3 Fidelity
+
+Persist and recoverable evidence must preserve:
+
+-   exact target text;
+-   semantic instant;
+-   original `DateTimeOffset` offset representation;
+-   exact decimal price;
+-   requested boundaries;
+-   coverage;
+-   observation count;
+-   deterministic observation ordering;
+-   provenance;
+-   narrow lineage.
+
+No floating-point conversion is permitted.
+
+### 6.4 Immutability and equivalence
+
+Previously accepted snapshot evidence must never be overwritten.
+
+An equivalent re-materialization may be recognized as already existing.
+
+Contradictory evidence under the same Snapshot Identity is an integrity
+conflict.
+
+No update/replace/delete/destructive upsert behavior is allowed.
+
+------------------------------------------------------------------------
+
+## 7. Accepted WP07 Physical Model --- Consume As-Is
+
+WP08 must use schema version **2**.
+
+### 7.1 Tables
+
+Use:
+
+-   `dataset_snapshots`
+-   `dataset_snapshot_observations`
+
+Do not introduce an alternative dataset persistence table.
+
+### 7.2 Snapshot descriptor
+
+The accepted descriptor representation includes, at minimum, the
+WP07-defined physical fields for:
+
+-   snapshot identity;
+-   definition identity;
+-   research dataset identity;
+-   source-state identity;
+-   identity scheme;
+-   exact target;
+-   requested boundary UTC ticks and offsets;
+-   ordering;
+-   observation count;
+-   source authority;
+-   nullable first/last actual observation UTC ticks and offsets.
+
+Dataset Version is represented by Snapshot Identity and must not be
+stored as an independent drifting value.
+
+### 7.3 Observation membership
+
+Persist ordered membership using the accepted fields:
+
+-   snapshot identity;
+-   zero-based ordinal;
+-   UTC ticks;
+-   original offset minutes;
+-   invariant decimal price text.
+
+The physical model already provides:
+
+-   primary key `(snapshot_identity, ordinal)`;
+-   unique `(snapshot_identity, instant_utc_ticks)`;
+-   restrictive foreign-key relationship to the snapshot descriptor.
+
+### 7.4 Representation rules
+
+Preserve:
+
+-   target as `TEXT COLLATE BINARY`;
+-   UTC ticks + offset minutes for timestamps;
+-   offset range `[-840, 840]`;
+-   invariant decimal `G29` text;
+-   no SQLite `REAL`;
+-   zero-observation snapshot as one descriptor row and zero membership
+    rows;
+-   no sentinel observation.
+
+Do not change schema version or bootstrap design in WP08 unless a proven
+blocker requires new authority.
+
+------------------------------------------------------------------------
+
+## 8. Authorized Implementation Scope
+
+Implement the **minimum Infrastructure-owned snapshot persistence
+behavior** necessary to fulfill the existing Application
+`IDatasetSnapshotStore` contract.
+
+Prefer extending the existing SQLite persistence area rather than
+introducing generalized repositories/frameworks.
+
+WP08 may add or modify only files authorized by the Release 1.2 file
+manifest for WP08.
+
+The implementation may include a focused SQLite dataset snapshot store
+and private helpers strictly necessary for:
+
+-   mapping the accepted candidate through the WP07 mapper;
+-   inserting snapshot descriptor evidence;
+-   inserting ordered snapshot-observation membership;
+-   recognizing equivalent existing evidence;
+-   detecting contradictory existing evidence;
+-   returning the existing Application-owned persistence outcome/failure
+    model;
+-   transaction ownership and deterministic disposal.
+
+Do not modify Application contracts unless the current accepted contract
+is literally impossible to implement. If so, stop and report the
+blocker.
+
+------------------------------------------------------------------------
+
+## 9. Persistence Algorithm
+
+Implement a deterministic insert-only algorithm.
+
+For one `DatasetSnapshotCandidate`:
+
+1.  Validate only what is necessary at the Infrastructure boundary
+    without changing Application semantics.
+2.  Obtain a fresh open connection through the accepted SQLite
+    connection boundary.
+3.  Begin one transaction covering the complete snapshot.
+4.  Determine whether the Snapshot Identity already exists.
+5.  If it does not exist:
+    -   insert exactly one snapshot descriptor;
+    -   insert all observation-membership rows in accepted ordinal
+        order;
+    -   commit;
+    -   return the existing outcome representing newly
+        accepted/registered snapshot evidence.
+6.  If it exists:
+    -   reconstruct/compare the complete existing persisted evidence
+        required to establish semantic equivalence;
+    -   if equivalent, perform no mutation and return the existing
+        equivalent/idempotent outcome;
+    -   if contradictory, perform no mutation and return the existing
+        integrity-conflict outcome.
+7.  On any unsuccessful write before commit, the transaction must leave
+    no partial snapshot evidence.
+
+Do not implement a destructive repair path.
+
+------------------------------------------------------------------------
+
+## 10. Equivalence Requirements
+
+Do not treat equal Snapshot Identity alone as sufficient evidence of
+equivalence.
+
+For an existing Snapshot Identity, compare enough persisted evidence to
+prove that the stored snapshot is the same accepted semantic snapshot.
+
+At minimum reconcile:
+
+-   all four identities;
+-   identity scheme;
+-   target;
+-   requested boundaries and offsets;
+-   ordering;
+-   observation count;
+-   source authority;
+-   first/last actual coverage values;
+-   complete ordered observation membership;
+-   each observation instant;
+-   each original offset;
+-   each exact decimal value.
+
+If persisted content contradicts the candidate under the same Snapshot
+Identity, return the accepted integrity-conflict outcome.
+
+Do not overwrite it.
+
+------------------------------------------------------------------------
+
+## 11. Empty Snapshot Requirements
+
+A valid empty candidate must persist successfully.
+
+It must result in:
+
+-   exactly one `dataset_snapshots` descriptor;
+-   observation count = 0;
+-   first actual observation = null;
+-   last actual observation = null;
+-   zero `dataset_snapshot_observations` rows.
+
+Repeated persistence of the equivalent empty snapshot must be
+idempotent/equivalent.
+
+No sentinel row is permitted.
+
+------------------------------------------------------------------------
+
+## 12. Atomicity
+
+The descriptor and all observation membership rows form one immutable
+snapshot.
+
+They must commit atomically.
+
+Mandatory cases:
+
+-   descriptor succeeds + observation fails → rollback all;
+-   N observations succeed + later observation fails → rollback all;
+-   conflict detected before insertion → no mutation;
+-   conflict detected against existing evidence → no mutation;
+-   equivalent existing evidence → no mutation.
+
+Do not leave partial descriptor or membership rows.
+
+------------------------------------------------------------------------
+
+## 13. Connection and Transaction Ownership
+
+Reuse the accepted Release 1.1/WP07 SQLite connection boundary.
+
+Requirements:
+
+-   no global/shared live connection;
+-   store operation owns its connection lifetime;
+-   transaction is operation-local;
+-   command objects are disposed deterministically;
+-   connection is disposed deterministically;
+-   DI does not own a live SQLite connection.
+
+Do not redesign connection ownership.
+
+------------------------------------------------------------------------
+
+## 14. Failure Boundary
+
+WP11 owns comprehensive **Dataset Validation & Failure Mapping**.
+
+Therefore WP08 must not build a new generalized SQLite
+error-classification framework.
+
+Preserve existing Application result/failure vocabulary and existing
+Release 1.1 storage behavior.
+
+WP08 may perform the minimum mapping already required by the existing
+snapshot-store contract for:
+
+-   invalid candidate data already representable by accepted contracts;
+-   equivalent existing snapshot;
+-   integrity conflict.
+
+Raw SQLite operational failure behavior that is explicitly assigned to
+WP11 should remain available for WP11 unless an existing shared Release
+1.1 boundary already maps it naturally without redesign.
+
+Do not add retry, resilience, repair, or availability policy.
+
+------------------------------------------------------------------------
+
+## 15. WP09 Protection
+
+WP09 owns **Dataset Catalog Persistence & Lookup**.
+
+WP08 must not implement `IDatasetCatalog`.
+
+Do not add:
+
+-   generalized catalog registration;
+-   public catalog lookup;
+-   catalog search;
+-   latest-version lookup;
+-   target/date-range search;
+-   list-all datasets;
+-   mutable catalog status;
+-   catalog indexes beyond the accepted WP07 physical model.
+
+WP08 may privately read persisted snapshot evidence only as required to
+classify its own persistence attempt as new, equivalent, or conflicting.
+
+That private equivalence check is not WP09 catalog lookup behavior.
+
+------------------------------------------------------------------------
+
+## 16. WP10 Protection
+
+WP10 owns **Dataset Materialization Integration**.
+
+Do not make WP05 materialization automatically persist snapshots.
+
+Do not orchestrate:
+
+materialize → snapshot store → catalog
+
+Do not modify the materialization use case to call Infrastructure.
+
+------------------------------------------------------------------------
+
+## 17. WP11 Protection
+
+WP11 owns **Dataset Validation & Failure Mapping**.
+
+Do not introduce:
+
+-   generalized dataset storage exception classifier;
+-   repair semantics;
+-   corruption recovery;
+-   retryability classification;
+-   new public failure vocabulary.
+
+Only implement what WP08 needs to satisfy the existing snapshot
+persistence contract.
+
+------------------------------------------------------------------------
+
+## 18. WP12 Protection
+
+WP12 owns **Dependency Registration & Bounded Dataset Execution**.
+
+Do not register the snapshot store with DI unless the authoritative
+manifest explicitly assigns that file/change to WP08.
+
+Do not modify Worker execution.
+
+Do not add configuration keys.
+
+Do not introduce dataset execution scheduling.
+
+------------------------------------------------------------------------
+
+## 19. WP13/WP14 Test Ownership
+
+WP13 and WP14 own the permanent Release 1.2 dataset test expansion.
+
+Therefore:
+
+-   permanent test count delta in WP08 should be **0** unless the
+    Release 1.2 manifest explicitly says otherwise;
+-   do not add broad permanent dataset tests;
+-   do not consume WP14 test scope early.
+
+Temporary focused offline probes are allowed when needed to prove WP08
+behavior.
+
+Any temporary probe must be removed before completion.
+
+The existing WP07 test-count-neutral schema alignment must remain
+intact.
+
+------------------------------------------------------------------------
+
+## 20. Required Focused Validation
+
+Use temporary offline validation if necessary to prove the
+implementation before removing the probe.
+
+At minimum prove:
+
+### 20.1 New non-empty snapshot
+
+-   descriptor inserted once;
+-   all observations inserted;
+-   ordinal order correct;
+-   count correct;
+-   exact identities preserved;
+-   exact target preserved;
+-   boundaries preserved;
+-   coverage preserved;
+-   source authority preserved;
+-   offsets preserved;
+-   decimal values preserved.
+
+### 20.2 Equivalent repeated persistence
+
+Persist the same candidate again.
+
+Prove:
+
+-   equivalent/idempotent outcome;
+-   no new descriptor;
+-   no new membership rows;
+-   no mutation of accepted evidence.
+
+### 20.3 Integrity conflict
+
+Create contradictory persisted evidence under the same Snapshot Identity
+in a controlled offline test.
+
+Prove:
+
+-   conflict result;
+-   existing evidence remains unchanged;
+-   candidate does not overwrite existing evidence.
+
+### 20.4 Empty snapshot
+
+Prove:
+
+-   descriptor exists;
+-   count = 0;
+-   actual first/last values are null;
+-   membership rows = 0;
+-   repeated persistence is equivalent/idempotent.
+
+### 20.5 Atomic rollback
+
+Force a failure after partial insertion would otherwise be possible.
+
+Prove:
+
+-   descriptor residue = 0 for the failed new snapshot;
+-   membership residue = 0;
+-   previously accepted unrelated snapshots remain intact.
+
+### 20.6 Multiple versions
+
+Persist two valid snapshots for the same logical Research Dataset
+Identity with different Source State/Snapshot identities.
+
+Prove coexistence without overwrite.
+
+### 20.7 Release 1.1 regression
+
+Historical observation persistence/retrieval remains unchanged.
+
+### 20.8 Residue
+
+Remove all temporary databases and probe files.
+
+Repository SQLite/WAL/SHM/journal residue must be zero.
+
+------------------------------------------------------------------------
+
+## 21. Security and Offline Requirements
+
+WP08 validation must be fully offline.
+
+Prohibited:
+
+-   live Twelve Data calls;
+-   provider/network access;
+-   real credentials;
+-   secrets;
+-   machine-specific persistent database paths;
+-   logging connection strings or database contents unnecessarily.
+
+Run canonical secret scanning.
+
+------------------------------------------------------------------------
+
+## 22. Architecture Requirements
+
+The production dependency graph must remain:
+
+-   Domain → none
+-   Application → Domain
+-   Infrastructure → Application
+-   Worker → Application, Infrastructure
+
+Requirements:
+
+-   Domain SQLite/SQL leakage: 0
+-   Application SQLite/SQL leakage: 0
+-   Domain provider/HTTP leakage: 0
+-   Application provider/HTTP leakage: 0
+-   new project-reference edges: 0 unless explicitly authorized
+-   dependency cycles: 0
+
+SQLite dataset persistence belongs to Infrastructure.
+
+------------------------------------------------------------------------
+
+## 23. Package and Reference Policy
+
+Expected WP08 package/reference delta:
+
+`0/0`
+
+Use the existing `Microsoft.Data.Sqlite` dependency.
+
+Do not add:
+
+-   ORM;
+-   migration framework;
+-   serialization package;
+-   hashing package;
+-   repository framework;
+-   database abstraction framework.
+
+If a new package is genuinely unavoidable, stop and request authority
+before adding it.
+
+------------------------------------------------------------------------
+
+## 24. Documentation Policy
+
+WP15 owns Architecture & Documentation Alignment.
+
+Do not broadly update documentation in WP08.
+
+Only modify documentation if the Release 1.2 file manifest explicitly
+assigns a WP08 artifact.
+
+Do not rewrite accepted WP02/WP03/WP07 semantic documentation.
+
+------------------------------------------------------------------------
+
+## 25. Git and GitHub Protection
+
+During WP08:
+
+Do not:
+
+-   stage;
+-   commit;
+-   push;
+-   create a branch;
+-   create a PR;
+-   merge;
+-   tag;
+-   create a release;
+-   rewrite history.
+
+Only the authorized issue #128 lifecycle may change.
+
+Do not mutate issue #129 or later WP issues.
+
+Do not modify milestone #53 except through normal issue count effects.
+
+------------------------------------------------------------------------
+
+## 26. Completion Validation
+
+After implementation and after all temporary probes are removed, run:
+
+1.  restore;
+2.  format verification;
+3.  build;
+4.  Domain.Tests;
+5.  Application.Tests;
+6.  Infrastructure.Tests;
+7.  Architecture.Tests;
+8.  `eng/verify.ps1`;
+9.  `git diff --check`;
+10. `git diff --cached --check`;
+11. direct whitespace checks for authorized untracked WP08 files when
+    Git diff cannot see them;
+12. secret scan through canonical verification;
+13. temporary SQLite residue check;
+14. architecture/leakage reconciliation;
+15. mutation accounting.
+
+Expected permanent-test baseline remains 145 unless repository truth
+legitimately differs.
+
+------------------------------------------------------------------------
+
+## 27. Mandatory Acceptance Matrix
+
+Do not close WP08 until all applicable rows pass.
+
+  Requirement                                       Required result
+  ------------------------------------------------- ----------------------------------
+  WP07 predecessor                                  PASS
+  Schema version                                    2
+  Existing WP07 physical model reused               PASS
+  `IDatasetSnapshotStore` implemented               PASS
+  New snapshot persistence                          PASS
+  Descriptor persistence                            PASS
+  Ordered observation membership persistence        PASS
+  Exact four identities preserved                   PASS
+  Dataset Version / Snapshot Identity consistency   PASS
+  Exact target preserved                            PASS
+  Requested boundaries preserved                    PASS
+  Coverage preserved                                PASS
+  Provenance/source authority preserved             PASS
+  Lineage evidence preserved                        PASS
+  Timestamp/offset fidelity                         PASS
+  Decimal fidelity                                  PASS
+  Successful empty snapshot                         PASS
+  Equivalent repeated persistence                   PASS
+  Integrity conflict non-destructive                PASS
+  Atomic rollback                                   PASS
+  Immutable accepted evidence                       PASS
+  Multiple logical-dataset versions coexist         PASS
+  Destructive update/delete/upsert                  NO
+  WP09 catalog implementation                       NO
+  WP10 integration started                          NO
+  WP11 generalized failure mapping started          NO
+  WP12 DI/Worker execution started                  NO
+  Release 1.3 implementation started                NO
+  Provider/network calls                            0
+  Domain SQLite/SQL leakage                         0
+  Application SQLite/SQL leakage                    0
+  Package/reference delta                           0/0
+  Permanent test delta                              0 unless manifest says otherwise
+  Temporary probe residue                           0
+  Temporary SQLite residue                          0
+  Build warnings/errors                             0/0
+  Canonical verification                            PASS
+
+------------------------------------------------------------------------
+
+## 28. Issue Completion
+
+After every required gate passes:
+
+1.  post concise evidence to GitHub issue #128;
+2.  close issue #128;
+3.  set its Project #2 status to Done;
+4.  verify issue #129 remains Open / Backlog;
+5.  verify milestone #53 remains open;
+6.  do not start WP09.
+
+If any mandatory gate fails, leave #128 open and report WP08 as blocked.
+
+------------------------------------------------------------------------
+
+## 29. Required Execution Report
+
+Return a structured report covering at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Predecessor/Lifecycle Gates
+7.  Issue Lifecycle
+8.  Initial Baseline
+9.  WP02 Reconciliation
+10. WP03 Reconciliation
+11. WP04 Contract Reconciliation
+12. WP05 Materialization Reconciliation
+13. WP06 Catalog Reconciliation
+14. WP07 Physical-Model Reconciliation
+15. Snapshot Store Design
+16. Persistence Algorithm
+17. Transaction Strategy
+18. New Snapshot Behavior
+19. Equivalent Existing Behavior
+20. Integrity Conflict Behavior
+21. Empty Snapshot Behavior
+22. Observation Membership / Ordering
+23. Identity / Version Fidelity
+24. Target / Boundary / Coverage Fidelity
+25. Provenance / Lineage Fidelity
+26. Timestamp / Offset Fidelity
+27. Decimal Fidelity
+28. Atomicity / Immutability
+29. Connection Ownership / Disposal
+30. Failure-Boundary Decision
+31. Exact Files Added/Modified
+32. Domain Delta
+33. Application Delta
+34. Infrastructure Delta
+35. Worker Delta
+36. Package/Reference Delta
+37. Permanent Test Delta
+38. Temporary Probe Evidence
+39. WP09 Protection
+40. WP10--WP12 / Release 1.3 Protection
+41. Security / Offline Evidence
+42. Whitespace / Diff Evidence
+43. Restore / Build Evidence
+44. Permanent Test Evidence
+45. Canonical Verification
+46. Architecture Validation
+47. Release 1.1 Persistence Regression
+48. Snapshot Persistence Validation Matrix
+49. Mutation Accounting
+50. Git / GitHub Protection
+51. Planning Protection
+52. Findings / Blockers
+53. Final Repository / GitHub State
+54. WP09 Handoff
+55. Final Decision
+56. Next Authorized Work Package
+
+------------------------------------------------------------------------
+
+## 30. Required Terminal Marker
+
+If successful, end exactly with:
+
+`RELEASE 1.2 WP08 COMPLETE`
+
+Then include:
+
+`NEXT AUTHORIZED WORK PACKAGE: WP09 — Dataset Catalog Persistence & Lookup — GitHub issue #129`
+
+If blocked, end with:
+
+`RELEASE 1.2 WP08 BLOCKED`
+
+and state the smallest corrective authority required.
+
+Do not start WP09.

--- a/docs/roadmap/release-1.2/prompts/09-dataset-catalog-persistence-lookup-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/09-dataset-catalog-persistence-lookup-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read `09-dataset-catalog-persistence-lookup-codex-prompt.md` completely as the sole WP09 authority and reconcile accepted WP01-WP08 state before mutation.
+Implement only the existing Application IDatasetCatalog over SQLite schema v2 with immutable registration, exact Snapshot Identity lookup, equivalence/conflict, and metadata fidelity.
+Do not begin WP10+, redesign snapshot persistence, change schema/packages/references, add tests, or perform Git transport; run all required lifecycle, lookup, fidelity, regression, architecture, security, whitespace, build, and canonical gates.
+Do not stage, commit, push, branch, or open a PR; leave #130 Open/Backlog and preserve Release 1.1 behavior.
+Close #129/mark Done only after every gate passes; otherwise stop on the precise authority or implementation blocker.

--- a/docs/roadmap/release-1.2/prompts/09-dataset-catalog-persistence-lookup-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/09-dataset-catalog-persistence-lookup-codex-prompt.md
@@ -1,0 +1,574 @@
+# Release 1.2 WP09 --- Dataset Catalog Persistence & Lookup --- Codex Execution Authority
+
+## 1. Authority
+
+You are authorized to execute **Release 1.2 WP09 --- Dataset Catalog
+Persistence & Lookup** for:
+
+-   Repository: `samuel-santos-engineer/AIQuantTradingResearch`
+-   GitHub issue: `#129`
+-   Milestone:
+    `#53 — Phase 3 - Release 1.2: Research Dataset Foundation`
+-   Project: `#2 — AIQuantTradingResearch Engineering Roadmap`
+
+This prompt is the execution authority for WP09. It must be interpreted
+together with:
+
+-   `RELEASE_1.2_EXECUTION_PLAN.md`
+-   `RELEASE_1.2_FILE_MANIFEST.md`
+-   accepted WP01--WP08 artifacts and execution evidence
+-   `docs/architecture/data/RESEARCH_DATASET_DEFINITION.md`
+-   `docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md`
+-   current Application dataset contracts
+-   current Release 1.1 SQLite persistence foundation
+-   accepted WP07 SQLite schema-v2 physical model
+-   accepted WP08 dataset snapshot persistence implementation
+
+If any authority conflicts materially, stop before mutation and report
+the conflict and the smallest corrective authority required.
+
+## 2. Objective
+
+Implement the **minimum bounded Infrastructure persistence required for
+`IDatasetCatalog` registration and exact lookup** using the accepted
+Release 1.2 Application catalog model and WP07 SQLite schema v2.
+
+WP09 must make accepted dataset snapshot evidence discoverable through
+the existing Application-owned catalog abstraction without redefining
+dataset semantics, identities, snapshot persistence, or materialization.
+
+The implementation must preserve:
+
+-   immutable catalog evidence;
+-   exact Snapshot Identity lookup;
+-   deterministic reconstruction of `DatasetCatalogEntry`;
+-   `NewlyRegistered`, `EquivalentExisting`, and `IntegrityConflict`
+    semantics;
+-   Dataset Version = Snapshot Identity semantics;
+-   exact target and requested-boundary fidelity;
+-   coverage fidelity;
+-   provenance and lineage fidelity;
+-   successful empty-snapshot representation;
+-   timestamp/offset/decimal fidelity;
+-   coexistence of multiple immutable versions of one logical Research
+    Dataset;
+-   storage independence of Domain and Application.
+
+## 3. Required Starting-State Gates
+
+Before changing anything, verify and report:
+
+1.  Repository identity is exactly
+    `samuel-santos-engineer/AIQuantTradingResearch`.
+2.  Current branch is `main`.
+3.  Local `main` is synchronized with `origin/main`; report HEAD, remote
+    SHA, and ahead/behind.
+4.  Staged paths are zero.
+5.  Every existing working-tree path is classified as an accepted
+    cumulative Release 1.2 artifact or an explicitly authorized WP09
+    artifact.
+6.  Unexpected or ambiguous paths are zero.
+7.  Release 1.1 remains closed and accepted.
+8.  Release 1.2 milestone #53 is open.
+9.  WP08 issue #128 is `Closed / Done`.
+10. WP09 issue #129 is `Open / Backlog`.
+11. WP10 issue #130 is `Open / Backlog`.
+12. WP09 dependency state matches the authoritative planning graph.
+13. No Release 1.3 implementation has started.
+14. Restore, format verification, build, permanent tests, architecture
+    tests, canonical verification, and Git whitespace checks pass before
+    mutation.
+
+Do **not** move #129 to In Progress until all starting-state gates pass.
+
+If a starting-state gate fails, stop without repository or GitHub
+mutation and emit `RELEASE 1.2 WP09 BLOCKED`.
+
+## 4. Mandatory Reconciliation Before Implementation
+
+Reconcile the current repository against WP02--WP08 and explicitly
+report the result.
+
+### WP02 --- Dataset semantics
+
+Preserve:
+
+-   one exact target;
+-   explicit `[from, to)` boundaries;
+-   deterministic semantic-instant ordering;
+-   valid successful empty materialization;
+-   immutable snapshots;
+-   exact offset and decimal fidelity.
+
+### WP03 --- Identity/version/provenance
+
+Preserve:
+
+-   Dataset Definition Identity;
+-   Research Dataset Identity;
+-   Source State Identity;
+-   Dataset Snapshot Identity;
+-   Dataset Version as the immutable Snapshot Identity;
+-   `aiq-dataset-identity-v1`;
+-   provenance and narrow lineage;
+-   identity immutability and collision/integrity-conflict semantics.
+
+Do not redesign canonicalization or recompute semantic identities in
+Infrastructure.
+
+### WP04 --- Application contracts
+
+Implement the existing `IDatasetCatalog` seam as currently accepted.
+
+Do not add SQLite, SQL, filesystem, or provider mechanics to
+Application.
+
+Do not create a competing catalog abstraction.
+
+### WP05 --- Materialization
+
+Materialization remains Application-owned and independent of catalog
+persistence.
+
+WP09 must not invoke historical acquisition or rematerialize a dataset
+to satisfy lookup.
+
+### WP06 --- Catalog model
+
+`DatasetCatalogEntry` is the authoritative logical catalog descriptor.
+
+Preserve the distinction between:
+
+-   identity-bearing semantic metadata;
+-   deterministic descriptive metadata;
+-   operational metadata, which is excluded;
+-   physical-storage metadata, which is excluded from the Application
+    model.
+
+Do not add mutable `latest`, status, timestamp, path, database ID, or
+similar operational concepts.
+
+### WP07 --- Physical storage
+
+Reuse schema v2 exactly as accepted.
+
+Do not introduce schema v3, migrations, replacement tables, generic
+repository infrastructure, ORM behavior, or a second physical catalog
+model unless an unavoidable contradiction is discovered. If such a
+contradiction exists, stop and report it.
+
+### WP08 --- Snapshot persistence
+
+`SqliteDatasetSnapshotStore` owns snapshot persistence semantics.
+
+WP09 must not redesign or duplicate snapshot write behavior.
+
+Catalog registration may rely on already persisted accepted snapshot
+evidence according to the existing contract/schema design, but must not
+overwrite or mutate contradictory accepted evidence.
+
+## 5. Implementation Scope
+
+Implement only the minimum Infrastructure behavior needed to satisfy
+`IDatasetCatalog`.
+
+Prefer extending the accepted SQLite persistence organization and
+existing connection boundary.
+
+Expected bounded behavior:
+
+### Registration
+
+For an accepted `DatasetCatalogEntry`:
+
+-   register new immutable catalog evidence and return
+    `NewlyRegistered`;
+-   recognize semantically equivalent existing evidence and return
+    `EquivalentExisting`;
+-   detect contradictory evidence under the same exact Snapshot Identity
+    and return `IntegrityConflict`;
+-   never overwrite, replace, repair, delete, or silently alias existing
+    evidence.
+
+Registration must preserve the accepted snapshot/catalog relationship
+established by WP07/WP08.
+
+### Exact lookup
+
+Lookup is by exact `DatasetSnapshotIdentity`.
+
+A successful hit must reconstruct the accepted `DatasetCatalogEntry`
+with all required semantic/descriptive facts.
+
+A valid miss must be represented according to the existing Application
+contract. Do not invent a mutable latest/search/listing API.
+
+Lookup must not:
+
+-   normalize identity text;
+-   perform prefix/fuzzy/case-insensitive matching;
+-   search by target;
+-   return an arbitrary version;
+-   materialize missing data;
+-   call a provider.
+
+### Multiple versions
+
+Distinct Snapshot Identities for the same Research Dataset Identity must
+coexist without replacement.
+
+Exact lookup must return only the requested immutable version.
+
+## 6. Fidelity Requirements
+
+Registration and lookup must preserve exactly the accepted
+representation semantics for:
+
+-   all four typed dataset identities;
+-   Dataset Version;
+-   identity scheme;
+-   target text;
+-   requested boundary instants and original offsets where represented;
+-   selected observation count;
+-   first/last actual observation instant semantics;
+-   empty-snapshot state;
+-   provenance;
+-   lineage;
+-   source authority;
+-   timestamp semantic instant and original offset;
+-   exact decimal values.
+
+Use the accepted WP07 records/mappers and WP08 persisted evidence where
+applicable.
+
+Do not introduce floating-point conversion, culture-sensitive
+parsing/formatting, local-time conversion, truncation, or rounding.
+
+## 7. SQL and Persistence Rules
+
+Any SQL introduced by WP09 must be:
+
+-   minimal;
+-   explicit;
+-   parameterized;
+-   deterministic;
+-   scoped to schema v2;
+-   compatible with immutable evidence.
+
+Use explicit ordering whenever reconstruction depends on ordered rows.
+Never depend on SQLite natural row order.
+
+Do not add:
+
+-   destructive upserts;
+-   `INSERT OR REPLACE`;
+-   update/delete repair paths;
+-   generic data-access frameworks;
+-   caching;
+-   background refresh;
+-   retries;
+-   resilience policies.
+
+## 8. Connection and Transaction Boundary
+
+Reuse the accepted `ISqliteConnectionFactory`.
+
+Every operation must own and deterministically dispose its connection,
+commands, readers, and transaction if one is required.
+
+Do not register or retain live SQLite connections.
+
+Use a transaction only where needed to preserve atomic catalog
+registration semantics. Explain the decision.
+
+## 9. Failure Boundary
+
+Do not perform WP11's generalized Dataset Validation & Failure Mapping
+work.
+
+WP09 may use only failure behavior already required by the existing
+`IDatasetCatalog` contract and accepted SQLite boundaries.
+
+Do not:
+
+-   invent new public failure categories;
+-   redesign WP10/WP11 failure semantics;
+-   add retryability classifications;
+-   catch arbitrary `Exception`;
+-   hide programming defects.
+
+If a failure cannot be represented without prematurely deciding WP11
+policy, preserve the existing boundary and document the WP11 handoff.
+
+## 10. Permanent Tests and Temporary Validation
+
+Permanent test expansion belongs to WP13/WP14 unless the Release 1.2
+manifest explicitly says otherwise.
+
+For WP09:
+
+-   permanent test delta should remain zero unless the manifest
+    explicitly authorizes otherwise;
+-   temporary focused offline probes are allowed;
+-   probes must be removed before completion;
+-   temporary SQLite databases/WAL/SHM/journal files must be removed.
+
+At minimum validate, using temporary focused offline evidence if
+permanent coverage does not yet exist:
+
+1.  new catalog registration;
+2.  exact lookup of a non-empty entry;
+3.  equivalent repeated registration;
+4.  contradictory same-Snapshot-Identity registration is
+    non-destructive;
+5.  valid empty snapshot registration and lookup;
+6.  multiple versions for one Research Dataset Identity coexist;
+7.  exact lookup returns only the requested version;
+8.  identity/version fidelity;
+9.  target/boundary/coverage fidelity;
+10. provenance/lineage fidelity;
+11. timestamp/offset/decimal fidelity where reconstructed from persisted
+    snapshot evidence;
+12. no provider/network calls;
+13. no temporary database residue.
+
+## 11. Explicitly Prohibited Scope
+
+WP09 must **not** start or implement:
+
+-   WP10 --- Dataset Materialization Integration;
+-   WP11 --- Dataset Validation & Failure Mapping;
+-   WP12 --- Dependency Registration & Bounded Dataset Execution;
+-   WP13/WP14 permanent test expansion beyond manifest authority;
+-   WP15 documentation alignment;
+-   WP16 integration/acceptance;
+-   Release 1.3 pipelines, scheduling, streaming, refresh, DAGs,
+    monitoring, or resilience.
+
+Also prohibited:
+
+-   Domain changes unless an unavoidable authority contradiction is
+    found;
+-   Application contract redesign unless required to resolve a proven
+    contradiction;
+-   Worker changes;
+-   package additions;
+-   project-reference additions;
+-   solution/build-script changes;
+-   schema version changes;
+-   Git staging/commit/push/branch/PR/merge/tag/release actions.
+
+## 12. Architecture Protection
+
+The production dependency graph must remain:
+
+-   Domain → none
+-   Application → Domain
+-   Infrastructure → Application
+-   Worker → Application, Infrastructure
+
+Required leakage counts after WP09:
+
+-   Domain SQLite/SQL/filesystem references: 0
+-   Application SQLite/SQL/filesystem references: 0
+-   Domain provider/HTTP mechanics: 0
+-   Application provider/HTTP mechanics: 0
+
+No new production dependency cycle is permitted.
+
+## 13. Security and Offline Constraints
+
+Execution and validation must be offline except for required GitHub
+planning-state inspection/mutation.
+
+Do not use:
+
+-   real provider calls;
+-   live market-data acquisition;
+-   real API keys;
+-   committed credentials;
+-   personal database paths;
+-   sensitive connection strings.
+
+Run the repository's canonical secret scan.
+
+## 14. GitHub Issue Lifecycle
+
+After all starting-state gates and the initial baseline pass:
+
+1.  move issue #129 from Backlog to In Progress;
+2.  perform WP09;
+3.  run all final gates;
+4.  post concise completion evidence to #129;
+5.  close #129 and set Project status to Done only if every WP09
+    acceptance gate passes.
+
+Issue #130 must remain `Open / Backlog`.
+
+Do not mutate unrelated issues, milestone fields, Project
+schema/options, labels, dependencies, priorities, releases, areas, or
+assignees.
+
+## 15. Required Final Validation
+
+Before declaring completion, run and report:
+
+-   restore;
+-   format verification;
+-   build;
+-   Domain.Tests;
+-   Application.Tests;
+-   Infrastructure.Tests;
+-   Architecture.Tests;
+-   complete permanent-test total;
+-   `eng/verify.ps1`;
+-   canonical secret scan result;
+-   `git diff --check`;
+-   `git diff --cached --check`;
+-   direct whitespace validation for relevant untracked WP09 files if
+    necessary;
+-   architecture dependency/leakage validation;
+-   Release 1.1 persistence regression;
+-   Release 1.2 snapshot-persistence regression;
+-   temporary SQLite residue check;
+-   package/reference delta;
+-   working-tree classification.
+
+Expected baseline before permanent-test work remains:
+
+-   Domain.Tests: 11
+-   Application.Tests: 42
+-   Infrastructure.Tests: 79
+-   Architecture.Tests: 13
+-   Total: 145
+
+If repository truth has legitimately changed under accepted authority,
+report the actual counts and reconcile them rather than forcing these
+numbers.
+
+## 16. WP09 Acceptance Matrix
+
+WP09 is complete only if all applicable rows pass:
+
+-   WP08 predecessor accepted;
+-   issue #129 lifecycle valid;
+-   existing `IDatasetCatalog` implemented;
+-   `DatasetCatalogEntry` reused;
+-   schema v2 reused unchanged;
+-   WP08 snapshot persistence semantics preserved;
+-   new immutable catalog registration works;
+-   equivalent existing registration works;
+-   same-identity contradictory evidence returns integrity conflict;
+-   conflict is non-destructive;
+-   exact Snapshot Identity lookup works;
+-   valid lookup miss follows existing contract;
+-   multiple immutable versions coexist;
+-   no mutable latest semantics;
+-   identity/version fidelity passes;
+-   target/boundary/coverage fidelity passes;
+-   provenance/lineage fidelity passes;
+-   valid empty snapshot works;
+-   timestamp/offset/decimal fidelity passes where applicable;
+-   deterministic SQL/ordering passes;
+-   operation-owned connections preserved;
+-   no destructive update/delete/replace behavior;
+-   provider/network calls = 0;
+-   Domain/Application SQLite leakage = 0;
+-   production graph unchanged;
+-   permanent-test delta = 0 unless manifest-authorized;
+-   package/reference delta = 0/0;
+-   temporary residue = 0;
+-   WP10 not started;
+-   Release 1.3 not started;
+-   all canonical validation passes.
+
+## 17. Required Execution Report
+
+Return a numbered execution report covering at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Predecessor/Lifecycle Gates
+7.  Issue Lifecycle
+8.  Initial Baseline
+9.  WP02 Reconciliation
+10. WP03 Reconciliation
+11. WP04 Contract Reconciliation
+12. WP05 Materialization Reconciliation
+13. WP06 Catalog Reconciliation
+14. WP07 Physical-Model Reconciliation
+15. WP08 Snapshot-Persistence Reconciliation
+16. Catalog Persistence Design
+17. Registration Algorithm
+18. New Registration Behavior
+19. Equivalent Existing Behavior
+20. Integrity Conflict Behavior
+21. Exact Lookup Behavior
+22. Lookup-Miss Behavior
+23. Multiple-Version Coexistence
+24. Identity / Version Fidelity
+25. Target / Boundary / Coverage Fidelity
+26. Provenance / Lineage Fidelity
+27. Empty Snapshot Semantics
+28. Timestamp / Offset / Decimal Fidelity
+29. SQL / Ordering Strategy
+30. Transaction Strategy
+31. Connection Ownership / Disposal
+32. Failure-Boundary Decision
+33. Exact Files Added/Modified
+34. Domain Delta
+35. Application Delta
+36. Infrastructure Delta
+37. Worker Delta
+38. Package/Reference Delta
+39. Permanent Test Delta
+40. Temporary Probe Evidence
+41. WP10/WP11/WP12 Protection
+42. Release 1.3 Protection
+43. Security / Offline Evidence
+44. Whitespace / Diff Evidence
+45. Restore / Build Evidence
+46. Permanent Test Evidence
+47. Canonical Verification
+48. Architecture Validation
+49. Release 1.1 Persistence Regression
+50. WP08 Snapshot-Persistence Regression
+51. Catalog Validation Matrix
+52. Mutation Accounting
+53. Git / GitHub Protection
+54. Planning Protection
+55. Findings / Blockers
+56. Final Repository / GitHub State
+57. WP10 Handoff
+58. Final Decision
+59. Next Authorized Work Package
+
+## 18. Terminal Markers
+
+On success, end exactly with:
+
+`RELEASE 1.2 WP09 COMPLETE`
+
+Then include:
+
+`NEXT AUTHORIZED WORK PACKAGE: WP10 — Dataset Materialization Integration — GitHub issue #130`
+
+On a blocking authority/state contradiction, end with:
+
+`RELEASE 1.2 WP09 BLOCKED`
+
+and identify the smallest corrective authority required.
+
+## 19. Execution Principle
+
+Prefer the **smallest implementation that makes the accepted Application
+catalog contract real over the accepted SQLite v2 model**.
+
+Do not redesign what WP02--WP08 have already decided.
+
+Correctness, immutability, deterministic reconstruction, exact identity
+lookup, and strict work-package boundaries take precedence over
+abstraction or convenience.

--- a/docs/roadmap/release-1.2/prompts/10-dataset-materialization-integration-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/10-dataset-materialization-integration-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read `10-dataset-materialization-integration-codex-prompt.md` completely as the sole WP10 authority and reconcile accepted WP01-WP09 state before mutation.
+Compose only the existing WP05 materialization, WP08 immutable snapshot persistence, and WP09 catalog seams with the smallest deterministic Application-owned integration boundary.
+Do not begin WP11+, add DI/Worker execution, redesign contracts/storage, add packages/tests, or introduce Release 1.3; run all required consistency, atomicity, regression, architecture, security, whitespace, build, and canonical gates.
+Do not stage, commit, push, branch, or create a PR; leave #131 Open/Backlog and preserve fail-stop and equivalent/conflict semantics.
+Close #130/mark Done only after every gate passes; otherwise report the smallest corrective authority required.

--- a/docs/roadmap/release-1.2/prompts/10-dataset-materialization-integration-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/10-dataset-materialization-integration-codex-prompt.md
@@ -1,0 +1,655 @@
+# Release 1.2 WP10 --- Dataset Materialization Integration --- Codex Execution Authority
+
+## 1. Authority
+
+You are authorized to execute **Release 1.2 WP10 --- Dataset
+Materialization Integration** for:
+
+-   Repository: `samuel-santos-engineer/AIQuantTradingResearch`
+-   GitHub issue: `#130`
+-   Milestone:
+    `#53 — Phase 3 - Release 1.2: Research Dataset Foundation`
+-   Project: `#2 — AIQuantTradingResearch Engineering Roadmap`
+
+This prompt is the execution authority for WP10. Interpret it together
+with:
+
+-   `RELEASE_1.2_EXECUTION_PLAN.md`
+-   `RELEASE_1.2_FILE_MANIFEST.md`
+-   accepted WP01--WP09 artifacts and execution evidence
+-   `docs/architecture/data/RESEARCH_DATASET_DEFINITION.md`
+-   `docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md`
+-   current Application dataset contracts
+-   accepted WP05 materialization use case
+-   accepted WP06 catalog model
+-   accepted WP07 SQLite schema-v2 physical model
+-   accepted WP08 snapshot persistence
+-   accepted WP09 catalog persistence and exact lookup
+-   accepted Release 1.1 historical-observation persistence/retrieval
+    foundation
+
+If these authorities materially conflict, stop before mutation and
+report the conflict plus the smallest corrective authority required.
+
+## 2. Objective
+
+Implement the **minimum bounded Application integration required to
+execute one complete dataset materialization workflow** using the
+already accepted Release 1.2 seams.
+
+WP10 must integrate, without redesigning:
+
+1.  deterministic dataset materialization from accepted Release 1.1
+    historical observations;
+2.  immutable dataset snapshot persistence;
+3.  immutable catalog registration;
+4.  exact persisted/catalog evidence consistency;
+5.  bounded success/equivalence/conflict/failure results.
+
+The integration must orchestrate existing contracts and implementations.
+It must not create a second identity model, persistence model, catalog
+model, storage schema, or Worker execution flow.
+
+## 3. Required Starting-State Gates
+
+Before changing anything, verify and report:
+
+1.  Repository is exactly
+    `samuel-santos-engineer/AIQuantTradingResearch`.
+2.  Branch is `main`.
+3.  Local `main` equals `origin/main`; report both SHAs and
+    ahead/behind.
+4.  Staged paths are zero.
+5.  Every working-tree path is classified as accepted cumulative Release
+    1.2 work or explicitly authorized WP10 work.
+6.  Unexpected/ambiguous paths are zero.
+7.  Release 1.1 remains closed and accepted.
+8.  Milestone #53 is open.
+9.  WP05 issue #125 is Closed/Done.
+10. WP08 issue #128 is Closed/Done.
+11. WP09 issue #129 is Closed/Done.
+12. WP10 issue #130 is Open/Backlog.
+13. WP11 issue #131 is Open/Backlog.
+14. WP10 dependencies are exactly the authoritative dependencies: WP05,
+    WP08, WP09.
+15. No Release 1.3 implementation has started.
+16. Restore, format, build, permanent tests, architecture tests,
+    canonical verification, and Git whitespace checks pass before
+    mutation.
+
+Do not move #130 to In Progress until every starting-state gate passes.
+
+If a gate fails, stop without repository/GitHub mutation and end with:
+
+`RELEASE 1.2 WP10 BLOCKED`
+
+## 4. Mandatory Reconciliation
+
+### WP02 --- Dataset semantics
+
+Preserve:
+
+-   exact target;
+-   `[from, to)` selection;
+-   deterministic ascending semantic-instant ordering;
+-   valid successful empty materialization;
+-   immutable snapshot semantics;
+-   exact timestamp-offset and decimal fidelity.
+
+### WP03 --- Identity/version/provenance
+
+Preserve the four typed identities:
+
+-   Dataset Definition Identity;
+-   Research Dataset Identity;
+-   Source State Identity;
+-   Dataset Snapshot Identity.
+
+Preserve:
+
+-   Dataset Version = Snapshot Identity;
+-   `aiq-dataset-identity-v1`;
+-   deterministic identity computation;
+-   provenance and narrow lineage;
+-   immutable identities;
+-   equivalent rematerialization semantics;
+-   integrity-conflict semantics.
+
+WP10 must not recompute identities independently of the accepted WP05
+materialization behavior.
+
+### WP04 --- Application contracts
+
+Reuse the accepted dataset contracts and bounded result/failure
+vocabulary.
+
+Do not introduce Infrastructure types into Application.
+
+If integration requires an Application-owned orchestration contract,
+keep it minimal and aligned with the file manifest.
+
+### WP05 --- Materialization
+
+`IMaterializeDatasetUseCase` / `MaterializeDatasetUseCase` remain
+authoritative for producing a deterministic `DatasetSnapshotCandidate`.
+
+WP10 must not duplicate:
+
+-   historical observation retrieval;
+-   `[from,to)` filtering;
+-   ordering;
+-   identity computation;
+-   coverage construction;
+-   provenance construction;
+-   lineage construction.
+
+### WP06 --- Catalog model
+
+`DatasetCatalogEntry` remains the authoritative catalog descriptor.
+
+Do not add mutable latest/status/operational metadata.
+
+### WP07 --- Physical storage
+
+SQLite schema v2 is fixed.
+
+WP10 must not change schema version, tables, columns, constraints,
+indexes, records, or physical encoding unless a proven authority
+contradiction requires stopping.
+
+### WP08 --- Snapshot persistence
+
+`IDatasetSnapshotStore` and `SqliteDatasetSnapshotStore` own immutable
+snapshot persistence.
+
+Preserve:
+
+-   `NewlyAccepted`;
+-   `EquivalentExisting`;
+-   `IntegrityConflict`;
+-   atomicity;
+-   immutability;
+-   empty snapshots;
+-   multiple-version coexistence;
+-   fidelity.
+
+### WP09 --- Catalog persistence
+
+`IDatasetCatalog` and `SqliteDatasetCatalog` own catalog registration
+and exact Snapshot Identity lookup.
+
+Preserve:
+
+-   `NewlyRegistered`;
+-   `EquivalentExisting`;
+-   `IntegrityConflict`;
+-   exact lookup;
+-   `NotFound`;
+-   immutable evidence.
+
+WP10 must not add new catalog SQL or duplicate catalog persistence.
+
+## 5. Integration Boundary
+
+Implement one focused Application-owned integration/use-case boundary
+whose responsibility is:
+
+1.  accept an existing `DatasetDefinition`;
+2.  invoke the accepted materialization use case;
+3.  if materialization fails, stop and propagate/map only according to
+    existing authorized Application semantics;
+4.  persist the resulting immutable snapshot candidate through
+    `IDatasetSnapshotStore`;
+5.  register the corresponding `DatasetCatalogEntry` through
+    `IDatasetCatalog`;
+6.  reconcile persistence and catalog outcomes deterministically;
+7.  return one bounded integration result that distinguishes successful
+    new acceptance, equivalent existing evidence, integrity conflict,
+    and authorized failure conditions.
+
+Prefer composition of existing contracts over new abstractions.
+
+Do not perform DI registration or Worker invocation; WP12 owns
+composition/execution.
+
+## 6. Consistency Model
+
+The integration must explicitly define and implement the consistency
+relationship between snapshot persistence and catalog registration.
+
+Required invariants:
+
+-   catalog registration must never describe evidence contradictory to
+    the accepted snapshot candidate;
+-   a catalog entry must be constructed from the exact accepted
+    materialization candidate;
+-   same Snapshot Identity with contradictory evidence must never be
+    overwritten;
+-   equivalent existing snapshot/catalog evidence must be accepted
+    deterministically;
+-   multiple versions of one Research Dataset must coexist;
+-   no mutable latest pointer is introduced;
+-   successful integration must leave snapshot evidence and catalog
+    evidence semantically consistent.
+
+First reconcile the actual WP08/WP09 implementation. Because WP09
+delegates registration to the accepted snapshot store, do not invent a
+distributed-transaction problem if repository truth shows both seams
+converge on the same immutable evidence.
+
+Document the observed consistency model and use the smallest
+orchestration compatible with it.
+
+## 7. Outcome Reconciliation
+
+Define the minimum deterministic outcome matrix using the existing
+WP08/WP09 vocabularies.
+
+At minimum reason about:
+
+### New candidate
+
+If snapshot persistence accepts new evidence and catalog registration
+registers/equates the same evidence, return the appropriate successful
+integrated outcome.
+
+### Equivalent rematerialization
+
+If the same deterministic candidate already exists and catalog evidence
+is equivalent, return an equivalent/idempotent successful outcome. Do
+not create another semantic version.
+
+### Integrity conflict
+
+Any contradiction under the same Snapshot Identity must produce an
+integrity-conflict result and must not overwrite evidence.
+
+### Materialization failure
+
+A materialization failure must prevent snapshot/catalog mutation.
+
+### Snapshot persistence failure
+
+If snapshot persistence returns an authorized failure, catalog
+registration must not proceed unless existing contract semantics make
+doing so provably safe and required. Prefer fail-stop behavior.
+
+### Catalog registration failure
+
+Handle only according to currently authorized contracts. Do not redesign
+generalized validation/failure mapping owned by WP11.
+
+The final report must include the exact integration outcome matrix
+derived from repository truth.
+
+## 8. Idempotency and Re-execution
+
+Equivalent execution of the same definition against the same relevant
+source state must:
+
+-   produce the same semantic identities and Dataset Version;
+-   preserve the same snapshot evidence;
+-   preserve the same catalog evidence;
+-   never overwrite;
+-   never create a new semantic version;
+-   return deterministic equivalent-success semantics.
+
+Re-execution after a relevant source-state change may produce a distinct
+Snapshot Identity/version while retaining earlier immutable evidence.
+
+## 9. Empty Materialization
+
+A valid empty materialization must flow through the complete
+integration:
+
+-   materialization succeeds with zero selected observations;
+-   immutable snapshot evidence is accepted/equated;
+-   catalog metadata represents count zero and absent actual first/last
+    observation instants;
+-   exact catalog lookup can represent the accepted empty snapshot;
+-   equivalent re-execution remains deterministic.
+
+No sentinel observation or fake timestamp may be introduced.
+
+## 10. Fidelity
+
+WP10 must preserve without transformation:
+
+-   exact target;
+-   requested boundaries;
+-   selected observation membership;
+-   semantic instant;
+-   original `DateTimeOffset` offset;
+-   exact decimal value;
+-   all four identities;
+-   Dataset Version;
+-   coverage;
+-   provenance;
+-   lineage;
+-   source authority.
+
+No culture-sensitive formatting, local-time conversion, floating-point
+intermediary, truncation, or rounding.
+
+## 11. Failure Boundary
+
+WP11 owns generalized Dataset Validation & Failure Mapping.
+
+WP10 may only define/map the minimum integration-level outcomes
+necessary to compose existing Application contracts.
+
+Do not:
+
+-   create a comprehensive SQLite failure classifier;
+-   add retries;
+-   add resilience policies;
+-   add arbitrary exception swallowing;
+-   catch `Exception`;
+-   invent provider retry semantics;
+-   convert integrity conflicts into success;
+-   collapse distinct existing failures without explicit semantic
+    justification.
+
+Unknown/unowned failures should remain visible for WP11 rather than
+being falsely classified.
+
+## 12. Files and Layer Ownership
+
+Follow `RELEASE_1.2_FILE_MANIFEST.md` exactly.
+
+Expected WP10 changes should be concentrated in Application
+integration/use-case files.
+
+Do not change Domain, Infrastructure, or Worker merely for convenience.
+
+Infrastructure changes are prohibited unless the accepted contracts
+cannot be integrated due to a proven defect. If such a defect is
+discovered, stop and report the authority conflict rather than silently
+expanding WP10.
+
+Do not add packages or project references.
+
+## 13. Permanent Tests and Temporary Probes
+
+Permanent test expansion remains owned by WP13/WP14 unless the manifest
+explicitly authorizes otherwise.
+
+Expected WP10 permanent-test delta: `0`.
+
+Temporary offline probes are allowed and must be removed before
+completion.
+
+Focused validation must prove at least:
+
+1.  new non-empty materialization integrates successfully;
+2.  equivalent re-execution is deterministic/idempotent;
+3.  relevant source-state change can produce a distinct immutable
+    version;
+4.  valid empty materialization integrates successfully;
+5.  materialization failure causes no snapshot/catalog mutation;
+6.  snapshot integrity conflict is non-destructive;
+7.  catalog integrity conflict is non-destructive if representable
+    independently;
+8.  exact catalog lookup after success returns equivalent accepted
+    evidence;
+9.  identities/version remain unchanged across boundaries;
+10. target/boundary/coverage fidelity;
+11. provenance/lineage fidelity;
+12. timestamp/offset/decimal fidelity;
+13. multiple versions coexist;
+14. no provider/network call;
+15. no temporary SQLite residue.
+
+Use hand-written stubs/fakes at Application boundaries where that
+provides clearer deterministic integration proof. Use real offline
+SQLite only if needed to prove the existing concrete seams work
+together, without turning WP10 into WP14.
+
+## 14. Explicitly Prohibited Scope
+
+Do not start:
+
+-   WP11 --- Dataset Validation & Failure Mapping;
+-   WP12 --- Dependency Registration & Bounded Dataset Execution;
+-   WP13 --- Domain & Application Dataset Tests;
+-   WP14 --- Infrastructure & Dataset Tests;
+-   WP15 --- Architecture & Documentation Alignment;
+-   WP16 --- Full Validation, Integration & Acceptance;
+-   Release 1.3.
+
+Do not add:
+
+-   Worker execution;
+-   DI registration;
+-   configuration keys;
+-   scheduling;
+-   loops/background services;
+-   automatic refresh;
+-   streaming;
+-   pipelines/DAGs;
+-   monitoring;
+-   retries/circuit breakers;
+-   schema v3;
+-   mutable latest pointers;
+-   new catalog search/list APIs;
+-   provider acquisition behavior.
+
+Do not stage, commit, push, branch, create a PR, merge, tag, or release.
+
+## 15. Architecture Protection
+
+Production graph must remain:
+
+-   Domain → none
+-   Application → Domain
+-   Infrastructure → Application
+-   Worker → Application, Infrastructure
+
+Required leakage after WP10:
+
+-   Domain SQLite/SQL/filesystem: 0
+-   Application SQLite/SQL/filesystem: 0
+-   Domain provider/HTTP: 0
+-   Application provider/HTTP: 0
+
+Production dependency cycles: 0.
+
+## 16. Security and Offline Execution
+
+Validation must remain offline except for GitHub lifecycle
+inspection/mutation.
+
+No:
+
+-   real provider calls;
+-   real API keys;
+-   secrets;
+-   personal paths committed to source;
+-   external market-data acquisition.
+
+Run canonical secret scanning.
+
+## 17. GitHub Lifecycle
+
+After all starting gates and initial validation pass:
+
+1.  move #130 Backlog → In Progress;
+2.  execute WP10;
+3.  complete all validation;
+4.  post concise evidence to #130;
+5.  close #130 and set Project status Done only after all acceptance
+    gates pass.
+
+Issue #131 must remain Open/Backlog.
+
+Do not mutate unrelated planning objects.
+
+## 18. Required Final Validation
+
+Before completion, run and report:
+
+-   restore;
+-   format verification;
+-   build;
+-   Domain.Tests;
+-   Application.Tests;
+-   Infrastructure.Tests;
+-   Architecture.Tests;
+-   total permanent tests;
+-   `eng/verify.ps1`;
+-   secret scan;
+-   `git diff --check`;
+-   `git diff --cached --check`;
+-   direct whitespace checks for relevant untracked WP10 files;
+-   architecture/leakage validation;
+-   Release 1.1 persistence regression;
+-   WP08 snapshot-persistence regression;
+-   WP09 catalog regression;
+-   integration validation matrix;
+-   temporary SQLite residue;
+-   package/reference delta;
+-   working-tree classification.
+
+Expected permanent baseline if unchanged:
+
+-   Domain.Tests: 11
+-   Application.Tests: 42
+-   Infrastructure.Tests: 79
+-   Architecture.Tests: 13
+-   Total: 145
+
+Reconcile legitimate accepted changes rather than forcing stale counts.
+
+## 19. Acceptance Matrix
+
+WP10 completes only if all applicable rows pass:
+
+-   WP05/WP08/WP09 dependencies accepted;
+-   issue #130 lifecycle valid;
+-   existing materialization use case reused;
+-   existing snapshot store reused;
+-   existing catalog reused;
+-   no duplicate identity computation;
+-   no duplicate snapshot persistence;
+-   no duplicate catalog persistence;
+-   bounded integration contract/use case implemented;
+-   new candidate integration passes;
+-   equivalent rematerialization passes;
+-   deterministic idempotency passes;
+-   relevant source-state change/version coexistence passes;
+-   empty materialization passes;
+-   materialization failure causes no persistence/catalog mutation;
+-   snapshot conflict remains non-destructive;
+-   catalog conflict remains non-destructive;
+-   exact catalog evidence after success passes;
+-   identities/version fidelity passes;
+-   target/boundary/coverage fidelity passes;
+-   provenance/lineage fidelity passes;
+-   timestamp/offset/decimal fidelity passes;
+-   consistency model explicitly reconciled;
+-   Domain/Application storage leakage = 0;
+-   provider/network calls = 0;
+-   production graph unchanged;
+-   permanent-test delta = 0 unless manifest-authorized;
+-   package/reference delta = 0/0;
+-   temporary residue = 0;
+-   WP11 not started;
+-   Release 1.3 not started;
+-   canonical validation passes.
+
+## 20. Required Execution Report
+
+Return a numbered report covering at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Predecessor/Lifecycle Gates
+7.  Issue Lifecycle
+8.  Initial Baseline
+9.  WP02 Semantic Reconciliation
+10. WP03 Identity Reconciliation
+11. WP04 Contract Reconciliation
+12. WP05 Materialization Reconciliation
+13. WP06 Catalog-Model Reconciliation
+14. WP07 Physical-Model Reconciliation
+15. WP08 Snapshot-Persistence Reconciliation
+16. WP09 Catalog-Persistence Reconciliation
+17. Integration Boundary Design
+18. Integration Contract/Use-Case Design
+19. Consistency Model
+20. New Candidate Flow
+21. Equivalent Re-materialization Flow
+22. Relevant Source-State Change Flow
+23. Empty Materialization Flow
+24. Materialization Failure Flow
+25. Snapshot Persistence Failure/Conflict Flow
+26. Catalog Registration Failure/Conflict Flow
+27. Outcome Reconciliation Matrix
+28. Exact Catalog Evidence Validation
+29. Identity / Version Fidelity
+30. Target / Boundary / Coverage Fidelity
+31. Provenance / Lineage Fidelity
+32. Timestamp / Offset / Decimal Fidelity
+33. Idempotency / Re-execution Evidence
+34. Multiple-Version Coexistence
+35. Failure-Boundary Decision
+36. Exact Files Added/Modified
+37. Domain Delta
+38. Application Delta
+39. Infrastructure Delta
+40. Worker Delta
+41. Package/Reference Delta
+42. Permanent Test Delta
+43. Temporary Probe Evidence
+44. WP11/WP12 Protection
+45. Release 1.3 Protection
+46. Security / Offline Evidence
+47. Whitespace / Diff Evidence
+48. Restore / Build Evidence
+49. Permanent Test Evidence
+50. Canonical Verification
+51. Architecture Validation
+52. Release 1.1 Persistence Regression
+53. WP08 Snapshot-Persistence Regression
+54. WP09 Catalog Regression
+55. Integration Validation Matrix
+56. Mutation Accounting
+57. Git / GitHub Protection
+58. Planning Protection
+59. Findings / Blockers
+60. Final Repository / GitHub State
+61. WP11 Handoff
+62. Final Decision
+63. Next Authorized Work Package
+
+## 21. Terminal Markers
+
+On success end exactly with:
+
+`RELEASE 1.2 WP10 COMPLETE`
+
+Then:
+
+`NEXT AUTHORIZED WORK PACKAGE: WP11 — Dataset Validation & Failure Mapping — GitHub issue #131`
+
+If blocked, end with:
+
+`RELEASE 1.2 WP10 BLOCKED`
+
+and state the smallest corrective authority required.
+
+## 22. Execution Principle
+
+WP10 is an **integration work package, not a redesign work package**.
+
+Use GPT-5.6 Sol's deeper reasoning to reconcile the already accepted
+boundaries before mutation, especially the relationship among
+materialization, snapshot persistence, and catalog registration.
+
+Prefer the smallest deterministic orchestration that composes WP05 +
+WP08 + WP09 while preserving all accepted semantics and leaving
+generalized validation/failure mapping, DI, Worker execution, and
+permanent coverage to their assigned later work packages.

--- a/docs/roadmap/release-1.2/prompts/11-dataset-validation-failure-mapping-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/11-dataset-validation-failure-mapping-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read `11-dataset-validation-failure-mapping-codex-prompt.md` completely as the sole WP11 authority and reconcile accepted WP01-WP10 state before mutation.
+Harden only established dataset validation/failure boundaries, preserving integrity conflict, NotFound, equivalence, schema-v2, immutability, and WP10 orchestration semantics.
+Do not begin WP12+, add DI/Worker behavior, redesign contracts/storage, add packages/tests, or perform Git transport; run all required failure, atomicity, fidelity, regression, architecture, security, whitespace, build, and canonical gates.
+Do not stage, commit, push, branch, or open a PR; leave #132 Open/Backlog and preserve unknown-failure propagation without catch-all normalization.
+Close #131/mark Done only after every gate passes; otherwise stop with the exact blocker and smallest corrective authority.

--- a/docs/roadmap/release-1.2/prompts/11-dataset-validation-failure-mapping-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/11-dataset-validation-failure-mapping-codex-prompt.md
@@ -1,0 +1,667 @@
+# Release 1.2 WP11 --- Dataset Validation & Failure Mapping --- Codex Execution Authority
+
+## 1. Authority
+
+You are authorized to execute **Release 1.2 WP11 --- Dataset Validation
+& Failure Mapping** for:
+
+-   Repository: `samuel-santos-engineer/AIQuantTradingResearch`
+-   GitHub issue: `#131`
+-   Milestone:
+    `#53 — Phase 3 - Release 1.2: Research Dataset Foundation`
+-   Project: `#2 — AIQuantTradingResearch Engineering Roadmap`
+
+This prompt is the execution authority for WP11. Interpret it together
+with:
+
+-   `RELEASE_1.2_EXECUTION_PLAN.md`
+-   `RELEASE_1.2_FILE_MANIFEST.md`
+-   accepted WP01--WP10 artifacts and execution evidence
+-   `docs/architecture/data/RESEARCH_DATASET_DEFINITION.md`
+-   `docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md`
+-   current Application dataset contracts and materialization
+    integration
+-   accepted Release 1.1 persistence/failure semantics
+-   accepted WP07 SQLite schema v2
+-   accepted WP08 snapshot persistence
+-   accepted WP09 catalog persistence/lookup
+-   accepted WP10 dataset materialization integration
+
+If these authorities materially conflict, stop before mutation and
+report the conflict and the smallest corrective authority required.
+
+## 2. Objective
+
+Implement the **minimum bounded dataset validation and failure-mapping
+behavior** required to make the accepted Release 1.2 dataset workflow
+deterministic and contained at its established
+Application/Infrastructure boundaries.
+
+WP11 must refine validation and failure handling without redesigning:
+
+-   dataset definition semantics;
+-   identity/version/provenance semantics;
+-   Application dataset contracts except where the accepted failure
+    vocabulary explicitly requires minimal completion;
+-   materialization;
+-   SQLite schema v2;
+-   snapshot persistence;
+-   catalog persistence;
+-   WP10 integration orchestration.
+
+The goal is to ensure invalid semantic inputs/evidence and known storage
+failures are represented by the accepted bounded contracts rather than
+leaking raw provider/storage mechanics across architectural boundaries.
+
+## 3. Required Starting-State Gates
+
+Before changing anything, verify and report:
+
+1.  Repository identity is exactly
+    `samuel-santos-engineer/AIQuantTradingResearch`.
+2.  Current branch is `main`.
+3.  Local `main` equals `origin/main`; report both SHAs and
+    ahead/behind.
+4.  Staged paths are zero.
+5.  Every working-tree path is classified as accepted cumulative Release
+    1.2 work or explicitly authorized WP11 work.
+6.  Unexpected/ambiguous paths are zero.
+7.  Release 1.1 remains closed and accepted.
+8.  Milestone #53 is open.
+9.  WP10 issue #130 is Closed/Done.
+10. WP11 issue #131 is Open/Backlog.
+11. WP12 issue #132 is Open/Backlog.
+12. WP11 dependency is exactly WP10 according to authoritative planning.
+13. No Release 1.3 implementation has started.
+14. Restore, format verification, build, permanent tests, architecture
+    tests, canonical verification, secret scan, and Git whitespace
+    checks pass before mutation.
+
+Do not move #131 to In Progress until every starting-state gate passes.
+
+If any starting-state gate fails, stop without repository or GitHub
+mutation and end with:
+
+`RELEASE 1.2 WP11 BLOCKED`
+
+## 4. Mandatory Reconciliation Before Mutation
+
+### WP02 --- Dataset semantics
+
+Preserve:
+
+-   exact target identity;
+-   explicit valid `[from, to)` boundaries;
+-   deterministic ascending semantic-instant ordering;
+-   valid successful empty materialization;
+-   immutable snapshot semantics;
+-   exact timestamp/offset and decimal fidelity.
+
+Validation must reject invalid data; it must not normalize invalid data
+into another valid semantic value.
+
+### WP03 --- Identity/version/provenance
+
+Preserve:
+
+-   Dataset Definition Identity;
+-   Research Dataset Identity;
+-   Source State Identity;
+-   Dataset Snapshot Identity;
+-   Dataset Version = Snapshot Identity;
+-   `aiq-dataset-identity-v1`;
+-   canonical identity representation;
+-   immutable identity assignment;
+-   integrity-conflict semantics;
+-   provenance and narrow lineage.
+
+Do not silently recompute or repair contradictory persisted identity
+evidence.
+
+### WP04 --- Application contracts
+
+Inventory the currently accepted dataset result/failure vocabularies
+before changing anything.
+
+Reuse existing public failure categories whenever they can represent
+WP11 semantics correctly.
+
+Do not create storage-specific public failures or expose SQLite
+exceptions/types.
+
+Any public contract refinement must be the smallest change required by
+the accepted execution plan/file manifest and must remain
+Application-owned and provider/storage independent.
+
+### WP05 --- Materialization
+
+Preserve deterministic materialization and existing source-history
+mapping.
+
+WP11 must not duplicate materialization or identity computation.
+
+### WP06 --- Catalog model
+
+Preserve immutable `DatasetCatalogEntry` semantics.
+
+Invalid catalog evidence must not be normalized, repaired, or assigned
+mutable operational metadata.
+
+### WP07 --- Physical model
+
+Schema v2 is fixed.
+
+No schema version, table, column, index, constraint, record-layout,
+migration, or mapper redesign is authorized unless a contradiction
+requires stopping.
+
+### WP08 --- Snapshot persistence
+
+Preserve immutable, atomic, insert-only snapshot semantics.
+
+Inventory its current failure behavior and identify which known
+SQLite/row-validation failures require bounded mapping.
+
+### WP09 --- Catalog persistence
+
+Preserve exact lookup, immutable registration, equivalent-existing
+behavior, integrity conflicts, and lookup misses.
+
+Do not create search/list/latest semantics.
+
+### WP10 --- Integration
+
+Preserve the accepted integration flow and outcome matrix.
+
+WP11 may refine failure propagation/mapping where explicitly required,
+but must not redesign orchestration.
+
+The accepted high-level sequence remains:
+
+`materialize → snapshot persistence → catalog registration`
+
+## 5. Validation Taxonomy
+
+Establish the smallest explicit validation taxonomy consistent with
+existing contracts.
+
+At minimum distinguish conceptually:
+
+### Semantic invalidity
+
+Examples include, where reachable at the relevant boundary:
+
+-   invalid/blank target;
+-   invalid `[from, to)` boundaries;
+-   malformed identity fingerprint/scheme;
+-   Dataset Version inconsistent with Snapshot Identity;
+-   inconsistent count/coverage;
+-   inconsistent provenance or lineage;
+-   duplicate or non-ascending semantic instants;
+-   contradictory target/definition/candidate/catalog facts;
+-   invalid timestamp/offset representation;
+-   invalid decimal representation/value;
+-   malformed persisted dataset evidence.
+
+Use existing constructors/contracts as the first validation boundary. Do
+not duplicate checks merely to create another validation layer.
+
+### Availability/storage failure
+
+Known transient/operational SQLite failures that prevent required
+persistence/lookup should map to the existing bounded
+unavailable/storage-unavailable semantics where authorized.
+
+Do not infer retryability or add retry policy.
+
+### Integrity conflict
+
+Contradictory immutable evidence under the same semantic identity
+remains an integrity conflict, not availability failure and not success.
+
+### Not found
+
+An exact catalog miss remains the accepted `NotFound` behavior. Do not
+classify an ordinary miss as corruption or unavailability.
+
+### Programming/unknown failure
+
+Programming defects and unknown/unclassified failures must not be
+swallowed or falsely converted into a public failure.
+
+## 6. Failure-Mapping Boundary
+
+Keep provider/storage mechanics inside Infrastructure.
+
+Where known SQLite failures arise in dataset snapshot/catalog
+persistence:
+
+-   map only explicitly recognized SQLite failure classes/codes;
+-   use the accepted dataset failure vocabulary;
+-   preserve semantic conflicts as semantic outcomes;
+-   preserve exact lookup misses;
+-   map malformed persisted dataset rows/evidence to the accepted
+    invalid/integrity failure only if the current contracts authorize
+    that distinction;
+-   allow unknown SQLite codes to propagate rather than guessing;
+-   do not catch arbitrary `Exception`.
+
+Follow the established Release 1.1 failure-mapping discipline where
+semantically applicable, but do not mechanically copy
+observation-specific behavior if dataset contracts differ.
+
+The final report must state the exact SQLite/error categories mapped and
+the reason for each mapping.
+
+## 7. Application Validation Boundary
+
+Application validation should remain focused on semantic contracts and
+orchestration.
+
+Do not add Infrastructure-aware validation.
+
+Where accepted constructors already make invalid states unrepresentable,
+document that as the validation mechanism instead of adding redundant
+validators.
+
+Where WP10 integration can receive an authorized failure from a lower
+seam, map/propagate it deterministically according to the existing
+integration contract.
+
+Do not collapse:
+
+-   integrity conflict into unavailable;
+-   unavailable into integrity conflict;
+-   not-found into invalid data;
+-   successful equivalence into conflict.
+
+## 8. Persisted-Evidence Validation
+
+When reconstructing persisted snapshot/catalog evidence, malformed or
+contradictory stored data must never be:
+
+-   skipped;
+-   repaired;
+-   normalized;
+-   overwritten;
+-   partially returned as successful evidence.
+
+If reconstruction cannot produce a valid accepted Application model,
+return/map the authorized bounded invalid/integrity failure where the
+contract supports it; otherwise preserve the failure for the correct
+boundary and report the handoff.
+
+No partial snapshot/catalog result is permitted after a classified
+reconstruction failure.
+
+## 9. Atomicity and Immutability Protection
+
+WP11 must preserve:
+
+-   WP08 transaction atomicity;
+-   insert-only immutable snapshot evidence;
+-   equivalent-existing behavior;
+-   non-destructive integrity conflicts;
+-   coexistence of multiple versions;
+-   no update/delete/replace/repair path.
+
+Failure mapping must not turn a failed transaction into partial success.
+
+## 10. Fidelity Protection
+
+Validation/failure handling must not alter:
+
+-   target text;
+-   requested boundaries;
+-   observation membership/order;
+-   UTC semantic instant;
+-   original `DateTimeOffset` offset;
+-   exact decimal value;
+-   four dataset identities;
+-   Dataset Version;
+-   coverage;
+-   provenance;
+-   lineage;
+-   source authority.
+
+No culture-sensitive conversion, local-time conversion, floating-point
+intermediary, rounding, or truncation.
+
+## 11. Connection and Disposal Protection
+
+Reuse the accepted `ISqliteConnectionFactory` and operation-owned
+connection model.
+
+No live SQLite connection may be retained in DI or shared as mutable
+state.
+
+Connections, transactions, commands, and readers must remain
+deterministically disposed.
+
+WP11 must not introduce connection pooling policy, retry policy, or
+resilience behavior.
+
+## 12. Expected File Scope
+
+Follow `RELEASE_1.2_FILE_MANIFEST.md` exactly.
+
+Prefer the smallest changes to existing dataset persistence/integration
+files needed to complete validation/failure mapping.
+
+Likely authorized areas are:
+
+-   Application dataset failure/result contracts only if the manifest
+    and current vocabulary require minimal refinement;
+-   Infrastructure SQLite dataset snapshot/catalog implementation for
+    bounded failure mapping;
+-   WP10 Application integration only if necessary to propagate an
+    already-authorized failure correctly.
+
+Do not change Domain or Worker.
+
+Do not add packages, project references, solution changes, build-script
+changes, schema changes, or configuration.
+
+If correct implementation requires any prohibited expansion, stop and
+report the authority conflict.
+
+## 13. Permanent Tests and Temporary Validation
+
+Permanent test expansion remains owned by WP13/WP14 unless the manifest
+explicitly authorizes WP11 test changes.
+
+Expected permanent-test delta: `0`.
+
+Temporary focused offline probes are allowed and must be removed before
+completion.
+
+At minimum prove, as applicable to repository truth:
+
+1.  invalid semantic input is rejected deterministically;
+2.  malformed identity/version relationship cannot be accepted;
+3.  contradictory immutable evidence remains `IntegrityConflict`;
+4.  known SQLite operational failure maps to the authorized unavailable
+    failure;
+5.  malformed persisted dataset evidence maps to the authorized
+    invalid/integrity failure if supported;
+6.  unknown SQLite failure is not falsely classified;
+7.  exact catalog `NotFound` remains distinct;
+8.  equivalent existing evidence remains successful equivalence;
+9.  failed snapshot persistence prevents catalog registration;
+10. no partial evidence after failure;
+11. atomicity remains intact;
+12. valid empty snapshot remains successful;
+13. exact target/boundary/coverage fidelity remains intact;
+14. provenance/lineage remains intact;
+15. timestamp/offset/decimal fidelity remains intact;
+16. no provider/network calls;
+17. temporary database residue is zero.
+
+Do not create artificial production hooks solely to force failures for
+probes.
+
+## 14. Explicitly Prohibited Scope
+
+WP11 must not start:
+
+-   WP12 --- Dependency Registration & Bounded Dataset Execution;
+-   WP13 --- Domain & Application Dataset Tests;
+-   WP14 --- Infrastructure & Dataset Tests;
+-   WP15 --- Architecture & Documentation Alignment;
+-   WP16 --- Full Validation, Integration & Acceptance;
+-   Release 1.3.
+
+Also prohibited:
+
+-   DI registration;
+-   Worker execution;
+-   new configuration keys;
+-   schema v3;
+-   migrations;
+-   new persistence/catalog abstraction;
+-   mutable latest semantics;
+-   provider acquisition;
+-   retries;
+-   circuit breakers;
+-   timeout policy;
+-   scheduling;
+-   background execution;
+-   streaming;
+-   pipelines/DAGs;
+-   monitoring;
+-   caching;
+-   destructive repair.
+
+Do not stage, commit, push, branch, create a PR, merge, tag, or release.
+
+## 15. Architecture Protection
+
+Production dependency graph must remain:
+
+-   Domain → none
+-   Application → Domain
+-   Infrastructure → Application
+-   Worker → Application, Infrastructure
+
+Required leakage counts:
+
+-   Domain SQLite/SQL/filesystem references: 0
+-   Application SQLite/SQL/filesystem references: 0
+-   Domain provider/HTTP mechanics: 0
+-   Application provider/HTTP mechanics: 0
+
+Production dependency cycles: 0.
+
+## 16. Security and Offline Constraints
+
+Validation must remain offline except for required GitHub planning
+inspection/mutation.
+
+Do not use:
+
+-   real market-data provider calls;
+-   real API keys;
+-   credentials;
+-   sensitive connection strings;
+-   committed personal paths.
+
+Run the canonical Gitleaks/secret scan.
+
+## 17. GitHub Lifecycle
+
+After every starting-state and baseline gate passes:
+
+1.  move issue #131 Backlog → In Progress;
+2.  execute WP11;
+3.  run all final gates;
+4.  post concise completion evidence to #131;
+5.  close #131 and set Project status Done only if all acceptance gates
+    pass.
+
+Issue #132 must remain Open/Backlog.
+
+Do not mutate unrelated issues, milestone metadata, Project
+schema/options, labels, dependencies, priorities, Release, Area, or
+assignee fields.
+
+## 18. Required Final Validation
+
+Before declaring completion, run and report:
+
+-   restore;
+-   format verification;
+-   build;
+-   Domain.Tests;
+-   Application.Tests;
+-   Infrastructure.Tests;
+-   Architecture.Tests;
+-   total permanent tests;
+-   `eng/verify.ps1`;
+-   canonical secret scan;
+-   `git diff --check`;
+-   `git diff --cached --check`;
+-   direct whitespace checks for relevant untracked WP11 files;
+-   architecture dependency/leakage validation;
+-   Release 1.1 persistence regression;
+-   WP08 snapshot-persistence regression;
+-   WP09 catalog regression;
+-   WP10 integration regression;
+-   WP11 validation/failure matrix;
+-   temporary SQLite residue;
+-   package/reference delta;
+-   final working-tree classification.
+
+Expected permanent baseline if unchanged:
+
+-   Domain.Tests: 11
+-   Application.Tests: 42
+-   Infrastructure.Tests: 79
+-   Architecture.Tests: 13
+-   Total: 145
+
+The WP10 report recorded a local Windows Application Control observation
+affecting a generated Debug Architecture.Tests DLL after mutation while
+the isolated Release architecture suite and full Release canonical
+workflow passed. Treat environment-specific recurrence as evidence to
+report, not authority to alter repository/system security policy. Do not
+implement a workaround unless separately authorized.
+
+## 19. Acceptance Matrix
+
+WP11 is complete only if all applicable rows pass:
+
+-   WP10 predecessor accepted;
+-   issue #131 lifecycle valid;
+-   existing semantic contracts reused;
+-   validation remains at correct layer boundaries;
+-   known invalid semantic states rejected;
+-   known storage unavailability mapped to authorized failure;
+-   malformed persisted evidence contained according to accepted
+    contract;
+-   unknown failures not falsely classified;
+-   no `catch (Exception)`;
+-   integrity conflict remains distinct;
+-   exact `NotFound` remains distinct;
+-   equivalent existing remains successful;
+-   materialization failure prevents persistence;
+-   snapshot failure prevents catalog registration;
+-   no partial successful evidence after failure;
+-   atomicity preserved;
+-   immutability preserved;
+-   empty snapshot semantics preserved;
+-   identity/version fidelity preserved;
+-   target/boundary/coverage fidelity preserved;
+-   provenance/lineage fidelity preserved;
+-   timestamp/offset/decimal fidelity preserved;
+-   schema remains v2;
+-   Domain/Application SQLite leakage = 0;
+-   provider/network calls = 0;
+-   production graph unchanged;
+-   permanent-test delta = 0 unless manifest-authorized;
+-   package/reference delta = 0/0;
+-   temporary residue = 0;
+-   WP12 not started;
+-   Release 1.3 not started;
+-   canonical validation passes.
+
+## 20. Required Execution Report
+
+Return a numbered execution report covering at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Predecessor/Lifecycle Gates
+7.  Issue Lifecycle
+8.  Initial Baseline
+9.  WP02 Semantic Reconciliation
+10. WP03 Identity/Version/Provenance Reconciliation
+11. WP04 Contract/Failure-Vocabulary Reconciliation
+12. WP05 Materialization Reconciliation
+13. WP06 Catalog-Model Reconciliation
+14. WP07 Physical-Model Reconciliation
+15. WP08 Snapshot-Persistence Reconciliation
+16. WP09 Catalog-Persistence Reconciliation
+17. WP10 Integration Reconciliation
+18. Validation Surface Discovery
+19. Validation Boundary Design
+20. Failure Surface Discovery
+21. Failure-Mapping Boundary Design
+22. Semantic Invalidity Handling
+23. Identity/Version Validation
+24. Coverage/Provenance/Lineage Validation
+25. SQLite Error Classification
+26. Snapshot Persistence Failure Mapping
+27. Catalog Persistence/Lookup Failure Mapping
+28. Integration Failure Propagation
+29. Integrity Conflict Preservation
+30. NotFound Preservation
+31. Equivalent-Existing Preservation
+32. Malformed Persisted Evidence Handling
+33. Unknown Failure Behavior
+34. Atomicity/Immutability Protection
+35. Empty Snapshot Protection
+36. Fidelity Protection
+37. Connection Ownership/Disposal
+38. Exact Files Added/Modified
+39. Domain Delta
+40. Application Delta
+41. Infrastructure Delta
+42. Worker Delta
+43. Package/Reference Delta
+44. Permanent Test Delta
+45. Temporary Probe Evidence
+46. WP12 Protection
+47. Release 1.3 Protection
+48. Security/Offline Evidence
+49. Whitespace/Diff Evidence
+50. Restore/Build Evidence
+51. Permanent Test Evidence
+52. Canonical Verification
+53. Architecture Validation
+54. Release 1.1 Persistence Regression
+55. WP08 Snapshot-Persistence Regression
+56. WP09 Catalog Regression
+57. WP10 Integration Regression
+58. Validation/Failure-Mapping Matrix
+59. Mutation Accounting
+60. Git/GitHub Protection
+61. Planning Protection
+62. Findings/Blockers
+63. Final Repository/GitHub State
+64. WP12 Handoff
+65. Final Decision
+66. Next Authorized Work Package
+
+## 21. Terminal Markers
+
+On success, end exactly with:
+
+`RELEASE 1.2 WP11 COMPLETE`
+
+Then include:
+
+`NEXT AUTHORIZED WORK PACKAGE: WP12 — Dependency Registration & Bounded Dataset Execution — GitHub issue #132`
+
+If blocked, end with:
+
+`RELEASE 1.2 WP11 BLOCKED`
+
+and identify the smallest corrective authority required.
+
+## 22. Execution Principle
+
+WP11 is a **boundary-hardening work package**, not an architecture
+redesign.
+
+Prefer explicit, narrow validation and failure classification over broad
+exception handling.
+
+Reuse accepted contracts and Release 1.1 failure-boundary discipline
+where semantically applicable. Preserve integrity conflicts, exact
+lookup misses, equivalent evidence, immutable history, and unknown
+programming/storage failures as distinct concepts.
+
+Do not make later WP12--WP16 work easier by prematurely implementing it.

--- a/docs/roadmap/release-1.2/prompts/12-dependency-registration-bounded-dataset-execution-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/12-dependency-registration-bounded-dataset-execution-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read `12-dependency-registration-bounded-dataset-execution-codex-prompt.md` completely as the sole WP12 authority and reconcile accepted WP01-WP11 state before mutation.
+Implement only minimum Application/Infrastructure registration, validated dataset configuration, and one bounded Worker execution through the WP10 seam.
+Preserve schema v2, WP11 failures, Release 1.1 behavior, and exact Dataset/Persistence inputs; do not add loops, scheduling, retries, pipelines, packages, tests, or Release 1.3.
+Do not stage, commit, push, branch, PR, merge, tag, or start WP13; run all required offline composition, execution, regression, architecture, security, whitespace, build, and residue gates.
+Close #132/mark Done only after every gate passes; otherwise report the precise blocker and do not authorize WP13.

--- a/docs/roadmap/release-1.2/prompts/12-dependency-registration-bounded-dataset-execution-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/12-dependency-registration-bounded-dataset-execution-codex-prompt.md
@@ -1,0 +1,620 @@
+# Release 1.2 WP12 --- Dependency Registration & Bounded Dataset Execution
+
+## Codex Execution Authority
+
+**Repository:** `samuel-santos-engineer/AIQuantTradingResearch`\
+**Release:** 1.2 --- Research Dataset Foundation\
+**Work package:** WP12 --- Dependency Registration & Bounded Dataset
+Execution\
+**GitHub issue:** #132\
+**Recommended model:** GPT-5.6 Terra
+
+------------------------------------------------------------------------
+
+## 1. Mission
+
+Execute WP12 only.
+
+Complete the minimum dependency-registration, configuration, and bounded
+host-execution work required to make the accepted Release 1.2 dataset
+flow resolvable and deliberately executable through the existing
+composition root.
+
+WP12 must connect the already accepted WP04--WP11 dataset abstractions
+and implementations. It must **not** redesign dataset semantics,
+identity, storage, persistence, catalog behavior, validation, or failure
+mapping.
+
+This is bounded Release 1.2 execution, **not** a Release 1.3 pipeline.
+
+------------------------------------------------------------------------
+
+## 2. Authoritative Inputs
+
+Before mutation, read completely and reconcile:
+
+1.  `RELEASE_1.2_EXECUTION_PLAN.md`
+2.  `RELEASE_1.2_FILE_MANIFEST.md`
+3.  `12-dependency-registration-bounded-dataset-execution-codex-prompt.md`
+4.  `12-dependency-registration-bounded-dataset-execution-codex-prompt-chat.md`
+5.  Accepted WP02 dataset-definition artifact.
+6.  Accepted WP03 identity/version/provenance artifact.
+7.  Accepted WP04 Application dataset contracts.
+8.  Accepted WP05 materialization use case and identity computer.
+9.  Accepted WP06 catalog model.
+10. Accepted WP07 SQLite schema-v2 physical model and mapper/bootstrap
+    work.
+11. Accepted WP08 snapshot persistence.
+12. Accepted WP09 catalog persistence and lookup.
+13. Accepted WP10 materialization integration.
+14. Accepted WP11 validation/failure mapping.
+15. Existing Release 1.0/1.1 Application and Infrastructure DI
+    conventions.
+16. Current Worker composition and bounded Release 1.1 execution
+    behavior.
+17. Current permanent tests and architecture tests.
+18. GitHub issue #132, milestone #53, Project #2, and predecessor
+    lifecycle state.
+
+If repository truth conflicts with this authority, stop and report the
+conflict. Do not silently reinterpret the authority.
+
+------------------------------------------------------------------------
+
+## 3. Starting-State Gates
+
+Before changing anything, prove and report:
+
+-   Repository is `samuel-santos-engineer/AIQuantTradingResearch`.
+-   Current branch and HEAD.
+-   Local branch relationship to `origin/main`.
+-   Ahead/behind counts.
+-   Staged paths.
+-   Tracked/untracked working-tree classification.
+-   Every pre-existing path is attributable to accepted cumulative
+    Release 1.2 work or this WP12 authority.
+-   Unexpected/ambiguous paths = 0.
+-   Release 1.1 remains closed.
+-   Milestone #53 is open.
+-   WP11 issue #131 is Closed/Done.
+-   WP12 issue #132 is Open/Backlog.
+-   WP13 issue #133 remains Open/Backlog.
+-   WP12 dependencies match the authoritative planning graph.
+-   WP13 has not started.
+-   Release 1.3 implementation has not started.
+
+Run the unchanged baseline before mutation:
+
+-   restore;
+-   format verification;
+-   build;
+-   all permanent tests;
+-   architecture tests;
+-   canonical `eng/verify.ps1`;
+-   `git diff --check`;
+-   `git diff --cached --check`.
+
+Prefer the repository's accepted canonical configuration. If the
+previously observed local Windows Application Control behavior recurs
+for Debug artifacts, do not work around system policy or mutate
+repository configuration merely to bypass it. Record the observation and
+use the accepted Release verification path where appropriate.
+
+Only after all starting gates pass may issue #132 move from Backlog to
+In Progress.
+
+------------------------------------------------------------------------
+
+## 4. Accepted Architecture That Must Not Be Redesigned
+
+Preserve:
+
+-   Domain → none
+-   Application → Domain
+-   Infrastructure → Application
+-   Worker → Application, Infrastructure
+
+Domain and Application remain independent of:
+
+-   SQLite;
+-   SQL;
+-   filesystem paths;
+-   provider HTTP mechanics;
+-   host configuration APIs.
+
+Infrastructure owns SQLite implementation.
+
+Worker remains the composition root and bounded host.
+
+No new project-reference edge is authorized unless the Release 1.2
+manifest explicitly requires it.
+
+------------------------------------------------------------------------
+
+## 5. Accepted Dataset Flow
+
+WP12 must compose the existing accepted flow rather than recreate it.
+
+Conceptually:
+
+`DatasetDefinition` → materialization → immutable snapshot persistence →
+catalog registration → bounded integrated result
+
+Use the existing WP10 Application orchestration seam as the
+authoritative integration boundary.
+
+Do not bypass WP10 by manually reproducing its sequence in Worker.
+
+Do not recompute identities in Worker or Infrastructure composition.
+
+Do not create a second orchestration use case.
+
+------------------------------------------------------------------------
+
+## 6. Dependency Registration Requirements
+
+Inspect existing `AddApplication`, `AddInfrastructure`, and Worker
+registration conventions first.
+
+Register only what is necessary for the accepted dataset graph.
+
+At minimum, reconcile and make resolvable as required by the actual
+contracts:
+
+-   WP05 materialization use-case abstraction/implementation;
+-   WP10 materialization-integration use-case
+    abstraction/implementation, if an abstraction exists;
+-   `IDatasetSnapshotStore` → accepted SQLite snapshot-store
+    implementation;
+-   `IDatasetCatalog` → accepted SQLite catalog implementation;
+-   existing `IHistoricalObservationStore` dependency from Release 1.1;
+-   existing `ISqliteConnectionFactory`;
+-   accepted SQLite configuration.
+
+Do not duplicate an existing registration.
+
+Do not introduce a service locator.
+
+Do not register live `SqliteConnection` instances.
+
+Connections must remain operation-owned and deterministically disposed
+by Infrastructure.
+
+Choose lifetimes from actual object ownership:
+
+-   immutable/stateless configuration/factories may retain their
+    accepted lifetime;
+-   use cases/stores should use the narrowest lifetime consistent with
+    existing conventions and dependencies;
+-   no singleton may capture a live connection or mutable execution
+    state.
+
+Document every registration and lifetime decision in the execution
+report.
+
+------------------------------------------------------------------------
+
+## 7. Configuration Boundary
+
+Reuse the accepted Release 1.1 persistence configuration model wherever
+possible.
+
+`Persistence:DatabasePath` remains the authoritative SQLite
+database-path input unless repository authority explicitly establishes
+otherwise.
+
+Requirements:
+
+-   no hidden default database path;
+-   no silent in-memory fallback;
+-   no personal/local absolute path committed;
+-   no connection string or path logged as sensitive diagnostic data;
+-   missing/blank required configuration fails deterministically;
+-   DI container construction/service resolution must not create or
+    mutate the database merely as a side effect.
+
+Do not introduce Release 1.3 pipeline configuration.
+
+------------------------------------------------------------------------
+
+## 8. Bounded Dataset Execution
+
+Add only the minimum Worker/composition-root behavior needed to
+deliberately execute one bounded dataset-materialization integration.
+
+The execution must:
+
+1.  obtain the accepted integrated Application use case from DI;
+2.  construct or obtain one explicit `DatasetDefinition` using existing
+    host configuration conventions;
+3.  invoke the integrated use case once per bounded host execution;
+4.  handle the existing integrated success/failure result without
+    redefining its semantics;
+5.  terminate or return control according to the existing bounded Worker
+    lifecycle.
+
+The definition must preserve WP02 semantics:
+
+-   exact target;
+-   explicit `[from, to)` boundaries;
+-   no trimming/case folding/normalization;
+-   deterministic semantics independent of local culture/timezone.
+
+Prefer explicit external configuration for definition inputs if the
+current Worker architecture already uses configuration for bounded
+execution. Do not invent a generalized dataset-job configuration
+framework.
+
+If exact configuration keys are not already dictated by the execution
+plan/manifest, choose the smallest coherent Release 1.2-specific shape
+and document it. Do not build a future pipeline DSL.
+
+------------------------------------------------------------------------
+
+## 9. Bounded Means Bounded
+
+WP12 is expressly prohibited from introducing:
+
+-   continuous loops for dataset refresh;
+-   recurring scheduling;
+-   cron semantics;
+-   timers for dataset refresh;
+-   streaming materialization;
+-   polling;
+-   queues;
+-   DAGs/workflow engines;
+-   automatic re-materialization;
+-   background refresh;
+-   change detection;
+-   retries/backoff/circuit breakers for dataset execution;
+-   pipeline monitoring;
+-   pipeline checkpoints;
+-   multi-dataset orchestration;
+-   concurrency framework;
+-   distributed transactions;
+-   Release 1.3 pipeline abstractions.
+
+One deliberate execution path is sufficient.
+
+If the existing Worker itself has a lifecycle loop from earlier
+releases, do not broaden that loop into a dataset pipeline. Keep the
+dataset action explicitly bounded according to the Release 1.2
+authority.
+
+------------------------------------------------------------------------
+
+## 10. Result and Failure Handling
+
+Reuse the accepted WP10/WP11 result vocabulary exactly.
+
+Preserve distinctions including, where represented by the current
+contracts:
+
+-   newly accepted;
+-   equivalent existing;
+-   integrity conflict;
+-   source-history unavailable;
+-   snapshot-store unavailable;
+-   invalid persisted evidence mapped through the accepted integration
+    boundary.
+
+Do not:
+
+-   add a new public failure category without authority;
+-   convert conflicts into success;
+-   convert `NotFound` into a storage failure;
+-   catch arbitrary `Exception`;
+-   swallow unknown SQLite/programming failures;
+-   add retryability policy;
+-   repair malformed evidence;
+-   overwrite immutable evidence.
+
+Worker may translate accepted results into bounded host control/logging
+behavior, but must not redefine their semantic meaning.
+
+------------------------------------------------------------------------
+
+## 11. Logging
+
+Use existing logging conventions only if logging is already part of the
+Worker pattern.
+
+Logs may communicate bounded execution status using non-sensitive
+semantic facts.
+
+Do not log:
+
+-   API keys;
+-   connection strings;
+-   secrets;
+-   personal filesystem paths;
+-   raw sensitive configuration.
+
+Avoid creating a new observability framework.
+
+------------------------------------------------------------------------
+
+## 12. WP11 Regression Protection
+
+WP12 must preserve all accepted WP11 behavior:
+
+-   `DatasetStoreFailure.Unavailable`;
+-   `DatasetStoreFailure.InvalidData`;
+-   SQLite known-unavailable classification;
+-   malformed schema/evidence containment;
+-   unknown failures propagating;
+-   integrity conflicts remaining non-destructive;
+-   `NotFound` remaining distinct;
+-   equivalent existing remaining success;
+-   no `catch (Exception)`;
+-   schema version remains 2.
+
+Do not move SQLite exception mapping into Worker.
+
+------------------------------------------------------------------------
+
+## 13. Release 1.1 Regression Protection
+
+Preserve:
+
+-   historical observation persistence;
+-   historical retrieval;
+-   exact target semantics;
+-   immutable/idempotent/conflict behavior;
+-   timestamp/offset/decimal fidelity;
+-   Release 1.1 failure mapping;
+-   `Persistence:DatabasePath`;
+-   existing provider composition;
+-   existing Worker behavior not explicitly superseded by Release 1.2.
+
+No Release 1.1 contract redesign is authorized.
+
+------------------------------------------------------------------------
+
+## 14. Testing Policy for WP12
+
+WP12 is implementation/composition work. Permanent test ownership
+remains governed by the Release 1.2 manifest, especially WP13 and WP14.
+
+Do not pre-empt WP13/WP14 by adding broad permanent dataset test suites
+unless the manifest explicitly assigns a specific WP12 test file.
+
+You may create minimal temporary offline probes to prove:
+
+-   concrete Microsoft DI container build;
+-   dataset graph resolution;
+-   no database mutation from service resolution alone;
+-   exact configuration handoff;
+-   one bounded successful execution;
+-   equivalent rerun if necessary to validate composition;
+-   missing/blank required configuration rejection;
+-   zero provider/network activity during purely composition-focused
+    probes where applicable.
+
+Temporary probes and databases must be removed before completion.
+
+Do not use live credentials or external provider calls for WP12
+validation.
+
+------------------------------------------------------------------------
+
+## 15. Expected Scope
+
+Prefer the smallest manifest-authorized mutation.
+
+Likely surfaces include only:
+
+-   existing Application DI registration;
+-   existing Infrastructure DI registration;
+-   existing Worker composition/configuration/bounded execution;
+-   narrowly necessary configuration files if explicitly authorized by
+    the manifest.
+
+Do not create speculative abstractions.
+
+Before editing, compare the exact intended paths with
+`RELEASE_1.2_FILE_MANIFEST.md`.
+
+Any required file outside the authorized WP12 scope is a stop condition
+unless the authority explicitly permits it.
+
+------------------------------------------------------------------------
+
+## 16. Explicitly Forbidden Scope
+
+Do not implement WP13, WP14, WP15, or WP16.
+
+Do not implement Release 1.3.
+
+Do not:
+
+-   change schema version 2;
+-   redesign dataset identity/canonicalization;
+-   alter SHA-256 identity semantics;
+-   alter WP02 selection semantics;
+-   alter WP04 public contracts except if an absolutely necessary
+    manifest-authorized composition seam is missing;
+-   redesign WP05 materialization;
+-   redesign WP06 catalog metadata;
+-   redesign WP08 snapshot persistence;
+-   redesign WP09 catalog persistence;
+-   redesign WP10 orchestration;
+-   redesign WP11 failure mapping;
+-   add packages unless explicitly unavoidable and authorized;
+-   add project references unless explicitly authorized;
+-   stage;
+-   commit;
+-   push;
+-   create a branch;
+-   create a PR;
+-   merge;
+-   tag;
+-   create a GitHub release.
+
+------------------------------------------------------------------------
+
+## 17. Validation Requirements
+
+After mutation run, at minimum:
+
+1.  restore;
+2.  format verification;
+3.  build with zero warnings/errors;
+4.  Domain tests;
+5.  Application tests;
+6.  Infrastructure tests;
+7.  Architecture tests;
+8.  canonical `eng/verify.ps1`;
+9.  secret scan through canonical verification;
+10. `git diff --check`;
+11. `git diff --cached --check`;
+12. direct whitespace checks for relevant untracked WP12 files when Git
+    diff does not include them;
+13. temporary SQLite residue check;
+14. production dependency-graph reconciliation.
+
+Expected permanent baseline before WP13/WP14 remains the accepted
+current count unless the manifest explicitly assigns WP12 permanent
+tests.
+
+Report exact suite counts rather than assuming them.
+
+------------------------------------------------------------------------
+
+## 18. Acceptance Matrix
+
+WP12 is complete only if all applicable rows pass:
+
+  Requirement                                        Expected
+  -------------------------------------------------- -------------------------------------
+  WP11 predecessor                                   PASS
+  Issue #132 lifecycle                               Backlog → In Progress → Closed/Done
+  Existing DI conventions reused                     PASS
+  Materialization use case resolvable                PASS
+  WP10 integration use case resolvable               PASS
+  `IDatasetSnapshotStore` concrete registration      PASS
+  `IDatasetCatalog` concrete registration            PASS
+  Release 1.1 historical store preserved             PASS
+  SQLite connection factory preserved                PASS
+  `Persistence:DatabasePath` handoff                 PASS
+  Missing/blank required configuration               deterministic rejection
+  Resolution-time DB mutation                        NO
+  Hidden in-memory fallback                          NO
+  Operation-owned connections                        PASS
+  One bounded dataset execution                      PASS
+  WP10 result semantics preserved                    PASS
+  WP11 failure semantics preserved                   PASS
+  Equivalent evidence preserved                      PASS
+  Integrity conflict non-destructive                 PASS
+  Schema version                                     2
+  Provider/storage leakage into Domain/Application   0
+  New pipeline/scheduling behavior                   0
+  Provider/network calls in offline proof            0
+  Temporary DB/probe residue                         0
+  Package/reference delta                            0/0 unless explicitly authorized
+  WP13 started                                       NO
+  Release 1.3 started                                NO
+
+------------------------------------------------------------------------
+
+## 19. GitHub Lifecycle
+
+After baseline gates pass, move issue #132:
+
+`Backlog → In Progress`
+
+Only after every WP12 acceptance gate passes:
+
+-   post concise completion evidence to #132;
+-   close #132;
+-   set Project #2 status to Done.
+
+Do not mutate #133 except to inspect it.
+
+At completion verify:
+
+-   #132 = Closed/Done;
+-   #133 = Open/Backlog;
+-   milestone #53 remains Open.
+
+------------------------------------------------------------------------
+
+## 20. Stop Conditions
+
+Stop without speculative repair if any of the following occurs:
+
+-   predecessor state is invalid;
+-   unexpected working-tree path exists;
+-   manifest conflicts with required mutation;
+-   WP12 requires schema redesign;
+-   accepted WP10 orchestration cannot be composed without redesign;
+-   required configuration semantics are contradictory;
+-   permanent-test authority conflicts with required implementation;
+-   architecture would require an unauthorized dependency edge;
+-   baseline is failing for a repository reason;
+-   completion would require Release 1.3 behavior.
+
+Report the smallest corrective authority required.
+
+------------------------------------------------------------------------
+
+## 21. Required Execution Report
+
+Produce a numbered execution report covering at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Predecessor/Lifecycle Gates
+7.  Issue Lifecycle
+8.  Initial Baseline
+9.  WP02--WP11 reconciliation
+10. Existing composition reconciliation
+11. Registration design
+12. Application use-case registration
+13. Snapshot-store registration
+14. Catalog registration
+15. Connection-factory/configuration reconciliation
+16. Lifetime decisions
+17. Configuration keys and validation
+18. Resolution side-effect evidence
+19. Bounded execution design
+20. Dataset-definition handoff
+21. Integrated-result handling
+22. WP11 failure preservation
+23. Release 1.1 regression protection
+24. Exact files added/modified
+25. Domain/Application/Infrastructure/Worker delta
+26. Package/reference delta
+27. Permanent test delta
+28. Temporary probe evidence
+29. WP13 protection
+30. Release 1.3 protection
+31. Security/offline evidence
+32. Whitespace/diff evidence
+33. Restore/build evidence
+34. Permanent test evidence
+35. Canonical verification
+36. Architecture validation
+37. Composition acceptance matrix
+38. Bounded-execution acceptance matrix
+39. Mutation accounting
+40. Git/GitHub protection
+41. Planning protection
+42. Findings/blockers
+43. Final repository/GitHub state
+44. WP13 handoff
+45. Final decision
+46. Next authorized work package
+
+End with:
+
+`RELEASE 1.2 WP12 COMPLETE`
+
+and:
+
+`NEXT AUTHORIZED WORK PACKAGE: WP13 — Domain & Application Dataset Tests — GitHub issue #133`
+
+Do not claim completion unless every mandatory gate passes.

--- a/docs/roadmap/release-1.2/prompts/13-domain-application-dataset-tests-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/13-domain-application-dataset-tests-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read `13-domain-application-dataset-tests-codex-prompt.md` completely as the sole WP13 authority and reconcile accepted WP01-WP12 state before mutation.
+Add only missing permanent deterministic pure Domain/Application dataset tests for definitions, identities, materialization, catalog evidence, integration outcomes, and failure propagation.
+Keep Domain delta zero when appropriate; use hand-written fakes only, no SQLite/provider/network/filesystem, packages, production changes, WP14 scope, or Release 1.3; run all required suites and canonical gates.
+Do not stage, commit, push, branch, PR, merge, tag, or begin WP14; leave #134 Open/Backlog and report exact before/after test counts.
+Close #133/mark Done only after every gate passes; otherwise stop with the smallest corrective authority required.

--- a/docs/roadmap/release-1.2/prompts/13-domain-application-dataset-tests-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/13-domain-application-dataset-tests-codex-prompt.md
@@ -1,0 +1,669 @@
+# Release 1.2 WP13 --- Domain & Application Dataset Tests
+
+## Codex Execution Authority
+
+**Repository:** `samuel-santos-engineer/AIQuantTradingResearch`\
+**Release:** 1.2 --- Research Dataset Foundation\
+**Work package:** WP13 --- Domain & Application Dataset Tests\
+**GitHub issue:** #133\
+**Recommended model:** GPT-5.6 Luna
+
+------------------------------------------------------------------------
+
+## 1. Mission
+
+Execute WP13 only.
+
+Add the minimum permanent, deterministic, offline Domain/Application
+test coverage required by the accepted Release 1.2 dataset semantics and
+Application implementation through WP12.
+
+WP13 is a **test-coverage work package**, not a production-design work
+package.
+
+Do not modify production code merely to make testing easier. If accepted
+production behavior cannot be tested without a production redesign, stop
+and report the smallest corrective authority required.
+
+Infrastructure/SQLite-specific proof belongs to WP14.
+
+------------------------------------------------------------------------
+
+## 2. Authoritative Inputs
+
+Before mutation, read completely and reconcile:
+
+1.  `RELEASE_1.2_EXECUTION_PLAN.md`
+2.  `RELEASE_1.2_FILE_MANIFEST.md`
+3.  `13-domain-application-dataset-tests-codex-prompt.md`
+4.  `13-domain-application-dataset-tests-codex-prompt-chat.md`
+5.  Accepted WP02 Research Dataset Definition & Reproducibility Model.
+6.  Accepted WP03 Dataset Identity, Version & Provenance Semantics.
+7.  Accepted WP04 Application Dataset Contracts.
+8.  Accepted WP05 Dataset Materialization Use Case.
+9.  Accepted WP06 Dataset Metadata & Catalog Model.
+10. Accepted WP07 physical-storage result only as context; do not test
+    its SQLite mechanics here.
+11. Accepted WP08 snapshot persistence result only as context.
+12. Accepted WP09 catalog persistence result only as context.
+13. Accepted WP10 Dataset Materialization Integration.
+14. Accepted WP11 Dataset Validation & Failure Mapping.
+15. Accepted WP12 Dependency Registration & Bounded Dataset Execution.
+16. Current Domain and Application production source.
+17. Existing Domain.Tests and Application.Tests.
+18. GitHub issue #133, milestone #53, Project #2, and predecessor state.
+
+Repository truth plus these authorities define the test target. Do not
+invent new semantics.
+
+------------------------------------------------------------------------
+
+## 3. Starting-State Gates
+
+Before editing:
+
+-   verify repository, branch, HEAD, and `origin/main`;
+-   report ahead/behind;
+-   verify staged paths = 0;
+-   classify every tracked/untracked path;
+-   unexpected/ambiguous paths = 0;
+-   verify Release 1.1 remains closed;
+-   verify milestone #53 remains open;
+-   verify WP12/#132 = Closed/Done;
+-   verify WP13/#133 = Open/Backlog;
+-   verify WP14/#134 = Open/Backlog;
+-   verify WP13 dependencies exactly match authoritative planning;
+-   verify WP14 has not started;
+-   verify Release 1.3 has not started.
+
+Run the unchanged baseline:
+
+-   restore;
+-   format verification;
+-   build;
+-   all permanent tests;
+-   architecture tests;
+-   canonical `eng/verify.ps1` using the accepted configuration;
+-   `git diff --check`;
+-   `git diff --cached --check`.
+
+Record exact existing suite counts.
+
+Only after baseline success may #133 move Backlog → In Progress.
+
+------------------------------------------------------------------------
+
+## 4. Test Inventory Before Mutation
+
+Inventory existing permanent Domain and Application tests first.
+
+Build a coverage matrix mapping existing tests against Release 1.2
+requirements.
+
+Do not add duplicate tests simply to increase counts.
+
+For each required behavior classify:
+
+-   already permanently covered;
+-   missing and WP13-owned;
+-   Infrastructure/WP14-owned;
+-   architecture/documentation-owned;
+-   not applicable.
+
+The final report must show why every new permanent test is necessary.
+
+------------------------------------------------------------------------
+
+## 5. Domain Test Policy
+
+Do not assume WP13 requires a Domain-test delta.
+
+The dataset feature is intentionally Application-owned and must not
+force dataset concepts into Domain merely to create Domain tests.
+
+Inspect existing Domain tests and determine whether Release 1.2
+introduced any new Domain-owned invariant.
+
+If no new Domain-owned production behavior exists:
+
+-   add **zero** Domain tests;
+-   explicitly report that Domain coverage is already sufficient;
+-   do not create artificial dataset Domain types or tests.
+
+If the manifest explicitly identifies a Domain test file or genuinely
+uncovered Domain-owned invariant, add only that authorized coverage.
+
+------------------------------------------------------------------------
+
+## 6. Application Contract Coverage
+
+Add permanent pure Application tests for the accepted dataset contracts
+where coverage is missing.
+
+Cover applicable invariants such as:
+
+### Dataset Definition
+
+-   exact target preservation;
+-   valid `[from, to)` boundaries;
+-   invalid/equal/reversed boundaries rejected;
+-   target is not trimmed, case-folded, or normalized;
+-   semantic ordering requirement remains explicit.
+
+### Typed identities
+
+Prove the accepted typed identity model remains distinct:
+
+-   Dataset Definition Identity;
+-   Research Dataset Identity;
+-   Source State Identity;
+-   Dataset Snapshot Identity;
+-   Dataset Version relationship to Snapshot Identity.
+
+Validate accepted fingerprint rules where Application owns them:
+
+-   `aiq-dataset-identity-v1`;
+-   64 lowercase hexadecimal fingerprint;
+-   malformed values rejected.
+
+Do not retest SHA-256 internals redundantly if materialization tests
+prove deterministic output more appropriately.
+
+### Snapshot candidate / coverage / provenance / lineage
+
+Cover applicable invariants:
+
+-   exact definition/identity consistency;
+-   successful empty candidate;
+-   non-empty coverage;
+-   observation count consistency;
+-   first/last actual instant rules;
+-   ascending semantic-instant ordering;
+-   duplicate semantic instant rejection;
+-   exact target consistency;
+-   version/snapshot relationship;
+-   provenance identity consistency;
+-   lineage consistency;
+-   original `DateTimeOffset` representation preserved;
+-   exact decimal values preserved.
+
+### Catalog entry
+
+Cover:
+
+-   construction from accepted candidate;
+-   identity/version preservation;
+-   target/boundary/coverage preservation;
+-   empty snapshot metadata;
+-   provenance/lineage preservation;
+-   absence of mutable "latest" semantics.
+
+Use behavior assertions, not implementation-detail assertions.
+
+------------------------------------------------------------------------
+
+## 7. WP05 Materialization Use-Case Coverage
+
+Add deterministic Application tests for `IMaterializeDatasetUseCase` /
+its implementation.
+
+Use an Application-owned hand-written fake/stub of
+`IHistoricalObservationStore`.
+
+Do not use SQLite.
+
+Required scenarios where not already permanently covered:
+
+1.  exact target forwarded unchanged to source history;
+2.  `[from,to)` selection:
+    -   include `from`;
+    -   exclude `to`;
+    -   exclude outside observations;
+3.  deterministic ascending ordering;
+4.  valid zero-observation materialization;
+5.  original timestamp offset preserved;
+6.  exact high-precision decimal preserved;
+7.  deterministic equivalent re-materialization;
+8.  identity output stable across culture/local timezone influences;
+9.  relevant selected source changes alter the appropriate
+    source/snapshot identity;
+10. outside-window source changes do not alter selected materialization
+    identity;
+11. definition changes alter definition/logical/snapshot identity as
+    required by accepted WP03 semantics;
+12. source `Unavailable` maps to `SourceHistoryUnavailable`;
+13. source `InvalidData` maps to `IntegrityConflict`;
+14. duplicate semantic instants fail according to accepted behavior;
+15. coverage/provenance/lineage are constructed consistently.
+
+Do not access provider/network/database/filesystem.
+
+------------------------------------------------------------------------
+
+## 8. Identity Determinism Coverage
+
+WP05 implemented `aiq-dataset-identity-v1`. WP13 should permanently
+prove the semantic contract without overfitting private encoding
+details.
+
+At minimum prove:
+
+-   same definition + same relevant source state → same four
+    identities/version;
+-   culture changes do not alter identity;
+-   original offset representation participates where accepted;
+-   exact decimal value participates;
+-   selected membership participates;
+-   boundary/definition changes participate;
+-   unrelated/outside-window observations do not participate in the
+    selected source-state identity;
+-   empty materialization has stable deterministic identities.
+
+Do not duplicate every byte-level canonicalization rule unless the
+public/accessible Application behavior requires it.
+
+------------------------------------------------------------------------
+
+## 9. WP06 Catalog-Model Coverage
+
+Pure Application tests should prove `DatasetCatalogEntry` represents
+accepted immutable evidence.
+
+Do not instantiate Infrastructure catalog implementations.
+
+Cover applicable semantics:
+
+-   exact snapshot identity/version;
+-   definition/research/source-state identities;
+-   exact target and boundaries;
+-   selected count;
+-   empty/non-empty actual coverage;
+-   provenance and lineage;
+-   no mutable status or "latest" pointer.
+
+Registration persistence and exact SQLite lookup belong to WP14.
+
+------------------------------------------------------------------------
+
+## 10. WP10 Integration Coverage
+
+Add permanent Application tests for the accepted WP10 orchestration
+using hand-written Application-level stubs/fakes for:
+
+-   materialization use case;
+-   `IDatasetSnapshotStore`;
+-   `IDatasetCatalog`.
+
+Do not use the concrete SQLite implementations.
+
+Cover the accepted matrix:
+
+  -----------------------------------------------------------------------
+  Materialization / Snapshot /        Expected
+  Catalog
+  ----------------------------------- -----------------------------------
+  materialization failure             stop; snapshot/catalog not called
+
+  snapshot newly accepted + catalog   integrated newly accepted
+  newly registered
+
+  snapshot newly accepted + catalog   integrated newly accepted
+  equivalent
+
+  snapshot equivalent + catalog newly equivalent existing
+  registered/equivalent
+
+  snapshot integrity conflict         stop; catalog not called; integrity
+                                      conflict
+
+  catalog integrity conflict          integrity conflict
+
+  snapshot unavailable                stop; catalog not called;
+                                      snapshot-store unavailable
+
+  snapshot invalid data               accepted WP11 integration mapping
+
+  catalog unavailable                 accepted unavailable mapping
+
+  catalog invalid data                accepted WP11 integration mapping
+  -----------------------------------------------------------------------
+
+Use the exact current contracts as authority if names differ.
+
+Also prove that the catalog entry passed to the catalog is derived from
+the exact materialized candidate without semantic mutation.
+
+------------------------------------------------------------------------
+
+## 11. WP11 Failure-Semantics Coverage
+
+Permanent Application tests must preserve distinctions
+introduced/confirmed by WP11.
+
+Where represented at the Application boundary, cover:
+
+-   `Unavailable`;
+-   `InvalidData`;
+-   `IntegrityConflict`;
+-   `NotFound`;
+-   `EquivalentExisting`.
+
+Do not collapse these categories.
+
+Do not add SQLite exception tests here.
+
+SQLite error-code mapping and malformed persisted-row/schema behavior
+are WP14-owned.
+
+------------------------------------------------------------------------
+
+## 12. WP12 Boundary
+
+WP13 must not test the real Worker process, concrete Microsoft DI
+container, configuration binding, or SQLite-backed execution unless the
+manifest explicitly assigns such coverage here.
+
+WP12 already supplied execution evidence.
+
+WP14 owns Infrastructure composition/persistence tests.
+
+WP13 should remain fast, deterministic, pure, and offline.
+
+Do not add:
+
+-   provider calls;
+-   HTTP;
+-   SQLite;
+-   temporary databases;
+-   filesystem persistence;
+-   environment-dependent process execution.
+
+------------------------------------------------------------------------
+
+## 13. Test Doubles
+
+Prefer small hand-written test doubles local to the test project/file.
+
+Do not add mocking packages.
+
+Test doubles must expose only what is necessary to prove:
+
+-   exact arguments;
+-   call counts/order where semantically relevant;
+-   configured outcomes/failures.
+
+Avoid building reusable testing frameworks.
+
+Package/reference delta should remain `0/0`.
+
+------------------------------------------------------------------------
+
+## 14. Production-Code Protection
+
+Expected production delta for WP13: **0**.
+
+Do not modify:
+
+-   Domain production;
+-   Application production;
+-   Infrastructure production;
+-   Worker production;
+-   schema/bootstrap/mappers;
+-   DI/configuration;
+-   engineering scripts.
+
+If a test exposes a genuine production defect, stop and report it rather
+than silently fixing it under WP13.
+
+------------------------------------------------------------------------
+
+## 15. WP14 Protection
+
+Do not pre-empt WP14 --- Infrastructure & Dataset Tests.
+
+Reserved for WP14 include:
+
+-   schema v2 structure and v1→v2 upgrade;
+-   bootstrap validation;
+-   SQLite mapper round trips;
+-   connection lifecycle;
+-   snapshot durable persistence;
+-   empty snapshot physical representation;
+-   equivalent persistence;
+-   integrity conflicts;
+-   transaction rollback;
+-   immutable evidence;
+-   catalog registration/exact lookup;
+-   multiple versions;
+-   SQLite failure-code mapping;
+-   malformed persisted evidence;
+-   Infrastructure DI/configuration;
+-   database cleanup.
+
+WP13 may test the Application abstraction/result semantics for these
+behaviors, but not the SQLite mechanics.
+
+------------------------------------------------------------------------
+
+## 16. Release 1.3 Protection
+
+Do not introduce or test speculative:
+
+-   pipelines;
+-   scheduling;
+-   refresh loops;
+-   streaming;
+-   polling;
+-   retries;
+-   DAGs;
+-   background materialization;
+-   multi-dataset orchestration;
+-   monitoring/checkpointing.
+
+Release 1.3 implementation started must remain `NO`.
+
+------------------------------------------------------------------------
+
+## 17. Expected Files
+
+Use `RELEASE_1.2_FILE_MANIFEST.md` as the exact path authority.
+
+Prefer the minimum number of focused Application test files.
+
+Possible logical groupings, only if manifest-authorized, include:
+
+-   dataset contract/model tests;
+-   materialization use-case tests;
+-   materialization-integration tests.
+
+Do not create paths solely because they are suggested here if the
+manifest specifies different names.
+
+Any necessary path outside the WP13 manifest scope is a stop condition.
+
+------------------------------------------------------------------------
+
+## 18. Validation
+
+After tests are added:
+
+1.  run targeted Domain tests;
+2.  run targeted Application tests;
+3.  restore;
+4.  format verification;
+5.  build with 0 warnings/errors;
+6.  run all permanent test projects;
+7.  run Architecture.Tests;
+8.  run canonical `eng/verify.ps1`;
+9.  confirm Gitleaks passes;
+10. run `git diff --check`;
+11. run `git diff --cached --check`;
+12. directly whitespace-check untracked WP13 files if necessary;
+13. verify provider/network calls = 0;
+14. verify SQLite/database use by WP13 tests = 0;
+15. verify temporary residue = 0;
+16. verify production dependency graph unchanged.
+
+Report before/after/delta test counts for every suite.
+
+------------------------------------------------------------------------
+
+## 19. Acceptance Matrix
+
+WP13 completes only when all applicable requirements pass:
+
+  Requirement                             Expected
+  --------------------------------------- ----------
+  WP12 predecessor                        PASS
+  Existing test inventory                 COMPLETE
+  Duplicate test additions                0
+  Domain production delta                 0
+  Application production delta            0
+  Infrastructure production delta         0
+  Worker production delta                 0
+  Dataset Definition coverage             PASS
+  Typed identity/version coverage         PASS
+  Snapshot candidate invariants           PASS
+  Coverage/provenance/lineage             PASS
+  Empty materialization                   PASS
+  Ordering/duplicate semantics            PASS
+  Timestamp/offset fidelity               PASS
+  Decimal fidelity                        PASS
+  Deterministic identity                  PASS
+  Relevant-change distinguishability      PASS
+  Catalog model coverage                  PASS
+  WP05 materialization coverage           PASS
+  WP10 integration matrix                 PASS
+  WP11 Application failure distinctions   PASS
+  SQLite/database use in WP13 tests       0
+  Provider/network calls                  0
+  Mocking package delta                   0
+  Package/reference delta                 0/0
+  WP14 started                            NO
+  Release 1.3 started                     NO
+
+------------------------------------------------------------------------
+
+## 20. GitHub Lifecycle
+
+After starting gates pass:
+
+`#133 Backlog → In Progress`
+
+After **all** acceptance gates pass:
+
+-   post concise completion evidence to #133;
+-   close #133;
+-   set Project #2 status to Done.
+
+Verify:
+
+-   #133 = Closed/Done;
+-   #134 = Open/Backlog;
+-   milestone #53 = Open.
+
+Do not otherwise mutate #134.
+
+------------------------------------------------------------------------
+
+## 21. Git Protection
+
+Do not:
+
+-   stage;
+-   commit;
+-   push;
+-   create/switch implementation branches;
+-   create PR;
+-   merge;
+-   tag;
+-   create release;
+-   rewrite history.
+
+The cumulative Release 1.2 working tree remains uncommitted until the
+later integration authority.
+
+------------------------------------------------------------------------
+
+## 22. Stop Conditions
+
+Stop and report the smallest corrective authority if:
+
+-   baseline fails for a repository reason;
+-   predecessor/planning state is invalid;
+-   unexpected working-tree paths exist;
+-   manifest conflicts with necessary test paths;
+-   required behavior cannot be tested without production changes;
+-   accepted WP02--WP12 semantics contradict one another;
+-   a genuine production defect is discovered;
+-   WP13 would require SQLite/Infrastructure mechanics;
+-   package/reference changes become necessary;
+-   completing tests would require WP14 or Release 1.3 scope.
+
+Do not repair beyond authority.
+
+------------------------------------------------------------------------
+
+## 23. Required Execution Report
+
+Produce a numbered report covering at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Predecessor/Lifecycle Gates
+7.  Issue Lifecycle
+8.  Initial Baseline
+9.  Existing Domain Test Inventory
+10. Existing Application Test Inventory
+11. Existing Coverage Matrix
+12. WP02 Reconciliation
+13. WP03 Reconciliation
+14. WP04 Contract Reconciliation
+15. WP05 Materialization Reconciliation
+16. WP06 Catalog Reconciliation
+17. WP10 Integration Reconciliation
+18. WP11 Failure Reconciliation
+19. WP12 Boundary Reconciliation
+20. Domain Test Design / Delta Decision
+21. Application Contract Test Design
+22. Dataset Definition Tests
+23. Identity/Version Tests
+24. Candidate/Coverage/Provenance/Lineage Tests
+25. Materialization Use-Case Tests
+26. Determinism/Relevant-Change Tests
+27. Catalog Model Tests
+28. Integration Outcome Matrix Tests
+29. Failure Propagation Tests
+30. Test-Double Design
+31. Exact Files Added/Modified
+32. Production Delta
+33. Package/Reference Delta
+34. Permanent Test Count Delta
+35. Targeted Domain Evidence
+36. Targeted Application Evidence
+37. Full Permanent Test Evidence
+38. Canonical Verification
+39. Architecture Validation
+40. Security/Offline Determinism
+41. SQLite/Database Use
+42. Whitespace/Diff Evidence
+43. Mutation Accounting
+44. Git/GitHub Protection
+45. Planning Protection
+46. Findings/Blockers
+47. Acceptance Matrix
+48. Final Repository/GitHub State
+49. WP14 Handoff
+50. Final Decision
+51. Next Authorized Work Package
+
+End only after every gate passes with:
+
+`RELEASE 1.2 WP13 COMPLETE`
+
+and:
+
+`NEXT AUTHORIZED WORK PACKAGE: WP14 — Infrastructure & Dataset Tests — GitHub issue #134`

--- a/docs/roadmap/release-1.2/prompts/14-infrastructure-dataset-tests-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/14-infrastructure-dataset-tests-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read `14-infrastructure-dataset-tests-codex-prompt.md` completely as the sole WP14 authority and reconcile accepted WP01-WP13 state before mutation.
+Add only justified permanent isolated offline Infrastructure tests for schema v2/v1-to-v2, mapper fidelity, snapshots, catalog, atomicity, failures, DI, and Release 1.1 regression.
+Do not redesign production/schema/contracts, add packages/references, provider/network calls, begin WP15/Release 1.3, or perform Git transport; run all required database cleanup, architecture, security, whitespace, build, test, and canonical gates.
+Do not stage, commit, push, branch, PR, merge, tag, or release; leave #135 Open/Backlog and preserve all existing persistence coverage.
+Close #134/mark Done only after every gate passes; otherwise report the exact blocker and required corrective authority.

--- a/docs/roadmap/release-1.2/prompts/14-infrastructure-dataset-tests-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/14-infrastructure-dataset-tests-codex-prompt.md
@@ -1,0 +1,468 @@
+# Release 1.2 WP14 --- Infrastructure & Dataset Tests --- Codex Execution Authority
+
+## Purpose
+
+Execute **Release 1.2 WP14 --- Infrastructure & Dataset Tests** for
+`samuel-santos-engineer/AIQuantTradingResearch`.
+
+WP14 owns the permanent, isolated, offline Infrastructure test coverage
+required to prove the accepted Release 1.2 dataset implementation
+through WP12, while preserving Release 1.1 persistence behavior and the
+permanent Application proof established by WP13.
+
+This is a **test work package**, not a redesign work package.
+
+## Model Recommendation
+
+**Recommended Codex model: GPT-5.6 Terra.**
+
+Rationale: WP14 is broad and implementation-aware, but the architecture,
+schema, contracts, persistence semantics, failure vocabulary, and
+execution boundaries are already established. Terra is the
+cost-effective choice for systematic test construction, reconciliation,
+and regression validation. Escalate to Sol only if a genuine
+architectural contradiction is discovered; do not redesign merely to
+satisfy a test.
+
+## Authoritative Inputs
+
+Before mutation, read and reconcile completely:
+
+1.  `RELEASE_1.2_EXECUTION_PLAN.md`
+2.  `RELEASE_1.2_FILE_MANIFEST.md`
+3.  Accepted WP02--WP13 authority/result state
+4.  `docs/architecture/data/RESEARCH_DATASET_DEFINITION.md`
+5.  `docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md`
+6.  Current Application dataset contracts and use cases
+7.  Current Infrastructure SQLite implementation
+8.  Existing Release 1.1 SQLite tests and behavior
+9.  Existing WP13 Application dataset tests
+10. GitHub issue #134 and milestone #53
+11. Current repository/GitHub state
+
+Repository truth takes precedence over assumptions. Do not silently
+repair contradictions. Stop and report the smallest corrective authority
+if an authoritative conflict prevents safe execution.
+
+## Starting-State Gates
+
+Before changing any test:
+
+-   Confirm repository is
+    `samuel-santos-engineer/AIQuantTradingResearch`.
+-   Confirm current branch and local/remote relationship.
+-   Confirm staged paths are zero.
+-   Classify every existing working-tree path.
+-   Preserve all accepted cumulative Release 1.2 artifacts.
+-   Confirm issue #133 is **Closed / Done**.
+-   Confirm issue #134 is **Open / Backlog** before execution.
+-   Confirm issue #135 remains **Open / Backlog**.
+-   Confirm milestone #53 remains open.
+-   Confirm WP14 dependencies exactly match authoritative planning.
+-   Confirm no Release 1.3 implementation has started.
+-   Run the canonical baseline before mutation.
+
+Expected permanent baseline after WP13:
+
+-   Domain.Tests: **11**
+-   Application.Tests: **60**
+-   Infrastructure.Tests: **79**
+-   Architecture.Tests: **13**
+-   Total: **163**
+
+If baseline truth differs, reconcile and report before proceeding.
+
+Only after all starting gates pass may issue #134 move **Backlog → In
+Progress**.
+
+## Scope
+
+WP14 may add or minimally refine permanent tests under:
+
+`tests/AIQuantTradingResearch.Infrastructure.Tests/`
+
+Prefer the smallest coherent test surface. Reuse existing test
+infrastructure where appropriate.
+
+WP14 may make a minimal production correction **only if a permanent
+Infrastructure test exposes a clear defect in already-authorized
+WP07--WP12 behavior and the correction is necessary to satisfy the
+accepted authority**. Any such production change must be narrowly
+justified and reported separately. Do not use WP14 to redesign
+contracts, schema, identity semantics, orchestration, or Worker
+behavior.
+
+No new package or project reference is expected.
+
+## Required Permanent Coverage
+
+### 1. Schema v2 and Upgrade
+
+Permanently prove:
+
+-   New/empty database bootstraps to the accepted **schema version 2**.
+-   Release 1.1 schema v1 upgrades deterministically to v2.
+-   Existing `historical_observations` data survives v1→v2 upgrade
+    unchanged.
+-   Repeated bootstrap at v2 is idempotent/non-destructive.
+-   Future unsupported schema version is rejected deterministically.
+-   Incompatible/corrupt schema evidence is rejected rather than
+    silently repaired.
+-   Accepted dataset tables, keys, constraints, collations, strictness,
+    and ordering representation match WP07.
+-   Release 1.1 historical storage remains valid after upgrade.
+
+Align any Release 1.1 bootstrap tests already corrected by the accepted
+WP07 resume authority; do not create contradictory version-one
+expectations.
+
+### 2. Connection Lifecycle and Bootstrap Boundary
+
+Prove:
+
+-   Factory calls return distinct operation-owned connections.
+-   Connections are open when returned as designed.
+-   Caller/store disposal closes/disposes operation-owned resources.
+-   DI resolution does not create or mutate the database.
+-   Bootstrap occurs only at the accepted storage-operation boundary.
+-   No shared live SQLite connection is captured by singleton services.
+
+### 3. Dataset Mapper Fidelity
+
+Permanently prove round-trip fidelity for the accepted WP07
+mapper/model:
+
+-   all four typed identities;
+-   identity scheme;
+-   Dataset Version = Snapshot Identity;
+-   exact target text;
+-   requested `[from,to)` boundaries;
+-   UTC semantic instants plus original offsets;
+-   exact decimal values without floating-point conversion;
+-   selected observation count;
+-   first/last actual instants for non-empty snapshots;
+-   null actual bounds for valid empty snapshots;
+-   provenance;
+-   lineage;
+-   deterministic observation ordinal/order.
+
+Include high-precision decimal and non-zero-offset cases.
+
+### 4. Snapshot Persistence --- New Evidence
+
+Using real isolated file-backed SQLite:
+
+-   Persist a new non-empty snapshot.
+-   Verify descriptor and membership evidence physically/durably.
+-   Retrieve/reconstruct exact semantic evidence.
+-   Persist a valid empty snapshot.
+-   Verify empty snapshot has descriptor evidence and zero membership
+    rows.
+-   Verify multiple immutable versions for the same logical Research
+    Dataset can coexist.
+
+### 5. Equivalent Existing Semantics
+
+Prove:
+
+-   Re-persisting semantically equivalent evidence returns the accepted
+    equivalent outcome.
+-   Equivalent persistence performs no destructive mutation.
+-   Equivalent evidence remains retrievable with exact fidelity.
+-   Equivalent behavior is deterministic across separate store
+    instances/connections.
+
+### 6. Integrity Conflict and Immutability
+
+Prove contradictory evidence under the same Snapshot Identity:
+
+-   returns `IntegrityConflict`;
+-   does not overwrite accepted descriptor evidence;
+-   does not overwrite accepted membership evidence;
+-   leaves previously accepted snapshot retrievable unchanged.
+
+Exercise meaningful contradictions such as selected
+price/offset/membership or descriptor inconsistency where safely
+representable.
+
+### 7. Atomicity / Rollback
+
+Permanently prove transaction atomicity.
+
+Create a controlled failure after partial write opportunity and verify:
+
+-   descriptor + membership are all committed or all rolled back;
+-   no partial accepted snapshot remains;
+-   existing accepted history remains unchanged;
+-   no repair/upsert behavior occurs.
+
+Do not weaken production constraints merely to make this test
+convenient.
+
+### 8. Catalog Registration
+
+Permanently prove `IDatasetCatalog`:
+
+-   new registration → `NewlyRegistered`;
+-   equivalent registration → `EquivalentExisting`;
+-   contradictory same-identity registration → `IntegrityConflict`;
+-   registration preserves immutable snapshot evidence;
+-   registration does not introduce a second persistence model.
+
+### 9. Exact Catalog Lookup
+
+Prove:
+
+-   exact Snapshot Identity hit returns the correct
+    `DatasetCatalogEntry`;
+-   missing identity returns `NotFound`;
+-   lookup of one version never returns another version;
+-   reconstructed entry preserves identities/version, target,
+    boundaries, coverage, provenance, lineage, empty-state semantics,
+    offsets, and decimals.
+
+No "latest", fuzzy, range, search, or listing semantics may be
+introduced.
+
+### 10. WP11 Failure Mapping
+
+Permanently prove bounded Infrastructure classification for dataset
+storage:
+
+-   known SQLite unavailable conditions →
+    `DatasetStoreFailure.Unavailable`;
+-   malformed/corrupt persisted dataset evidence →
+    `DatasetStoreFailure.InvalidData`;
+-   incompatible/malformed schema evidence is contained at the
+    Infrastructure boundary as authorized;
+-   constraint/type/data corruption classified by WP11 does not leak
+    SQLite types to Application;
+-   unknown/unclassified SQLite failures are not falsely normalized;
+-   unrelated unknown exceptions are not swallowed.
+
+Do not introduce `catch (Exception)` normalization.
+
+### 11. DI / Configuration Composition
+
+At the Infrastructure-owned boundary prove:
+
+-   exactly one `IDatasetSnapshotStore` registration resolves to the
+    accepted SQLite implementation;
+-   exactly one `IDatasetCatalog` registration resolves to the accepted
+    SQLite implementation;
+-   existing `IHistoricalObservationStore` registration remains valid;
+-   existing `ISqliteConnectionFactory` ownership/lifetime remains
+    valid;
+-   configured `Persistence:DatabasePath` is handed through exactly;
+-   graph construction/resolution creates no database file;
+-   existing Release 1.0/Twelve Data registrations remain intact without
+    provider calls.
+
+WP14 does **not** own Worker execution/configuration tests; those remain
+outside this Infrastructure test boundary.
+
+### 12. Release 1.1 Regression
+
+The final permanent suite must continue proving Release 1.1 behavior:
+
+-   schema/bootstrap compatibility;
+-   historical observation persistence;
+-   retrieval;
+-   idempotency;
+-   conflicts;
+-   atomicity;
+-   target isolation;
+-   ordering;
+-   timestamp/offset/decimal fidelity;
+-   failure mapping;
+-   DI/configuration.
+
+Do not delete or weaken Release 1.1 tests to make Release 1.2 pass.
+
+## Test Isolation Requirements
+
+All WP14 tests must be:
+
+-   offline;
+-   deterministic;
+-   provider/network independent;
+-   credential independent;
+-   isolated from user databases;
+-   file-backed where durable SQLite behavior is being proven;
+-   unique per test/scenario where necessary;
+-   fully cleaned after execution.
+
+Use repository-appropriate temporary-directory/database helpers. Clear
+SQLite pools when necessary before deletion.
+
+At completion, verify zero residue for temporary database, WAL, SHM, and
+journal files.
+
+## Explicit Non-Goals
+
+WP14 must not:
+
+-   change Domain behavior;
+-   redesign Application contracts;
+-   redesign identity/canonicalization;
+-   redesign schema v2;
+-   introduce schema v3;
+-   add migrations beyond accepted v1→v2 behavior;
+-   redesign WP08 snapshot persistence;
+-   redesign WP09 catalog semantics;
+-   redesign WP10 orchestration;
+-   redesign WP11 failure vocabulary/classification;
+-   change WP12 Worker execution;
+-   add scheduling, streaming, refresh, DAG, retry policy, monitoring,
+    or Release 1.3 behavior;
+-   add provider/network integration tests;
+-   add live Twelve Data tests;
+-   stage, commit, push, create branches, create PRs, merge, tag, or
+    release.
+
+## Validation Gates
+
+After implementation run, at minimum:
+
+1.  Targeted Infrastructure tests.
+2.  Domain tests.
+3.  Application tests.
+4.  Full Infrastructure tests.
+5.  Architecture tests.
+6.  Restore.
+7.  Format verification.
+8.  Build with zero warnings/errors.
+9.  Canonical `eng/verify.ps1 -Configuration Release`.
+10. Gitleaks through the canonical verification path.
+11. `git diff --check`.
+12. `git diff --cached --check`.
+13. Direct whitespace checks for untracked WP14 files where normal Git
+    diff does not cover them.
+14. Architecture/dependency reconciliation.
+15. Temporary SQLite residue scan.
+
+Expected permanent total is **at least 163** and should increase only by
+justified WP14 Infrastructure tests. Report exact before/after counts.
+
+## Acceptance Matrix
+
+WP14 is complete only if evidence supports all applicable rows:
+
+-   schema v2 bootstrap: PASS
+-   v1→v2 upgrade: PASS
+-   Release 1.1 data preservation across upgrade: PASS
+-   unsupported future version rejection: PASS
+-   schema validation/non-destructive behavior: PASS
+-   connection lifecycle: PASS
+-   mapper fidelity: PASS
+-   non-empty snapshot persistence: PASS
+-   empty snapshot persistence: PASS
+-   equivalent existing behavior: PASS
+-   integrity conflict/non-overwrite: PASS
+-   atomic rollback: PASS
+-   multiple versions coexist: PASS
+-   catalog new/equivalent/conflict registration: PASS
+-   exact catalog hit/miss: PASS
+-   exact version lookup isolation: PASS
+-   identity/version fidelity: PASS
+-   target/boundary/coverage fidelity: PASS
+-   provenance/lineage fidelity: PASS
+-   timestamp/offset fidelity: PASS
+-   decimal fidelity: PASS
+-   unavailable failure mapping: PASS
+-   invalid-data failure mapping: PASS
+-   unknown failure propagation: PASS
+-   Infrastructure DI/configuration: PASS
+-   resolution-time database mutation: NO
+-   provider/network calls: 0
+-   temporary SQLite residue: 0
+-   Release 1.1 persistence regression: PASS
+-   production architecture regression: PASS
+-   package/reference delta: 0/0 unless separately justified by
+    authority
+-   WP15 started: NO
+-   Release 1.3 implementation started: NO
+
+## GitHub Lifecycle
+
+When and only when all WP14 acceptance gates pass:
+
+1.  Post concise completion evidence to issue #134.
+2.  Close issue #134.
+3.  Set its Project #2 status to Done.
+4.  Verify issue #135 remains Open / Backlog.
+5.  Leave milestone #53 open.
+
+Do not mutate later WP issues except to inspect their state.
+
+If a blocker remains, leave #134 open/in progress and report the blocker
+precisely.
+
+## Required Execution Report
+
+Return a structured report covering:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Predecessor/Lifecycle Gates
+7.  Issue Lifecycle
+8.  Initial Baseline
+9.  Existing Infrastructure Test Inventory
+10. WP07 Schema/Upgrade Reconciliation
+11. WP08 Snapshot-Persistence Reconciliation
+12. WP09 Catalog Reconciliation
+13. WP11 Failure-Mapping Reconciliation
+14. WP12 Composition Reconciliation
+15. Test Isolation Strategy
+16. Schema v2 Coverage
+17. v1→v2 Upgrade Coverage
+18. Connection Lifecycle Coverage
+19. Mapper Fidelity Coverage
+20. Snapshot Persistence Coverage
+21. Empty Snapshot Coverage
+22. Equivalent Existing Coverage
+23. Integrity Conflict / Immutability Coverage
+24. Atomic Rollback Coverage
+25. Multiple-Version Coverage
+26. Catalog Registration Coverage
+27. Exact Lookup Coverage
+28. Failure-Mapping Coverage
+29. DI/Configuration Coverage
+30. Release 1.1 Regression Protection
+31. Exact Files Added/Modified
+32. Production Code Delta
+33. Package/Reference Delta
+34. Permanent Test Count Delta
+35. Targeted Infrastructure Evidence
+36. Full Permanent Test Evidence
+37. Canonical Verification
+38. Architecture Validation
+39. Security/Offline Determinism
+40. Database Cleanup Evidence
+41. Whitespace/Diff Evidence
+42. Mutation Accounting
+43. Git/GitHub Protection
+44. Planning Protection
+45. Findings/Blockers
+46. Acceptance Matrix
+47. Final Repository/GitHub State
+48. WP15 Handoff
+49. Final Decision
+50. Next Authorized Work Package
+
+End a successful execution exactly with:
+
+`RELEASE 1.2 WP14 COMPLETE`
+
+and:
+
+`NEXT AUTHORIZED WORK PACKAGE: WP15 — Architecture & Documentation Alignment — GitHub issue #135`
+
+If blocked, end with:
+
+`RELEASE 1.2 WP14 BLOCKED`
+
+and do not authorize WP15.

--- a/docs/roadmap/release-1.2/prompts/15-architecture-documentation-alignment-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/15-architecture-documentation-alignment-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read `15-architecture-documentation-alignment-codex-prompt.md` completely as the sole WP15 authority and reconcile accepted WP01-WP14 implementation, tests, and documentation before mutation.
+Align only manifest-authorized current-state documentation with Release 1.1-to-1.2 architecture, dataset semantics, schema v2, persistence/catalog, failure, DI, Worker, and 171-test evidence.
+Keep production/test/package/reference deltas zero, preserve Domain/Application storage independence and all implemented-vs-planned boundaries, and keep Release 1.3 future-only.
+Do not stage, commit, push, branch, PR, merge, tag, or start WP16; leave #136 Open/Backlog and run all required link, build, test, security, whitespace, and contradiction gates.
+Close #135/mark Done only after every gate passes; otherwise stop with the precise blocker and smallest corrective authority.

--- a/docs/roadmap/release-1.2/prompts/15-architecture-documentation-alignment-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/15-architecture-documentation-alignment-codex-prompt.md
@@ -1,0 +1,620 @@
+# Release 1.2 WP15 --- Architecture & Documentation Alignment --- Codex Execution Authority
+
+## Purpose
+
+Execute **Release 1.2 WP15 --- Architecture & Documentation Alignment**
+for:
+
+`samuel-santos-engineer/AIQuantTradingResearch`
+
+WP15 reconciles the accepted Release 1.2 implementation through WP14
+with the repository's authoritative current-state architecture and
+engineering documentation.
+
+This is a **documentation and architecture-alignment work package**. It
+must describe what the repository actually implements, preserve
+architectural boundaries, distinguish implemented behavior from future
+plans, and introduce no new product behavior.
+
+## Recommended Model
+
+**GPT-5.6 Terra**
+
+WP15 is reconciliation-heavy rather than invention-heavy. The
+implementation, schema, contracts, persistence behavior, execution
+model, and permanent proof already exist. Terra is the cost-effective
+model for systematic repository/documentation reconciliation.
+
+Do not escalate to Sol merely for documentation breadth. If a genuine
+architecture contradiction is discovered that cannot be resolved without
+changing accepted production behavior, stop and report the smallest
+corrective authority instead of redesigning the system.
+
+## Authoritative Inputs
+
+Before any mutation, read and reconcile completely:
+
+1.  `RELEASE_1.2_EXECUTION_PLAN.md`
+2.  `RELEASE_1.2_FILE_MANIFEST.md`
+3.  Accepted WP02--WP14 authority/result state
+4.  `docs/architecture/data/RESEARCH_DATASET_DEFINITION.md`
+5.  `docs/architecture/data/DATASET_IDENTITY_VERSION_PROVENANCE.md`
+6.  Current Release 1.1 persistence architecture documentation
+7.  Current solution/design/implementation/testing documentation
+    relevant to the implemented Release 1.2 surface
+8.  Current README/navigation where Release 1.2 current-state claims are
+    exposed
+9.  Current Domain/Application/Infrastructure/Worker source
+10. Current permanent tests, including WP13 and WP14
+11. GitHub issue #135, milestone #53, and Project #2 state
+12. Current repository/Git state
+
+Repository implementation and accepted Release 1.2 semantics are the
+source of truth for current-state documentation.
+
+Do not silently reinterpret accepted WP02/WP03 semantics.
+
+## Starting-State Gates
+
+Before modifying documentation:
+
+-   Confirm repository identity.
+-   Confirm current branch and local/remote relationship.
+-   Confirm staged paths = 0.
+-   Classify every existing working-tree path.
+-   Preserve accepted cumulative Release 1.2 artifacts.
+-   Confirm issue #134 is **Closed / Done**.
+-   Confirm issue #135 is **Open / Backlog**.
+-   Confirm issue #136 remains **Open / Backlog**.
+-   Confirm milestone #53 remains open.
+-   Confirm WP15 dependencies match authoritative planning.
+-   Confirm no Release 1.3 implementation is active.
+-   Run the canonical baseline before mutation.
+
+Expected permanent test baseline:
+
+-   Domain.Tests: **11**
+-   Application.Tests: **60**
+-   Infrastructure.Tests: **87**
+-   Architecture.Tests: **13**
+-   Total: **171**
+
+If repository truth differs, reconcile before proceeding.
+
+Only after all starting gates pass may #135 move **Backlog → In
+Progress**.
+
+## Core Alignment Objective
+
+Documentation must accurately represent the accepted Release 1.2
+architecture now implemented through WP14:
+
+**Release 1.2 --- Research Dataset Foundation**
+
+The repository now supports deterministic, immutable, versioned research
+datasets materialized from accepted Release 1.1 historical observations,
+with semantic identity, reproducibility, provenance, lineage,
+SQLite-backed immutable snapshot/catalog evidence, bounded execution,
+validation/failure mapping, and permanent Application/Infrastructure
+proof.
+
+Do not describe Release 1.3 pipeline capabilities as implemented.
+
+## Required Architecture Reconciliation
+
+### 1. Production Dependency Graph
+
+Verify and document the actual graph:
+
+-   Domain → none
+-   Application → Domain
+-   Infrastructure → Application
+-   Worker → Application, Infrastructure
+
+Confirm:
+
+-   cycles = 0;
+-   Domain remains provider/storage independent;
+-   Application remains provider/storage independent;
+-   SQLite remains Infrastructure-owned;
+-   provider/HTTP mechanics remain Infrastructure-owned;
+-   Worker remains composition/execution host.
+
+Do not alter production references in WP15.
+
+### 2. Release 1.1 Foundation Relationship
+
+Document clearly that Release 1.2 **builds on**, rather than replaces,
+Release 1.1.
+
+Release 1.1 remains responsible for accepted historical market
+observations and their SQLite persistence/retrieval foundation.
+
+Release 1.2 uses those accepted observations as dataset source truth.
+
+Preserve Release 1.1 guarantees including:
+
+-   exact target identity;
+-   immutable/idempotent historical observations;
+-   deterministic conflict behavior;
+-   chronological retrieval;
+-   timestamp/offset fidelity;
+-   decimal fidelity;
+-   explicit persistence configuration;
+-   Infrastructure-owned SQLite.
+
+### 3. Dataset Definition and Reproducibility
+
+Align documentation with WP02:
+
+-   Research Dataset;
+-   Dataset Definition;
+-   Materialization;
+-   Snapshot;
+-   exact single target;
+-   explicit `[from,to)` selection;
+-   deterministic ascending semantic-instant ordering;
+-   successful empty materialization;
+-   exact offset/decimal fidelity;
+-   reproducibility based on definition + relevant source state;
+-   immutable prior snapshots when source history changes.
+
+### 4. Identity, Version, Provenance, and Lineage
+
+Align with WP03 and implementation:
+
+Distinct concepts:
+
+-   Dataset Definition Identity
+-   Research Dataset Identity
+-   Source State Identity
+-   Dataset Snapshot Identity
+-   Dataset Version
+
+Document:
+
+-   Dataset Version is the immutable Snapshot Identity representation;
+-   identity scheme `aiq-dataset-identity-v1`;
+-   SHA-256 / 64 lowercase hexadecimal representation;
+-   deterministic canonical semantic representation;
+-   equivalent rematerialization semantics;
+-   relevant source-state changes create distinguishable snapshot
+    identities;
+-   operational metadata is excluded from semantic identity;
+-   identities are immutable and cannot be reassigned;
+-   provenance explains definition/source/identity facts;
+-   lineage connects snapshot, definition, source state, and selected
+    observations.
+
+Avoid exposing low-level implementation detail where architecture
+documentation should remain semantic.
+
+### 5. Application Dataset Contracts
+
+Document the accepted Application-owned dataset seam:
+
+-   `DatasetDefinition`
+-   typed identities and `DatasetVersion`
+-   `DatasetSnapshotCandidate`
+-   coverage
+-   provenance
+-   lineage
+-   materialization result/failure vocabulary
+-   `IMaterializeDatasetUseCase`
+-   `IDatasetSnapshotStore`
+-   `IDatasetCatalog`
+-   bounded materialization integration seam
+
+Make clear that Application contracts contain no SQLite, SQL,
+filesystem, provider, or HTTP mechanics.
+
+### 6. Deterministic Materialization
+
+Align with WP05:
+
+-   exact target-scoped source history;
+-   `[from,to)` selection;
+-   deterministic ordering;
+-   duplicate semantic-instant rejection;
+-   valid empty result;
+-   preservation of original offsets and decimal values;
+-   deterministic identity computation;
+-   coverage/provenance/lineage construction;
+-   no persistence/catalog side effect inside the pure materialization
+    use case.
+
+### 7. Catalog Metadata Model
+
+Align with WP06:
+
+-   immutable catalog evidence;
+-   identity-bearing versus deterministic descriptive metadata;
+-   exact snapshot lookup;
+-   Research Dataset identity distinct from Snapshot identity/version;
+-   multiple immutable versions may coexist;
+-   no mutable "latest" semantics;
+-   no operational metadata in semantic identity;
+-   no physical-storage detail in Application catalog contracts.
+
+### 8. SQLite Physical Dataset Model
+
+Align with accepted WP07 state:
+
+-   SQLite schema version **2**;
+-   explicit v1→v2 evolution;
+-   preservation of Release 1.1 `historical_observations`;
+-   dataset snapshot descriptor/catalog evidence;
+-   ordered snapshot observation membership;
+-   exact target representation;
+-   UTC ticks + original offset representation;
+-   invariant exact decimal text;
+-   explicit empty-snapshot representation without sentinel
+    observations;
+-   accepted constraints/keys/indexes/ordering strategy;
+-   non-destructive schema validation.
+
+Do not invent schema v3 or future migration policy beyond current
+accepted design.
+
+### 9. Snapshot Persistence
+
+Align with WP08:
+
+-   immutable insert-only snapshot evidence;
+-   descriptor + membership atomicity;
+-   `NewlyAccepted`;
+-   equivalent existing evidence;
+-   `IntegrityConflict`;
+-   no overwrite/repair/delete semantics;
+-   empty snapshot persistence;
+-   multiple versions coexist;
+-   operation-owned connections;
+-   exact reconstruction fidelity.
+
+### 10. Catalog Persistence and Lookup
+
+Align with WP09:
+
+-   `NewlyRegistered`;
+-   `EquivalentExisting`;
+-   `IntegrityConflict`;
+-   exact typed Snapshot Identity lookup;
+-   `NotFound`;
+-   catalog registration reuses accepted immutable snapshot evidence;
+-   no second persistence model;
+-   no latest/search/listing semantics.
+
+### 11. Materialization Integration
+
+Align with WP10:
+
+Describe the bounded Application orchestration joining:
+
+1.  materialization;
+2.  snapshot persistence;
+3.  catalog registration.
+
+Preserve fail-stop semantics.
+
+Document outcome behavior at an architectural level without creating new
+vocabulary.
+
+Do not describe distributed transactions, eventual consistency, retries,
+or pipeline orchestration that do not exist.
+
+### 12. Validation and Failure Mapping
+
+Align with WP11:
+
+-   Application constructors enforce semantic invariants;
+-   Infrastructure validates physical schema and reconstructed evidence;
+-   `DatasetStoreFailure.Unavailable`;
+-   `DatasetStoreFailure.InvalidData`;
+-   integrity conflict remains distinct;
+-   catalog miss remains `NotFound`;
+-   unknown/unclassified failures are not silently normalized;
+-   SQLite-specific mechanics do not leak into Domain/Application;
+-   no catch-all exception normalization.
+
+### 13. Dependency Registration and Bounded Worker Execution
+
+Align with WP12:
+
+-   Application dataset use cases registered through existing
+    composition conventions;
+-   Infrastructure snapshot store/catalog registrations;
+-   existing SQLite configuration/factory ownership preserved;
+-   `Persistence:DatabasePath`;
+-   `Dataset:Target`;
+-   `Dataset:From`;
+-   `Dataset:To`;
+-   deterministic configuration rejection;
+-   one bounded Worker dataset execution;
+-   first execution may accept new evidence;
+-   equivalent rerun recognizes existing evidence;
+-   no scheduling, looping, refresh, pipeline, retry, or streaming
+    behavior.
+
+Do not imply that the Worker is a Release 1.3 pipeline engine.
+
+### 14. Testing Strategy and Current Evidence
+
+Update current-state testing documentation where authorized to reflect:
+
+-   Domain.Tests: 11
+-   Application.Tests: 60
+-   Infrastructure.Tests: 87
+-   Architecture.Tests: 13
+-   Permanent total: 171
+
+Describe responsibility boundaries:
+
+-   Domain: Domain-owned invariants;
+-   Application: dataset contracts, deterministic materialization,
+    identities, catalog semantics, orchestration/failure propagation;
+-   Infrastructure: schema v2, v1→v2 upgrade, SQLite fidelity, snapshot
+    persistence, catalog lookup, atomicity, failure containment, DI
+    boundary;
+-   Architecture: dependency/ownership rules.
+
+Do not turn transient probes from earlier WPs into claims of permanent
+tests.
+
+### 15. Implemented vs Planned
+
+Audit all touched documentation for wording that can confuse:
+
+-   implemented/current;
+-   accepted architecture;
+-   future/planned.
+
+Release 1.2 implemented scope may be described as current only where
+repository evidence supports it.
+
+Release 1.3 remains future work, including:
+
+-   continuous/periodic pipelines;
+-   scheduling;
+-   automatic refresh;
+-   streaming;
+-   DAG orchestration;
+-   retry/resilience orchestration;
+-   monitoring of dataset pipelines;
+-   production pipeline lifecycle.
+
+Do not accidentally promote roadmap intent to current capability.
+
+## Documentation Scope
+
+Use `RELEASE_1.2_FILE_MANIFEST.md` as the strict authority for files
+WP15 may modify.
+
+Do not modify unrelated documentation merely because it could be
+improved.
+
+Prefer targeted current-state corrections over broad rewrites.
+
+Preserve repository terminology, document organization, tone, and
+navigation conventions.
+
+Where an existing historical decision/assessment document describes an
+earlier state, preserve its historical nature and add only the minimum
+clarification needed to prevent it from being mistaken for current
+state.
+
+## Architecture Tests
+
+Inspect existing Architecture.Tests against the Release 1.2
+implementation.
+
+Default expectation: **architecture-test delta = 0**.
+
+Do not add architecture tests merely to increase counts.
+
+If an accepted Release 1.2 architectural rule is both:
+
+1.  important and mechanically enforceable, and
+2.  currently missing from executable architecture protection,
+
+report the gap first. Only modify Architecture.Tests if the execution
+plan/file manifest explicitly authorizes it for WP15.
+
+Never weaken an architecture rule to make the current implementation
+pass.
+
+## Production/Test Mutation Protection
+
+Expected WP15 deltas:
+
+-   Domain production: 0
+-   Application production: 0
+-   Infrastructure production: 0
+-   Worker production: 0
+-   Permanent functional tests: 0
+-   Packages: 0
+-   Project references: 0
+-   Solution/build/scripts: 0
+
+If documentation cannot be made truthful without changing accepted
+production behavior, stop and report a blocker.
+
+## Validation Gates
+
+After documentation alignment, run:
+
+1.  repository-relative Markdown link validation for touched/current
+    navigation;
+2.  restore;
+3.  format verification;
+4.  build;
+5.  Domain.Tests;
+6.  Application.Tests;
+7.  Infrastructure.Tests;
+8.  Architecture.Tests;
+9.  canonical `eng/verify.ps1 -Configuration Release`;
+10. Gitleaks through canonical verification;
+11. `git diff --check`;
+12. `git diff --cached --check`;
+13. direct whitespace checks for untracked WP15 documentation where
+    necessary;
+14. production dependency graph reconciliation;
+15. documentation contradiction audit;
+16. implemented-vs-planned terminology audit;
+17. temporary database/residue check where canonical validation creates
+    any transient state.
+
+Required final permanent baseline:
+
+-   Domain: 11/11
+-   Application: 60/60
+-   Infrastructure: 87/87
+-   Architecture: 13/13
+-   Total: **171/171**
+-   skipped: 0 unless repository baseline already proves otherwise
+-   build warnings/errors: 0/0
+
+## Documentation Acceptance Matrix
+
+WP15 is complete only if all applicable rows pass:
+
+-   manifest-authorized documentation scope: PASS
+-   Release 1.1 → Release 1.2 relationship: PASS
+-   production dependency graph alignment: PASS
+-   Domain storage/provider independence: PASS
+-   Application storage/provider independence: PASS
+-   SQLite Infrastructure ownership: PASS
+-   Research Dataset vocabulary: PASS
+-   deterministic definition/selection/ordering: PASS
+-   reproducibility semantics: PASS
+-   four identity concepts: PASS
+-   Dataset Version semantics: PASS
+-   canonical identity scheme representation: PASS
+-   provenance semantics: PASS
+-   lineage semantics: PASS
+-   catalog metadata semantics: PASS
+-   schema v2 alignment: PASS
+-   v1→v2 evolution alignment: PASS
+-   Release 1.1 historical-data preservation: PASS
+-   snapshot persistence semantics: PASS
+-   catalog persistence/lookup semantics: PASS
+-   materialization integration semantics: PASS
+-   validation/failure mapping alignment: PASS
+-   DI/configuration alignment: PASS
+-   bounded Worker execution alignment: PASS
+-   successful empty snapshot semantics: PASS
+-   multiple immutable versions: PASS
+-   timestamp/offset/decimal fidelity: PASS
+-   testing strategy/count alignment: PASS
+-   implemented-vs-planned distinction: PASS
+-   Release 1.3 capability leakage: 0
+-   cross-document contradictions: 0
+-   broken repository-relative links introduced: 0
+-   production code delta: 0
+-   permanent functional test delta: 0
+-   architecture-test delta: 0 unless separately authorized
+-   package/reference delta: 0/0
+-   permanent tests: 171/171
+-   WP16 started: NO
+
+## Explicit Non-Goals
+
+WP15 must not:
+
+-   redesign dataset semantics;
+-   change identity canonicalization;
+-   change schema;
+-   add schema v3;
+-   change persistence behavior;
+-   change catalog behavior;
+-   change failure mapping;
+-   change DI behavior;
+-   change Worker execution;
+-   add product features;
+-   add Release 1.3 pipelines;
+-   add scheduling/streaming/refresh/retries;
+-   add packages/references;
+-   stage/commit/push;
+-   create branches/PRs;
+-   merge/tag/release;
+-   start WP16.
+
+## GitHub Lifecycle
+
+When and only when every WP15 gate passes:
+
+1.  Post concise completion evidence to issue #135.
+2.  Close issue #135.
+3.  Set Project #2 status to Done.
+4.  Verify #136 remains **Open / Backlog**.
+5.  Leave milestone #53 open.
+
+Do not start or mutate WP16 beyond state inspection.
+
+If blocked, leave #135 open/in progress and report the exact blocker.
+
+## Required Execution Report
+
+Return a structured report covering:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Repository Context
+4.  Initial Git State
+5.  Working-Tree Classification
+6.  Predecessor/Lifecycle Gates
+7.  Issue Lifecycle
+8.  Initial Baseline
+9.  Manifest Documentation Scope
+10. Release 1.1 Foundation Reconciliation
+11. Production Dependency Graph Reconciliation
+12. WP02 Dataset Definition/Reproducibility Alignment
+13. WP03 Identity/Version/Provenance/Lineage Alignment
+14. WP04 Application Contract Alignment
+15. WP05 Materialization Alignment
+16. WP06 Catalog Metadata Alignment
+17. WP07 Physical Storage Alignment
+18. WP08 Snapshot Persistence Alignment
+19. WP09 Catalog Persistence/Lookup Alignment
+20. WP10 Integration Alignment
+21. WP11 Validation/Failure Mapping Alignment
+22. WP12 DI/Bounded Execution Alignment
+23. WP13/WP14 Testing Alignment
+24. Implemented-vs-Planned Audit
+25. Release 1.3 Protection
+26. Architecture-Test Decision
+27. Exact Documentation Files Added/Modified
+28. Production Code Delta
+29. Permanent Test Delta
+30. Architecture-Test Delta
+31. Package/Reference Delta
+32. Documentation/Link Validation
+33. Restore/Build Evidence
+34. Permanent Test Evidence
+35. Canonical Verification
+36. Architecture Validation
+37. Security/Offline Evidence
+38. Whitespace/Diff Evidence
+39. Cross-Document Contradiction Audit
+40. Mutation Accounting
+41. Git/GitHub Protection
+42. Planning Protection
+43. Findings/Blockers
+44. Acceptance Matrix
+45. Final Repository/GitHub State
+46. WP16 Handoff
+47. Final Decision
+48. Next Authorized Work Package
+
+A successful report must end exactly with:
+
+`RELEASE 1.2 WP15 COMPLETE`
+
+and:
+
+`NEXT AUTHORIZED WORK PACKAGE: WP16 — Full Validation, Integration & Acceptance — GitHub issue #136`
+
+If blocked, end with:
+
+`RELEASE 1.2 WP15 BLOCKED`
+
+and do not authorize WP16.

--- a/docs/roadmap/release-1.2/prompts/16-full-validation-integration-acceptance-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/16-full-validation-integration-acceptance-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Read `16-full-validation-integration-acceptance-codex-prompt.md` completely as the sole WP16 authority and reconcile the complete accepted Release 1.2 candidate and GitHub state before transport.
+Require the accepted 171-test baseline, semantic/architecture/security/offline/documentation checks, exact candidate accounting, post-commit validation, and fresh-checkout reproducibility.
+Only after every gate passes create exactly branch `release/1.2-research-dataset-foundation`, one integration commit, one pushed review-ready PR, and no merge, tag, milestone closure, or Release 1.3 work.
+Do not stage or include this out-of-band corrective pair; keep #136 Open/Backlog until the exact PR exists, and preserve all accepted WP01-WP15 files.
+Finish only with the prescribed WP16 COMPLETE marker when every gate passes; otherwise emit WP16 BLOCKED with the smallest corrective authority required.

--- a/docs/roadmap/release-1.2/prompts/16-full-validation-integration-acceptance-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/16-full-validation-integration-acceptance-codex-prompt.md
@@ -1,0 +1,566 @@
+# Release 1.2 WP16 --- Full Validation, Integration & Acceptance --- Codex Execution Authority
+
+## Execution model
+
+Use **GPT-5.6 Sol** for this work package.
+
+WP16 is the release-wide reconciliation and integration authority. It
+requires high-confidence reasoning across the complete Release 1.2
+candidate, the authoritative execution plan/file manifest, architecture,
+tests, Git state, GitHub lifecycle, and integration boundaries.
+
+------------------------------------------------------------------------
+
+## 1. Authority
+
+You are authorized to execute **Release 1.2 WP16 --- Full Validation,
+Integration & Acceptance** for:
+
+-   Repository: `samuel-santos-engineer/AIQuantTradingResearch`
+-   GitHub issue: `#136`
+-   Milestone:
+    `#53 — Phase 3 - Release 1.2: Research Dataset Foundation`
+-   Project: `#2 — AIQuantTradingResearch Engineering Roadmap`
+
+This is the final implementation/integration work package for Release
+1.2.
+
+Read completely before mutation:
+
+1.  `RELEASE_1.2_EXECUTION_PLAN.md`
+2.  `RELEASE_1.2_FILE_MANIFEST.md`
+3.  this WP16 authority
+4.  all accepted Release 1.2 WP01--WP15 authority/evidence available in
+    the repository/worktree
+5.  the Release 1.2 semantic architecture artifacts
+6.  current production source and permanent tests
+7.  relevant Release 1.1 persistence authorities/current implementation
+8.  GitHub issue #136, milestone #53, and Project #2 state
+
+The execution plan and file manifest remain authoritative. Do not
+silently repair an authority contradiction. Stop and report the smallest
+corrective authority required if a mandatory requirement conflicts with
+repository truth.
+
+------------------------------------------------------------------------
+
+## 2. Required starting state
+
+Before changing Git or GitHub lifecycle state, prove:
+
+-   Release 1.1 is closed and remains intact.
+-   WP01--WP15 Release 1.2 issues are Closed/Done.
+-   issue #136 is Open/Backlog.
+-   milestone #53 is Open.
+-   no WP17+ Release 1.2 implementation package exists.
+-   Release 1.3 implementation has not started.
+-   local repository identity is correct.
+-   current branch is `main`.
+-   local `main` equals `origin/main`.
+-   ahead/behind is `0/0`.
+-   no files are staged.
+-   every tracked/untracked path is classified.
+-   all cumulative Release 1.2 candidate paths are expected under the
+    authoritative manifest or explicitly accepted authority.
+-   unexpected or ambiguous paths = 0.
+
+Do not discard, normalize, regenerate, or rewrite accepted cumulative
+WP01--WP15 work merely because it is uncommitted.
+
+Only after the starting-state gates pass may issue #136 move from
+Backlog to In Progress.
+
+------------------------------------------------------------------------
+
+## 3. Accepted technical baseline
+
+The accepted WP15 handoff baseline is:
+
+-   Domain.Tests: **11**
+-   Application.Tests: **60**
+-   Infrastructure.Tests: **87**
+-   Architecture.Tests: **13**
+-   Permanent total: **171**
+
+Expected production dependency graph:
+
+-   Domain → none
+-   Application → Domain
+-   Infrastructure → Application
+-   Worker → Application, Infrastructure
+
+Expected schema state:
+
+-   Release 1.1 historical-observation foundation preserved.
+-   SQLite schema current version: **2**.
+-   v1 → v2 upgrade supported and non-destructive.
+-   dataset snapshot/catalog evidence uses the accepted v2 physical
+    model.
+
+WP16 must not casually change these counts, architecture rules, or
+schema. Any delta must be explicitly required by the authoritative
+manifest and reconciled before proceeding.
+
+------------------------------------------------------------------------
+
+## 4. WP16 objective
+
+Validate the complete Release 1.2 candidate as one coherent release,
+prove reproducibility from a clean checkout, integrate it into exactly
+one release branch/commit candidate, push it without history rewriting,
+and open a review-ready pull request against `main`.
+
+WP16 is an **integration and acceptance** package, not a redesign
+package.
+
+Do not introduce new product behavior to make validation pass.
+
+------------------------------------------------------------------------
+
+## 5. Candidate reconciliation
+
+Build the candidate inventory from repository truth and
+`RELEASE_1.2_FILE_MANIFEST.md`.
+
+Prove and report:
+
+-   exact governed candidate path count;
+-   every required path present;
+-   missing governed paths = 0;
+-   unexpected governed paths = 0;
+-   duplicate logical artifacts = 0;
+-   temporary/generated residue = 0;
+-   no out-of-band authority accidentally included;
+-   no Release 1.3 implementation path included.
+
+Validate Release 1.2 prompt/governance conventions required by the
+manifest, including standard prompt/chat pairs and five-line bootstrap
+companions where applicable.
+
+Do not guess the candidate count in advance. Derive it from the accepted
+manifest and actual worktree.
+
+------------------------------------------------------------------------
+
+## 6. Semantic reconciliation
+
+Validate the complete accepted Release 1.2 model.
+
+### Dataset definition and reproducibility
+
+Prove preservation of:
+
+-   exact single target;
+-   explicit `[from, to)` selection;
+-   deterministic semantic-instant ordering;
+-   valid successful empty materialization;
+-   exact `DateTimeOffset` offset fidelity;
+-   exact decimal fidelity;
+-   deterministic equivalent re-materialization.
+
+### Identity/version/provenance
+
+Prove preservation of:
+
+-   Dataset Definition Identity;
+-   Research Dataset Identity;
+-   Source State Identity;
+-   Dataset Snapshot Identity;
+-   Dataset Version = immutable Snapshot Identity semantics;
+-   `aiq-dataset-identity-v1`;
+-   canonical deterministic representation;
+-   SHA-256 / 64 lowercase hexadecimal fingerprints;
+-   provenance and narrow lineage;
+-   source-state change distinguishability;
+-   snapshot immutability;
+-   no identity reassignment.
+
+### Application boundaries
+
+Prove:
+
+-   contracts remain provider independent;
+-   contracts remain storage independent;
+-   materialization remains Application-owned;
+-   materialization reads accepted Release 1.1 observations through the
+    Application seam;
+-   catalog metadata remains immutable semantic evidence;
+-   WP10 integration remains bounded and fail-stop.
+
+### Physical persistence
+
+Prove:
+
+-   SQLite ownership remains Infrastructure-only;
+-   schema version 2 is authoritative;
+-   v1 → v2 upgrade preserves Release 1.1 history;
+-   snapshot descriptor/membership evidence is immutable;
+-   empty snapshots are represented without sentinel observations;
+-   equivalent evidence is non-mutating;
+-   contradictory same-identity evidence is an integrity conflict;
+-   multiple immutable versions coexist;
+-   writes are atomic;
+-   exact lookup is by typed Snapshot Identity;
+-   catalog miss remains `NotFound`;
+-   timestamp offsets and decimals round-trip exactly.
+
+### Failure mapping
+
+Prove:
+
+-   `Unavailable` and `InvalidData` remain distinct storage failures;
+-   integrity conflict remains distinct and non-destructive;
+-   unknown/unclassified failures are not silently swallowed;
+-   SQLite implementation details do not leak into Domain/Application
+    public semantics.
+
+### Composition and Worker
+
+Prove:
+
+-   required dataset services resolve through accepted DI;
+-   graph resolution itself does not create a database;
+-   `Persistence:DatabasePath` remains the storage configuration
+    boundary;
+-   `Dataset:Target`, `Dataset:From`, and `Dataset:To` remain the
+    bounded execution inputs;
+-   valid Worker execution performs one bounded
+    materialization/integration operation;
+-   repeat execution against equivalent source state produces
+    equivalent-existing behavior;
+-   no scheduling, streaming, refresh loop, DAG, retry orchestration, or
+    Release 1.3 pipeline behavior exists.
+
+------------------------------------------------------------------------
+
+## 7. Permanent test acceptance
+
+Run the authoritative permanent suites.
+
+Required accepted baseline unless an authority explicitly says
+otherwise:
+
+-   Domain.Tests: 11/11
+-   Application.Tests: 60/60
+-   Infrastructure.Tests: 87/87
+-   Architecture.Tests: 13/13
+-   Total: 171/171
+-   skipped: 0
+
+Run canonical repository verification in the configuration established
+by the accepted repository workflow. Prefer the Release configuration
+where prior accepted WP evidence requires it.
+
+Required:
+
+-   restore: PASS;
+-   format verification: PASS;
+-   build: PASS;
+-   warnings/errors: 0/0;
+-   permanent tests: PASS;
+-   architecture tests: PASS;
+-   canonical `eng/verify.ps1`: PASS;
+-   Gitleaks/secret scan: PASS;
+-   `git diff --check`: PASS;
+-   `git diff --cached --check`: PASS;
+-   documentation/link audit: PASS where repository conventions require
+    it;
+-   temporary SQLite residue: 0.
+
+Do not weaken tests, suppress warnings, bypass architecture rules, or
+alter security tooling to obtain a pass.
+
+------------------------------------------------------------------------
+
+## 8. Release 1.1 regression protection
+
+Explicitly prove the Release 1.1 historical-observation foundation
+remains valid after the cumulative Release 1.2 candidate.
+
+At minimum reconcile:
+
+-   historical SQLite persistence/retrieval;
+-   idempotency;
+-   conflict preservation;
+-   atomicity;
+-   immutable accepted history;
+-   target isolation;
+-   deterministic ordering;
+-   timestamp/offset fidelity;
+-   decimal fidelity;
+-   successful empty retrieval;
+-   failure mapping;
+-   existing persistence configuration;
+-   operation-owned connection lifecycle.
+
+------------------------------------------------------------------------
+
+## 9. Fresh-checkout reproducibility
+
+Before opening the PR, validate the exact integration candidate from a
+clean detached checkout/worktree.
+
+The fresh validation must use the exact candidate commit that will be
+pushed.
+
+Prove:
+
+-   restore: PASS;
+-   format verification: PASS;
+-   build: PASS;
+-   warnings/errors: 0/0;
+-   permanent tests: 171/171 unless an authorized final count differs;
+-   Architecture.Tests: 13/13;
+-   canonical verification: PASS;
+-   security scan: PASS;
+-   temporary database residue: 0;
+-   checkout working tree: CLEAN.
+
+Do not use uncommitted files from the original worktree to make the
+fresh checkout pass.
+
+------------------------------------------------------------------------
+
+## 10. Integration branch and commit authority
+
+Only after all pre-integration acceptance gates pass:
+
+1.  create/switch to the dedicated Release 1.2 integration branch:
+    `release/1.2-research-dataset-foundation`
+2.  stage **only** the fully reconciled Release 1.2 candidate.
+3.  verify staged path inventory against the authoritative manifest.
+4.  verify no secrets/generated residue/out-of-scope files are staged.
+5.  create exactly **one integration commit** for the Release 1.2
+    candidate.
+
+Preferred commit message:
+
+`feat: establish Release 1.2 research dataset foundation`
+
+Do not:
+
+-   amend historical commits;
+-   rebase published history;
+-   squash unrelated existing history;
+-   force push;
+-   create multiple Release 1.2 integration commits unless an
+    unavoidable external Git failure makes the first commit
+    unusable---in that case stop and report rather than improvising;
+-   merge to `main`.
+
+After commit, require a clean working tree and rerun post-commit
+acceptance before push.
+
+------------------------------------------------------------------------
+
+## 11. Push authority
+
+After post-commit and fresh-checkout validation pass:
+
+-   push the integration branch normally;
+-   set upstream if required;
+-   never force push;
+-   prove local branch SHA equals remote branch SHA;
+-   prove ahead/behind upstream = `0/0`.
+
+Do not push `main`.
+
+------------------------------------------------------------------------
+
+## 12. Pull request authority
+
+Create exactly one review-ready pull request:
+
+-   base: `main`
+-   head: `release/1.2-research-dataset-foundation`
+-   draft: NO
+-   auto-merge: disabled
+-   merge: DO NOT PERFORM
+
+Preferred title:
+
+`Release 1.2 — Research Dataset Foundation`
+
+The PR body must summarize:
+
+-   Release 1.2 purpose;
+-   deterministic dataset definition/reproducibility;
+-   identity/version/provenance model;
+-   Application contracts/materialization/catalog model;
+-   SQLite schema v2 and v1→v2 evolution;
+-   immutable snapshot/catalog persistence;
+-   bounded integration/failure mapping;
+-   DI/Worker bounded execution;
+-   permanent test counts;
+-   architecture/security/offline evidence;
+-   fresh-checkout reproducibility;
+-   explicit Release 1.3 exclusions.
+
+Include issue closure/reference information consistent with repository
+conventions, but do not cause premature merge or milestone closure.
+
+If a competing authoritative Release 1.2 integration PR already exists,
+stop and report rather than creating a duplicate.
+
+------------------------------------------------------------------------
+
+## 13. GitHub lifecycle
+
+Issue #136 may be closed/Done only after:
+
+-   candidate reconciliation passes;
+-   all technical acceptance passes;
+-   integration commit exists;
+-   post-commit validation passes;
+-   fresh-checkout validation passes;
+-   branch is pushed successfully;
+-   review-ready PR exists and points to the exact accepted head SHA.
+
+At completion:
+
+-   #121--#136 should be Closed/Done;
+-   milestone #53 must remain **OPEN** pending post-merge closure;
+-   PR must remain **OPEN / UNMERGED**;
+-   no Release 1.3 planning/implementation mutation is authorized.
+
+Do not close milestone #53 in WP16.
+
+Do not create a GitHub Release or tag unless separately authorized.
+
+Do not delete the integration branch.
+
+------------------------------------------------------------------------
+
+## 14. Scope prohibitions
+
+WP16 must not:
+
+-   redesign WP02--WP12 semantics;
+-   introduce new dataset capabilities;
+-   add Release 1.3 pipelines;
+-   add scheduling/streaming/automatic refresh;
+-   add retry/circuit-breaker orchestration;
+-   change identity scheme without corrective authority;
+-   redesign schema v2;
+-   alter Release 1.1 history;
+-   modify permanent tests merely to hide failures;
+-   weaken secret scanning;
+-   change package/project references unless the manifest explicitly
+    requires it;
+-   merge the PR;
+-   close milestone #53;
+-   tag/release;
+-   modify unrelated GitHub objects.
+
+If validation exposes a genuine defect requiring out-of-scope production
+or test redesign, stop and report it.
+
+------------------------------------------------------------------------
+
+## 15. Expected WP16 repository delta
+
+WP16 should normally add **no new product behavior**.
+
+Expected integration delta is the cumulative accepted Release 1.2
+candidate becoming staged/committed on the integration branch.
+
+Any WP16-specific repository content not already authorized by the
+manifest must be treated as suspicious and reconciled before inclusion.
+
+------------------------------------------------------------------------
+
+## 16. Required final report
+
+Produce a detailed execution report containing at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Initial Repository/Git State
+4.  Release 1.1 Closure/Reconciliation
+5.  WP01--WP15 Lifecycle Gate
+6.  Candidate Reconciliation
+7.  Governance Prompt-Pair Validation
+8.  Dataset Semantic Reconciliation
+9.  Identity/Version/Provenance Reconciliation
+10. Application Boundary Reconciliation
+11. Schema v2 / Upgrade Reconciliation
+12. Snapshot Persistence Reconciliation
+13. Catalog Reconciliation
+14. Integration Reconciliation
+15. Validation/Failure-Mapping Reconciliation
+16. DI/Worker Reconciliation
+17. Release 1.3 Exclusion Check
+18. Permanent Test Evidence
+19. Canonical Verification
+20. Architecture Validation
+21. Security/Offline Validation
+22. Release 1.1 Regression Evidence
+23. Documentation Acceptance
+24. Candidate Path Accounting
+25. Integration Branch
+26. Integration Commit SHA / Message / Parent / Commit Count
+27. Post-Commit Validation
+28. Fresh-Checkout Reproducibility
+29. Push Evidence
+30. Pull Request Number / URL / Base / Head / SHA / State
+31. GitHub Lifecycle State
+32. Mutation Accounting
+33. Final Repository State
+34. Findings / Blockers
+35. Acceptance Matrix
+36. Final Decision
+37. Next Authorized Lifecycle Action
+
+Report exact observed counts and SHAs. Do not fabricate values.
+
+------------------------------------------------------------------------
+
+## 17. Terminal completion marker
+
+Only when every mandatory WP16 gate passes, end with:
+
+``` text
+RELEASE 1.2 WP16 COMPLETE
+
+FULL VALIDATION, INTEGRATION & ACCEPTANCE:
+Manifest reconciliation: PASS
+Unexpected candidate paths: 0
+Build warnings/errors: 0/0
+Domain.Tests: 11/11
+Application.Tests: 60/60
+Infrastructure.Tests: 87/87
+Architecture.Tests: 13/13
+Permanent tests: 171/171
+Canonical verification: PASS
+Architecture acceptance: PASS
+Documentation acceptance: PASS
+Dataset semantic acceptance: PASS
+Identity/version/provenance acceptance: PASS
+Schema v2 / v1→v2 acceptance: PASS
+Snapshot persistence acceptance: PASS
+Catalog acceptance: PASS
+Integration acceptance: PASS
+Failure-mapping acceptance: PASS
+DI/Worker bounded execution acceptance: PASS
+Release 1.1 regression: PASS
+Security/offline validation: PASS
+Fresh-checkout reproducibility: PASS
+Working tree: CLEAN
+Integration branch pushed: PASS
+Pull request: OPEN / REVIEW-READY
+Pull request merged: NO
+Issue #136: CLOSED / DONE
+Milestone #53: OPEN
+Release 1.3 implementation started: NO
+
+NEXT AUTHORIZED LIFECYCLE ACTION:
+Human review and explicit merge authorization for the Release 1.2 integration pull request.
+```
+
+If any mandatory gate fails, do **not** emit the completion marker.
+Emit:
+
+`RELEASE 1.2 WP16 BLOCKED`
+
+and explain the exact blocker and smallest corrective authority
+required.

--- a/docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt-chat.md
+++ b/docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt-chat.md
@@ -1,0 +1,5 @@
+Execute Release 1.2 GitHub planning for `Phase 3 - Release 1.2: Research Dataset Foundation`.
+Read and follow `release-1.2-github-planning-codex-prompt.md` as the sole authoritative GitHub-planning contract, together with the accepted Release 1.2 execution plan and file manifest.
+Reconcile Project #2 first, including only the explicitly authorized `Release = 1.2` option addition if absent, preserve legacy milestone #43 closed/empty, then create or reconcile exactly the authoritative milestone and WP01–WP16 planning set.
+Validate exact dependencies, labels, assignee, Backlog/P1/Release 1.2/Area fields, prevent WP17+/lifecycle issues, and perform no repository implementation, Git transport, Release 1.3 work, or WP01 execution.
+Return the required planning execution report, ending only in `RELEASE 1.2 GITHUB PLANNING COMPLETE` or `RELEASE 1.2 GITHUB PLANNING BLOCKED`, then stop.

--- a/docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt.md
+++ b/docs/roadmap/release-1.2/prompts/release-1.2-github-planning-codex-prompt.md
@@ -1,0 +1,971 @@
+# Release 1.2 GitHub Planning --- Authoritative Codex Execution Prompt
+
+## 1. Authority
+
+This file is the authoritative GitHub-planning execution contract for:
+
+``` text
+Phase 3 - Release 1.2: Research Dataset Foundation
+```
+
+Repository:
+
+``` text
+samuel-santos-engineer/AIQuantTradingResearch
+```
+
+This authority begins only after the accepted Release 1.2 definition and
+the accepted governance pair exist:
+
+``` text
+docs/roadmap/release-1.2/RELEASE_1.2_EXECUTION_PLAN.md
+docs/roadmap/release-1.2/RELEASE_1.2_FILE_MANIFEST.md
+```
+
+This authority may create/reconcile Release 1.2 GitHub planning only.
+
+It does **not** authorize WP01 implementation.
+
+Successful terminal:
+
+``` text
+RELEASE 1.2 GITHUB PLANNING COMPLETE
+```
+
+Blocked terminal:
+
+``` text
+RELEASE 1.2 GITHUB PLANNING BLOCKED
+```
+
+------------------------------------------------------------------------
+
+## 2. Governing Authorities
+
+Before mutation, read completely:
+
+1.  `docs/roadmap/release-1.2/RELEASE_1.2_EXECUTION_PLAN.md`
+2.  `docs/roadmap/release-1.2/RELEASE_1.2_FILE_MANIFEST.md`
+3.  the accepted Release 1.2 planning/definition result;
+4.  the accepted Release 1.1 post-merge closure result;
+5.  current repository/GitHub truth;
+6.  current GitHub Project #2 schema and item conventions.
+
+The execution plan is authoritative for:
+
+-   Release identity;
+-   work-package titles;
+-   exact dependency graph;
+-   lifecycle sequence;
+-   implementation boundaries.
+
+The file manifest is authoritative for:
+
+-   governance artifact paths;
+-   prompt naming;
+-   allowed repository-side planning artifacts;
+-   ownership boundaries.
+
+GitHub planning must reflect those authorities exactly.
+
+------------------------------------------------------------------------
+
+## 3. Accepted Predecessor State
+
+Verify before any mutation:
+
+``` text
+Release 1.1 terminal = RELEASE 1.1 CLOSED
+PR #120 = MERGED
+Milestone #52 = CLOSED
+Issues #103–#118 = Closed / Done
+Active Release 1.2 authoritative planning = 0
+Release 1.2 implementation = NOT STARTED
+```
+
+Legacy milestone:
+
+``` text
+#43 — Phase 3 - Release 1.2: Storage
+```
+
+must be treated as historical only.
+
+Expected accepted historical state:
+
+``` text
+state = CLOSED
+issues = 0
+```
+
+Do not reuse milestone #43 as the authoritative Release 1.2 milestone.
+
+------------------------------------------------------------------------
+
+## 4. Planning Objective
+
+Create the complete GitHub planning representation for:
+
+``` text
+Phase 3 - Release 1.2: Research Dataset Foundation
+```
+
+The final planning model must contain:
+
+``` text
+1 authoritative Release 1.2 milestone
+16 authoritative WP issues
+16 Project #2 items
+exact dependency graph
+exact issue ownership/labels
+Status = Backlog
+Priority = P1
+Release = 1.2
+Area = mapped per this authority
+WP01 implementation = NOT STARTED
+Release 1.3 implementation = NOT STARTED
+```
+
+No WP17+ issue is authorized.
+
+No lifecycle-gate issue is authorized.
+
+------------------------------------------------------------------------
+
+## 5. Mutation Scope
+
+This authority may mutate only the following GitHub planning surfaces
+when all preflight gates pass:
+
+-   the existing Project #2 `Release` field by adding exactly one `1.2`
+    option **if and only if it is absent**;
+-   legacy milestone #43 state from OPEN → CLOSED **only if it is still
+    empty and all identity checks match**;
+-   one new authoritative Release 1.2 milestone;
+-   sixteen new/reconciled Release 1.2 WP issues;
+-   issue milestone assignments;
+-   issue labels;
+-   issue assignee;
+-   Project #2 item membership;
+-   Project #2 field values for those sixteen Release 1.2 items;
+-   issue dependency text/links in the issue bodies.
+
+No repository production/test/documentation implementation mutation is
+authorized.
+
+------------------------------------------------------------------------
+
+## 6. Explicitly Prohibited
+
+Do not:
+
+-   start WP01;
+-   move WP01 to `In Progress`;
+-   create WP17+;
+-   create a lifecycle-gate issue;
+-   create Release 1.3 issues;
+-   create Release 1.3 milestone;
+-   reopen or repurpose milestone #43;
+-   rename milestone #43;
+-   change milestone #43 description;
+-   assign issues to milestone #43;
+-   modify milestone #52;
+-   alter Release 1.1 issues;
+-   create or edit labels unless a later explicit authority permits it;
+-   change Project field names;
+-   delete Project fields/options;
+-   rename existing Project options;
+-   change existing Project option IDs;
+-   change Status/Priority/Area schema;
+-   create repository branches;
+-   stage files;
+-   commit;
+-   push;
+-   create PRs;
+-   change source;
+-   change tests;
+-   begin implementation.
+
+------------------------------------------------------------------------
+
+## 7. Authentication / Repository Identity Gate
+
+Before planning mutation verify:
+
+``` text
+GitHub authentication = PASS
+authenticated account = samuel-santos-engineer
+repository = samuel-santos-engineer/AIQuantTradingResearch
+default branch = main
+```
+
+Do not expose tokens, credentials, or sensitive authentication
+information.
+
+If repository/account identity does not match, stop.
+
+------------------------------------------------------------------------
+
+## 8. Repository Preservation Gate
+
+Inspect local Git before GitHub mutation.
+
+Expected:
+
+``` text
+branch = main
+main = origin/main
+ahead/behind = 0/0
+staged tracked changes = 0
+tracked modifications = 0
+```
+
+The Release 1.2 execution plan, file manifest, planning prompt, and
+five-line companion may exist as expected governance artifacts according
+to current repository workflow.
+
+Classify every visible repository change.
+
+No Git operation is authorized except read-only inspection.
+
+If unexpected user work or unexplained tracked mutation exists, stop
+rather than discarding it.
+
+------------------------------------------------------------------------
+
+## 9. Existing GitHub Planning Inspection
+
+Before creating anything, inventory:
+
+### Milestones
+
+Find:
+
+-   authoritative Release 1.2 milestone candidates;
+-   legacy #43;
+-   Release 1.1 milestone #52;
+-   any Release 1.3 planning objects.
+
+### Issues
+
+Search for:
+
+-   existing Release 1.2 WP01--WP16 identities;
+-   duplicates;
+-   WP17+;
+-   lifecycle-gate issues;
+-   issues accidentally assigned to legacy #43;
+-   Release 1.3 issues.
+
+### Project #2
+
+Inspect:
+
+-   Project identity/title;
+-   `Status` field/options;
+-   `Priority` field/options;
+-   `Release` field/options;
+-   `Area` field/options;
+-   existing Release 1.2 items.
+
+Do not mutate until the complete preflight is reconciled.
+
+------------------------------------------------------------------------
+
+## 10. Narrow Project Release-Option Reconciliation
+
+Required Project value:
+
+``` text
+Release = 1.2
+```
+
+If exactly one `1.2` option already exists:
+
+-   reuse it;
+-   do not recreate or rename it.
+
+If no `1.2` option exists, this authority explicitly permits **one
+narrow Project-schema mutation**:
+
+``` text
+Add exactly one option named `1.2`
+to Project #2's existing `Release` single-select field.
+```
+
+Preserve:
+
+-   field identity;
+-   all existing Release options;
+-   existing option IDs;
+-   existing names;
+-   existing colors/descriptions;
+-   all unrelated fields/options.
+
+Do not add any other option.
+
+If more than one `1.2` option already exists, or the `Release` field is
+not the expected single-select field, stop.
+
+Record pre/post option counts and IDs.
+
+------------------------------------------------------------------------
+
+## 11. Legacy Milestone #43 Reconciliation
+
+Verify identity exactly:
+
+``` text
+#43
+Phase 3 - Release 1.2: Storage
+```
+
+If #43 is CLOSED and empty:
+
+-   preserve it unchanged.
+
+If #43 is OPEN and empty:
+
+this authority explicitly permits exactly:
+
+``` text
+state = CLOSED
+```
+
+Preserve title, description, due date, and empty issue state.
+
+If #43 contains any issue, has been repurposed, or materially differs in
+identity, stop.
+
+Never use #43 for new planning.
+
+------------------------------------------------------------------------
+
+## 12. Duplicate / Collision Gate
+
+Before new object creation, determine whether an authoritative planning
+set already exists.
+
+Authoritative milestone identity:
+
+``` text
+Phase 3 - Release 1.2: Research Dataset Foundation
+```
+
+Authoritative WP identity is determined by WP number + exact title from
+Section 16.
+
+Rules:
+
+-   exactly zero or one authoritative milestone may exist before
+    reconciliation;
+-   exactly zero or one issue may represent each WP;
+-   no duplicate WP identity may remain;
+-   no competing active Release 1.2 milestone may remain;
+-   do not create duplicate issues merely because labels/body differ.
+
+If a complete authoritative planning set already exists, reconcile it
+idempotently rather than duplicating it.
+
+If ambiguous collisions cannot be reconciled safely, stop.
+
+------------------------------------------------------------------------
+
+## 13. Labels
+
+Reuse existing repository labels only.
+
+Required semantic labels:
+
+``` text
+research
+architecture
+feature
+infra
+tests
+```
+
+Do not create or edit labels.
+
+If a required label does not exist, stop and report the missing label.
+
+Each WP receives exactly one governed semantic label according to
+Section 16.
+
+------------------------------------------------------------------------
+
+## 14. Assignee
+
+Required assignee for all sixteen issues:
+
+``` text
+samuel-santos-engineer
+```
+
+Verify assignment permission before creation/reconciliation.
+
+Final:
+
+``` text
+assigned = 16/16
+additional assignees = 0
+```
+
+If assignment is not possible, stop before issue creation where
+possible.
+
+------------------------------------------------------------------------
+
+## 15. Authoritative Milestone
+
+Create or reconcile exactly one milestone titled:
+
+``` text
+Phase 3 - Release 1.2: Research Dataset Foundation
+```
+
+Required state:
+
+``` text
+OPEN
+```
+
+No due date is required unless an existing accepted authority explicitly
+provides one.
+
+Milestone description must concisely establish:
+
+-   objective: deterministic, versioned, reproducible, discoverable
+    research datasets;
+-   metadata/provenance/lineage/catalog scope;
+-   reuse of Release 1.1 durable historical observations;
+-   Release 1.3 pipeline orchestration explicitly out of scope;
+-   WP01--WP16 governed by the Release 1.2 execution plan/file manifest.
+
+Do not reuse #43.
+
+------------------------------------------------------------------------
+
+## 16. Authoritative Work-Package Mapping
+
+Create/reconcile exactly these sixteen issues.
+
+  ---------------------------------------------------------------------------------
+  WP             Exact Title       Depends On     Label            Project Area
+  -------------- ----------------- -------------- ---------------- ----------------
+  WP01           Release &         Release 1.1    `research`       Engineering
+                 Repository        CLOSED
+                 Preflight
+
+  WP02           Research Dataset  WP01           `research`       Data
+                 Definition &
+                 Reproducibility
+                 Model
+
+  WP03           Dataset Identity, WP02           `architecture`   Architecture
+                 Version &
+                 Provenance
+                 Semantics
+
+  WP04           Application       WP03           `feature`        Architecture
+                 Dataset Contracts
+
+  WP05           Dataset           WP04           `feature`        Data
+                 Materialization
+                 Use Case
+
+  WP06           Dataset Metadata  WP03, WP04     `architecture`   Data
+                 & Catalog Model
+
+  WP07           Dataset Physical  WP05, WP06     `infra`          Infrastructure
+                 Storage Model
+
+  WP08           Dataset Snapshot  WP07           `feature`        Infrastructure
+                 Persistence
+
+  WP09           Dataset Catalog   WP08           `feature`        Infrastructure
+                 Persistence &
+                 Lookup
+
+  WP10           Dataset           WP05, WP08,    `feature`        Data
+                 Materialization   WP09
+                 Integration
+
+  WP11           Dataset           WP10           `feature`        Infrastructure
+                 Validation &
+                 Failure Mapping
+
+  WP12           Dependency        WP11           `feature`        Host
+                 Registration &
+                 Bounded Dataset
+                 Execution
+
+  WP13           Domain &          WP03, WP04,    `tests`          Testing
+                 Application       WP05, WP06
+                 Dataset Tests
+
+  WP14           Infrastructure &  WP07, WP08,    `tests`          Testing
+                 Dataset Tests     WP09, WP10,
+                                   WP11, WP12
+
+  WP15           Architecture &    WP13, WP14     `architecture`   Architecture
+                 Documentation
+                 Alignment
+
+  WP16           Full Validation,  WP15           `research`       Validation
+                 Integration &
+                 Acceptance
+  ---------------------------------------------------------------------------------
+
+Issue titles should follow the repository's established Release/WP
+naming convention while preserving the exact WP identity and title
+above.
+
+No artificial dependency edges are allowed.
+
+------------------------------------------------------------------------
+
+## 17. Issue Body Contract
+
+Every WP issue must contain exactly these eight logical sections:
+
+``` text
+## Objective
+## Scope
+## Dependencies
+## Deliverables
+## Validation Evidence
+## Exit Criteria
+## Out of Scope
+## Authority
+```
+
+The content must be derived from the Release 1.2 execution plan and file
+manifest.
+
+### Objective
+
+Use the corresponding WP objective.
+
+### Scope
+
+Summarize the WP-owned responsibilities and mutation boundary.
+
+### Dependencies
+
+Use actual GitHub issue links/numbers after issue identity is known.
+
+WP01 dependency must state:
+
+``` text
+Release 1.1 CLOSED
+```
+
+For multi-parent dependencies, enumerate every required issue.
+
+Do not add transitive dependencies unless explicitly required by the
+plan.
+
+### Deliverables
+
+State artifact classes/behaviors owned by the WP without inventing
+filenames where the manifest intentionally leaves names evidence-driven.
+
+### Validation Evidence
+
+State evidence the WP must later produce, not fabricated current
+results.
+
+### Exit Criteria
+
+Use the plan's WP exit condition.
+
+### Out of Scope
+
+Protect later WPs and Release 1.3.
+
+### Authority
+
+Reference both:
+
+``` text
+docs/roadmap/release-1.2/RELEASE_1.2_EXECUTION_PLAN.md
+docs/roadmap/release-1.2/RELEASE_1.2_FILE_MANIFEST.md
+```
+
+Do not paste the full authority text into issue bodies.
+
+------------------------------------------------------------------------
+
+## 18. Issue Creation Order
+
+Create/reconcile issues in dependency-safe WP order:
+
+``` text
+WP01
+WP02
+WP03
+WP04
+WP05
+WP06
+WP07
+WP08
+WP09
+WP10
+WP11
+WP12
+WP13
+WP14
+WP15
+WP16
+```
+
+This allows concrete predecessor issue numbers to be inserted in
+dependent issue bodies.
+
+Before first issue creation, all foreseeable non-issue blockers must
+already be cleared:
+
+-   milestone identity;
+-   labels;
+-   assignee;
+-   Project field/schema readiness;
+-   required Project options;
+-   legacy #43 state;
+-   duplicate/collision reconciliation.
+
+Do not knowingly begin a partial issue set while a prerequisite remains
+unresolved.
+
+------------------------------------------------------------------------
+
+## 19. Project #2 Integration
+
+Project:
+
+``` text
+AIQuantTradingResearch Engineering Roadmap
+```
+
+Add each authoritative WP issue exactly once.
+
+Required values for all sixteen items:
+
+``` text
+Status   = Backlog
+Priority = P1
+Release  = 1.2
+Area     = mapping from Section 16
+```
+
+Do not move WP01 to `In Progress`.
+
+Do not change Project schema except the explicitly authorized narrow
+`Release = 1.2` option addition in Section 10.
+
+Do not alter unrelated Project items.
+
+------------------------------------------------------------------------
+
+## 20. Project Automation
+
+After creating/adding/configuring items, inspect whether Project
+automation changed any intended values.
+
+Final required state:
+
+``` text
+WP01–WP16 Status = Backlog
+```
+
+If automation sets a different status and it is safe/authorized to
+restore the intended existing field value, set it back to `Backlog`.
+
+Do not change Project workflows/automation definitions.
+
+------------------------------------------------------------------------
+
+## 21. Dependency Validation
+
+After all issues exist, validate the full graph.
+
+Required exact edges:
+
+``` text
+WP01  ← Release 1.1 CLOSED
+WP02  ← WP01
+WP03  ← WP02
+WP04  ← WP03
+WP05  ← WP04
+WP06  ← WP03, WP04
+WP07  ← WP05, WP06
+WP08  ← WP07
+WP09  ← WP08
+WP10  ← WP05, WP08, WP09
+WP11  ← WP10
+WP12  ← WP11
+WP13  ← WP03, WP04, WP05, WP06
+WP14  ← WP07, WP08, WP09, WP10, WP11, WP12
+WP15  ← WP13, WP14
+WP16  ← WP15
+```
+
+Required:
+
+``` text
+missing edges = 0
+artificial edges = 0
+dependency drift = 0
+```
+
+------------------------------------------------------------------------
+
+## 22. Final Issue Validation
+
+For each WP verify:
+
+-   exactly one authoritative issue;
+-   state OPEN;
+-   correct milestone;
+-   correct semantic label;
+-   exact one governed label;
+-   assignee exactly `samuel-santos-engineer`;
+-   all eight body sections;
+-   two authority references;
+-   exact dependencies;
+-   Project membership exactly once;
+-   `Status=Backlog`;
+-   `Priority=P1`;
+-   `Release=1.2`;
+-   correct Area.
+
+Final:
+
+``` text
+WP01–WP16 = 16/16
+open = 16
+closed = 0
+```
+
+------------------------------------------------------------------------
+
+## 23. Release 1.3 Protection
+
+Inspect current Release 1.3 planning state.
+
+This authority must not create or modify:
+
+-   Release 1.3 milestone;
+-   Release 1.3 issues;
+-   Release 1.3 Project items;
+-   Release 1.3 implementation.
+
+Existing historical/future Release 1.3 planning may be observed, but
+must not be mutated unless a later explicit authority governs it.
+
+The key success condition is:
+
+``` text
+Release 1.3 objects created by this execution = 0
+Release 1.3 implementation started = NO
+```
+
+------------------------------------------------------------------------
+
+## 24. Repository Mutation Protection
+
+This GitHub-planning execution must not perform implementation or Git
+transport.
+
+Expected repository mutation:
+
+``` text
+tracked production/test/docs edits = 0
+staged paths = 0
+commits = 0
+branches = 0
+pushes = 0
+PRs = 0
+```
+
+The governance files already created for Release 1.2 must remain
+byte-preserved unless this planning authority is separately integrated
+later.
+
+If this planning authority/chat pair appears as untracked execution
+input, classify it according to the Release 1.2 manifest and current
+workflow; do not stage/commit it during GitHub planning.
+
+Do not remove unrelated user files.
+
+------------------------------------------------------------------------
+
+## 25. Failure / Partial-Mutation Policy
+
+GitHub planning APIs are not assumed transactional.
+
+Therefore:
+
+1.  resolve every foreseeable blocker before the first milestone/issue
+    creation;
+2.  prefer idempotent reconciliation over duplicate creation;
+3.  if an unexpected failure occurs after some authorized planning
+    mutations:
+    -   stop further mutation;
+    -   do not invent destructive rollback;
+    -   record exactly what was created/changed;
+    -   report the partial state;
+    -   request the smallest reconciliation authority required.
+
+Never hide a partial planning run.
+
+------------------------------------------------------------------------
+
+## 26. Acceptance Matrix
+
+Report at least:
+
+  Requirement                           Required
+  ------------------------------------- ----------------
+  Release 1.1 closure gate              PASS
+  Legacy #43                            CLOSED / EMPTY
+  Authoritative milestone               exactly 1
+  Milestone state                       OPEN
+  WP issues                             16
+  WP01--WP16 represented                16/16
+  WP17+                                 0
+  Lifecycle-gate issues                 0
+  Open WP issues                        16
+  Closed WP issues                      0
+  Correct milestone assignment          16/16
+  Eight-section bodies                  16/16
+  Authority references                  16/16
+  Dependency drift                      0
+  Assignees                             16/16
+  Semantic labels                       16/16
+  Project items                         16/16
+  Status Backlog                        16/16
+  Priority P1                           16/16
+  Release 1.2                           16/16
+  Area populated                        16/16
+  Duplicate WPs                         0
+  Repository implementation mutations   0
+  Release 1.3 objects created           0
+  WP01 started                          NO
+
+------------------------------------------------------------------------
+
+## 27. Required Execution Report
+
+Return a structured:
+
+``` text
+Release 1.2 GitHub Planning Execution Report
+```
+
+with at least:
+
+1.  Executive Summary
+2.  Authorities Reviewed
+3.  Authentication / Repository Context
+4.  Release 1.1 Closure Gate
+5.  Existing GitHub Planning-State Inspection
+6.  Legacy Milestone #43 Reconciliation
+7.  Project Release-Option Reconciliation
+8.  Duplicate / Collision Reconciliation
+9.  Authoritative Milestone Result
+10. Issue Creation / Reconciliation
+11. Work-Package Mapping
+12. Dependency Validation
+13. Labels
+14. Assignees
+15. GitHub Project Integration
+16. Project Automation Observations
+17. Release / Priority / Area Validation
+18. Scope Protection
+19. Repository Mutation Check
+20. Release 1.3 Protection
+21. Findings / Observations
+22. Planning Acceptance Matrix
+23. Final GitHub Planning State
+24. Final Decision
+25. Next Authorized Action
+
+Include actual milestone/issue numbers and links.
+
+------------------------------------------------------------------------
+
+## 28. Success Terminal
+
+Only if every mandatory planning gate passes, end exactly with:
+
+``` text
+RELEASE 1.2 GITHUB PLANNING COMPLETE
+
+RELEASE 1.2 PLANNING:
+Authoritative milestone: exactly 1 / OPEN
+WP01–WP16: 16/16 OPEN / BACKLOG
+Dependency drift: 0
+Assignees: 16/16
+Priority P1: 16/16
+Release 1.2: 16/16
+Area populated: 16/16
+Legacy milestone #43: CLOSED / EMPTY
+WP17+: 0
+Lifecycle-gate issues: 0
+Repository implementation mutations: 0
+Release 1.3 implementation started: NO
+WP01 started: NO
+
+NEXT AUTHORIZED ACTION:
+Human review and acceptance of the Release 1.2 GitHub planning state.
+After acceptance, the next separately authorized work package is WP01 — Release & Repository Preflight.
+```
+
+------------------------------------------------------------------------
+
+## 29. Blocked Terminal
+
+If any mandatory gate cannot be satisfied, end with:
+
+``` text
+RELEASE 1.2 GITHUB PLANNING BLOCKED
+
+BLOCKER:
+<exact blocker>
+
+PARTIAL MUTATIONS:
+<exact GitHub mutations, or NONE>
+
+SMALLEST CORRECTIVE AUTHORITY:
+<required narrow action>
+
+WP01 started: NO
+Release 1.3 implementation started: NO
+```
+
+Do not emit the COMPLETE terminal.
+
+------------------------------------------------------------------------
+
+## 30. Final Boundary
+
+This authority ends at complete GitHub planning.
+
+After success:
+
+-   milestone exists;
+-   WP01--WP16 exist and are Backlog;
+-   dependencies and Project values are reconciled;
+-   WP01 remains unstarted.
+
+Do not continue into WP01 in the same run.
+
+A separately authored authoritative:
+
+``` text
+01-release-repository-preflight-codex-prompt.md
+```
+
+plus its standard five-line bootstrap is required before implementation
+work may begin.

--- a/src/AIQuantTradingResearch.Application/Datasets/DatasetCatalogEntry.cs
+++ b/src/AIQuantTradingResearch.Application/Datasets/DatasetCatalogEntry.cs
@@ -1,0 +1,53 @@
+namespace AIQuantTradingResearch.Application.Datasets;
+
+public sealed record DatasetCatalogEntry
+{
+    public DatasetCatalogEntry(DatasetSnapshotCandidate snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        Definition = snapshot.Definition;
+        DefinitionIdentity = snapshot.DefinitionIdentity;
+        ResearchDatasetIdentity = snapshot.ResearchDatasetIdentity;
+        SourceStateIdentity = snapshot.SourceStateIdentity;
+        SnapshotIdentity = snapshot.SnapshotIdentity;
+        Version = snapshot.Version;
+        Coverage = snapshot.Coverage;
+        Provenance = snapshot.Provenance;
+        Lineage = snapshot.Lineage;
+    }
+
+    public DatasetDefinition Definition { get; }
+
+    public DatasetDefinitionIdentity DefinitionIdentity { get; }
+
+    public ResearchDatasetIdentity ResearchDatasetIdentity { get; }
+
+    public SourceStateIdentity SourceStateIdentity { get; }
+
+    public DatasetSnapshotIdentity SnapshotIdentity { get; }
+
+    public DatasetVersion Version { get; }
+
+    public DatasetCoverage Coverage { get; }
+
+    public DatasetProvenance Provenance { get; }
+
+    public DatasetLineage Lineage { get; }
+
+    public string Target => Definition.Target;
+
+    public DateTimeOffset RequestedFrom => Coverage.RequestedFrom;
+
+    public DateTimeOffset RequestedTo => Coverage.RequestedTo;
+
+    public int ObservationCount => Coverage.ObservationCount;
+
+    public DateTimeOffset? FirstObservationInstant => Coverage.FirstObservationInstant;
+
+    public DateTimeOffset? LastObservationInstant => Coverage.LastObservationInstant;
+
+    public bool IsEmpty => ObservationCount == 0;
+
+    public string IdentityScheme => Provenance.IdentityScheme;
+}

--- a/src/AIQuantTradingResearch.Application/Datasets/DatasetContracts.cs
+++ b/src/AIQuantTradingResearch.Application/Datasets/DatasetContracts.cs
@@ -1,0 +1,218 @@
+namespace AIQuantTradingResearch.Application.Datasets;
+
+public enum DatasetMaterializationFailure
+{
+    InvalidDefinition,
+    SourceHistoryUnavailable,
+    IntegrityConflict,
+    SnapshotStoreUnavailable,
+}
+
+public sealed record DatasetMaterializationResult
+{
+    private DatasetMaterializationResult(
+        DatasetSnapshotCandidate? snapshot,
+        DatasetMaterializationFailure? failure)
+    {
+        Snapshot = snapshot;
+        Failure = failure;
+    }
+
+    public bool IsSuccess => Snapshot is not null;
+
+    public DatasetSnapshotCandidate? Snapshot { get; }
+
+    public DatasetMaterializationFailure? Failure { get; }
+
+    public static DatasetMaterializationResult Materialized(DatasetSnapshotCandidate snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        return new DatasetMaterializationResult(snapshot, null);
+    }
+
+    public static DatasetMaterializationResult Failed(DatasetMaterializationFailure failure)
+    {
+        if (!Enum.IsDefined(failure))
+        {
+            throw new ArgumentOutOfRangeException(nameof(failure), failure, "Unknown dataset materialization failure.");
+        }
+
+        return new DatasetMaterializationResult(null, failure);
+    }
+}
+
+public enum DatasetSnapshotStoreOutcome
+{
+    NewlyAccepted,
+    EquivalentExisting,
+    IntegrityConflict,
+}
+
+public enum DatasetStoreFailure
+{
+    Unavailable,
+    InvalidData,
+}
+
+public sealed record DatasetSnapshotStoreResult
+{
+    private DatasetSnapshotStoreResult(DatasetSnapshotStoreOutcome? outcome, DatasetStoreFailure? failure)
+    {
+        Outcome = outcome;
+        Failure = failure;
+    }
+
+    public bool HasOutcome => Outcome is not null;
+
+    public DatasetSnapshotStoreOutcome? Outcome { get; }
+
+    public DatasetStoreFailure? Failure { get; }
+
+    public static DatasetSnapshotStoreResult Completed(DatasetSnapshotStoreOutcome outcome)
+    {
+        if (!Enum.IsDefined(outcome))
+        {
+            throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "Unknown snapshot-store outcome.");
+        }
+
+        return new DatasetSnapshotStoreResult(outcome, null);
+    }
+
+    public static DatasetSnapshotStoreResult Failed(DatasetStoreFailure failure)
+    {
+        if (!Enum.IsDefined(failure))
+        {
+            throw new ArgumentOutOfRangeException(nameof(failure), failure, "Unknown dataset-store failure.");
+        }
+
+        return new DatasetSnapshotStoreResult(null, failure);
+    }
+}
+
+public sealed record DatasetSnapshotRetrievalResult
+{
+    private DatasetSnapshotRetrievalResult(DatasetSnapshotCandidate? snapshot, DatasetStoreFailure? failure)
+    {
+        Snapshot = snapshot;
+        Failure = failure;
+    }
+
+    public bool IsFound => Snapshot is not null;
+
+    public bool IsNotFound => Snapshot is null && Failure is null;
+
+    public DatasetSnapshotCandidate? Snapshot { get; }
+
+    public DatasetStoreFailure? Failure { get; }
+
+    public static DatasetSnapshotRetrievalResult Found(DatasetSnapshotCandidate snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        return new DatasetSnapshotRetrievalResult(snapshot, null);
+    }
+
+    public static DatasetSnapshotRetrievalResult NotFound() => new(null, null);
+
+    public static DatasetSnapshotRetrievalResult Failed(DatasetStoreFailure failure)
+    {
+        if (!Enum.IsDefined(failure))
+        {
+            throw new ArgumentOutOfRangeException(nameof(failure), failure, "Unknown dataset-store failure.");
+        }
+
+        return new DatasetSnapshotRetrievalResult(null, failure);
+    }
+}
+
+public interface IDatasetSnapshotStore
+{
+    DatasetSnapshotStoreResult Store(DatasetSnapshotCandidate snapshot);
+
+    DatasetSnapshotRetrievalResult Retrieve(DatasetSnapshotIdentity snapshotIdentity);
+}
+
+public enum DatasetCatalogRegistrationOutcome
+{
+    NewlyRegistered,
+    EquivalentExisting,
+    IntegrityConflict,
+}
+
+public sealed record DatasetCatalogRegistrationResult
+{
+    private DatasetCatalogRegistrationResult(
+        DatasetCatalogRegistrationOutcome? outcome,
+        DatasetStoreFailure? failure)
+    {
+        Outcome = outcome;
+        Failure = failure;
+    }
+
+    public bool HasOutcome => Outcome is not null;
+
+    public DatasetCatalogRegistrationOutcome? Outcome { get; }
+
+    public DatasetStoreFailure? Failure { get; }
+
+    public static DatasetCatalogRegistrationResult Completed(DatasetCatalogRegistrationOutcome outcome)
+    {
+        if (!Enum.IsDefined(outcome))
+        {
+            throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "Unknown catalog-registration outcome.");
+        }
+
+        return new DatasetCatalogRegistrationResult(outcome, null);
+    }
+
+    public static DatasetCatalogRegistrationResult Failed(DatasetStoreFailure failure)
+    {
+        if (!Enum.IsDefined(failure))
+        {
+            throw new ArgumentOutOfRangeException(nameof(failure), failure, "Unknown dataset-store failure.");
+        }
+
+        return new DatasetCatalogRegistrationResult(null, failure);
+    }
+}
+
+public sealed record DatasetCatalogLookupResult
+{
+    private DatasetCatalogLookupResult(DatasetCatalogEntry? entry, DatasetStoreFailure? failure)
+    {
+        Entry = entry;
+        Failure = failure;
+    }
+
+    public bool IsFound => Entry is not null;
+
+    public bool IsNotFound => Entry is null && Failure is null;
+
+    public DatasetCatalogEntry? Entry { get; }
+
+    public DatasetStoreFailure? Failure { get; }
+
+    public static DatasetCatalogLookupResult Found(DatasetCatalogEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        return new DatasetCatalogLookupResult(entry, null);
+    }
+
+    public static DatasetCatalogLookupResult NotFound() => new(null, null);
+
+    public static DatasetCatalogLookupResult Failed(DatasetStoreFailure failure)
+    {
+        if (!Enum.IsDefined(failure))
+        {
+            throw new ArgumentOutOfRangeException(nameof(failure), failure, "Unknown dataset-store failure.");
+        }
+
+        return new DatasetCatalogLookupResult(null, failure);
+    }
+}
+
+public interface IDatasetCatalog
+{
+    DatasetCatalogRegistrationResult Register(DatasetCatalogEntry entry);
+
+    DatasetCatalogLookupResult Find(DatasetSnapshotIdentity snapshotIdentity);
+}

--- a/src/AIQuantTradingResearch.Application/Datasets/DatasetDefinition.cs
+++ b/src/AIQuantTradingResearch.Application/Datasets/DatasetDefinition.cs
@@ -1,0 +1,34 @@
+namespace AIQuantTradingResearch.Application.Datasets;
+
+public sealed record DatasetDefinition
+{
+    public DatasetDefinition(string target, DateTimeOffset from, DateTimeOffset to)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(target);
+
+        if (from >= to)
+        {
+            throw new ArgumentException(
+                "Dataset selection requires an inclusive lower boundary before its exclusive upper boundary.",
+                nameof(to));
+        }
+
+        Target = target;
+        From = from;
+        To = to;
+        Ordering = DatasetOrdering.SemanticInstantAscending;
+    }
+
+    public string Target { get; }
+
+    public DateTimeOffset From { get; }
+
+    public DateTimeOffset To { get; }
+
+    public DatasetOrdering Ordering { get; }
+}
+
+public enum DatasetOrdering
+{
+    SemanticInstantAscending,
+}

--- a/src/AIQuantTradingResearch.Application/Datasets/DatasetIdentity.cs
+++ b/src/AIQuantTradingResearch.Application/Datasets/DatasetIdentity.cs
@@ -1,0 +1,88 @@
+namespace AIQuantTradingResearch.Application.Datasets;
+
+public static class DatasetIdentityScheme
+{
+    public const string Name = "aiq-dataset-identity-v1";
+}
+
+public sealed record DatasetDefinitionIdentity
+{
+    public DatasetDefinitionIdentity(string fingerprint)
+    {
+        Fingerprint = DatasetFingerprint.Validate(fingerprint);
+        Scheme = DatasetIdentityScheme.Name;
+    }
+
+    public string Scheme { get; }
+
+    public string Fingerprint { get; }
+}
+
+public sealed record ResearchDatasetIdentity
+{
+    public ResearchDatasetIdentity(string fingerprint)
+    {
+        Fingerprint = DatasetFingerprint.Validate(fingerprint);
+        Scheme = DatasetIdentityScheme.Name;
+    }
+
+    public string Scheme { get; }
+
+    public string Fingerprint { get; }
+}
+
+public sealed record SourceStateIdentity
+{
+    public SourceStateIdentity(string fingerprint)
+    {
+        Fingerprint = DatasetFingerprint.Validate(fingerprint);
+        Scheme = DatasetIdentityScheme.Name;
+    }
+
+    public string Scheme { get; }
+
+    public string Fingerprint { get; }
+}
+
+public sealed record DatasetSnapshotIdentity
+{
+    public DatasetSnapshotIdentity(string fingerprint)
+    {
+        Fingerprint = DatasetFingerprint.Validate(fingerprint);
+        Scheme = DatasetIdentityScheme.Name;
+    }
+
+    public string Scheme { get; }
+
+    public string Fingerprint { get; }
+}
+
+public sealed record DatasetVersion
+{
+    public DatasetVersion(DatasetSnapshotIdentity snapshotIdentity)
+    {
+        ArgumentNullException.ThrowIfNull(snapshotIdentity);
+        SnapshotIdentity = snapshotIdentity;
+    }
+
+    public DatasetSnapshotIdentity SnapshotIdentity { get; }
+}
+
+internal static class DatasetFingerprint
+{
+    public static string Validate(string fingerprint)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fingerprint);
+
+        if (fingerprint.Length != 64
+            || fingerprint.Any(static character => !((character >= '0' && character <= '9')
+                || (character >= 'a' && character <= 'f'))))
+        {
+            throw new ArgumentException(
+                "Dataset fingerprints must contain exactly 64 lowercase hexadecimal characters.",
+                nameof(fingerprint));
+        }
+
+        return fingerprint;
+    }
+}

--- a/src/AIQuantTradingResearch.Application/Datasets/DatasetIdentityComputer.cs
+++ b/src/AIQuantTradingResearch.Application/Datasets/DatasetIdentityComputer.cs
@@ -1,0 +1,120 @@
+using System.Globalization;
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Text;
+using AIQuantTradingResearch.Domain;
+
+namespace AIQuantTradingResearch.Application.Datasets;
+
+internal static class DatasetIdentityComputer
+{
+    private static readonly Encoding Utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    public static DatasetDefinitionIdentity ComputeDefinitionIdentity(DatasetDefinition definition) =>
+        new(ComputeFingerprint("dataset-definition", DefinitionFields(definition)));
+
+    public static ResearchDatasetIdentity ComputeResearchDatasetIdentity(DatasetDefinition definition) =>
+        new(ComputeFingerprint("research-dataset", DefinitionFields(definition)));
+
+    public static SourceStateIdentity ComputeSourceStateIdentity(
+        string target,
+        IReadOnlyList<PriceObservation> observations)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(target);
+        ArgumentNullException.ThrowIfNull(observations);
+
+        var fields = new List<string> { target, observations.Count.ToString(CultureInfo.InvariantCulture) };
+
+        foreach (var observation in observations)
+        {
+            ArgumentNullException.ThrowIfNull(observation);
+            fields.Add(observation.Instant.UtcTicks.ToString(CultureInfo.InvariantCulture));
+            fields.Add((observation.Instant.Offset.Ticks / TimeSpan.TicksPerMinute).ToString(CultureInfo.InvariantCulture));
+            fields.Add(CanonicalDecimal(observation.Price));
+        }
+
+        return new SourceStateIdentity(ComputeFingerprint("source-state", fields));
+    }
+
+    public static DatasetSnapshotIdentity ComputeSnapshotIdentity(
+        DatasetDefinitionIdentity definitionIdentity,
+        SourceStateIdentity sourceStateIdentity)
+    {
+        ArgumentNullException.ThrowIfNull(definitionIdentity);
+        ArgumentNullException.ThrowIfNull(sourceStateIdentity);
+
+        return new DatasetSnapshotIdentity(ComputeFingerprint(
+            "dataset-snapshot",
+            [
+                "dataset-definition",
+                definitionIdentity.Scheme,
+                definitionIdentity.Fingerprint,
+                "source-state",
+                sourceStateIdentity.Scheme,
+                sourceStateIdentity.Fingerprint,
+            ]));
+    }
+
+    private static IReadOnlyList<string> DefinitionFields(DatasetDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        return
+        [
+            definition.Target,
+            definition.From.UtcTicks.ToString(CultureInfo.InvariantCulture),
+            definition.To.UtcTicks.ToString(CultureInfo.InvariantCulture),
+            "lower-inclusive",
+            "upper-exclusive",
+            "semantic-instant-ascending",
+            "0",
+        ];
+    }
+
+    private static string ComputeFingerprint(string typeDomain, IReadOnlyList<string> semanticFields)
+    {
+        var canonical = new StringBuilder();
+        AppendField(canonical, typeDomain);
+        AppendField(canonical, DatasetIdentityScheme.Name);
+        AppendField(canonical, semanticFields.Count.ToString(CultureInfo.InvariantCulture));
+
+        foreach (var field in semanticFields)
+        {
+            ArgumentNullException.ThrowIfNull(field);
+            AppendField(canonical, field);
+        }
+
+        var digest = SHA256.HashData(Utf8.GetBytes(canonical.ToString()));
+        return Convert.ToHexString(digest).ToLowerInvariant();
+    }
+
+    private static void AppendField(StringBuilder canonical, string value)
+    {
+        canonical.Append(Utf8.GetByteCount(value).ToString(CultureInfo.InvariantCulture));
+        canonical.Append(':');
+        canonical.Append(value);
+    }
+
+    private static string CanonicalDecimal(decimal value)
+    {
+        var bits = decimal.GetBits(value);
+        var coefficient = new BigInteger((uint)bits[0])
+            | ((BigInteger)(uint)bits[1] << 32)
+            | ((BigInteger)(uint)bits[2] << 64);
+        var scale = (bits[3] >> 16) & 0x7f;
+
+        while (scale > 0 && coefficient % 10 == BigInteger.Zero)
+        {
+            coefficient /= 10;
+            scale--;
+        }
+
+        var sign = (bits[3] & int.MinValue) == 0 ? "0" : "1";
+        return string.Concat(
+            sign,
+            ",",
+            coefficient.ToString(CultureInfo.InvariantCulture),
+            ",",
+            scale.ToString(CultureInfo.InvariantCulture));
+    }
+}

--- a/src/AIQuantTradingResearch.Application/Datasets/DatasetMaterializationIntegrationContracts.cs
+++ b/src/AIQuantTradingResearch.Application/Datasets/DatasetMaterializationIntegrationContracts.cs
@@ -1,0 +1,57 @@
+namespace AIQuantTradingResearch.Application.Datasets;
+
+public enum DatasetMaterializationIntegrationOutcome
+{
+    NewlyAccepted,
+    EquivalentExisting,
+}
+
+public sealed record DatasetMaterializationIntegrationResult
+{
+    private DatasetMaterializationIntegrationResult(
+        DatasetSnapshotCandidate? snapshot,
+        DatasetMaterializationIntegrationOutcome? outcome,
+        DatasetMaterializationFailure? failure)
+    {
+        Snapshot = snapshot;
+        Outcome = outcome;
+        Failure = failure;
+    }
+
+    public bool IsSuccess => Snapshot is not null;
+
+    public DatasetSnapshotCandidate? Snapshot { get; }
+
+    public DatasetMaterializationIntegrationOutcome? Outcome { get; }
+
+    public DatasetMaterializationFailure? Failure { get; }
+
+    public static DatasetMaterializationIntegrationResult Completed(
+        DatasetSnapshotCandidate snapshot,
+        DatasetMaterializationIntegrationOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        if (!Enum.IsDefined(outcome))
+        {
+            throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "Unknown dataset integration outcome.");
+        }
+
+        return new DatasetMaterializationIntegrationResult(snapshot, outcome, null);
+    }
+
+    public static DatasetMaterializationIntegrationResult Failed(DatasetMaterializationFailure failure)
+    {
+        if (!Enum.IsDefined(failure))
+        {
+            throw new ArgumentOutOfRangeException(nameof(failure), failure, "Unknown dataset materialization failure.");
+        }
+
+        return new DatasetMaterializationIntegrationResult(null, null, failure);
+    }
+}
+
+public interface IDatasetMaterializationIntegrationUseCase
+{
+    DatasetMaterializationIntegrationResult Execute(DatasetDefinition definition);
+}

--- a/src/AIQuantTradingResearch.Application/Datasets/DatasetMaterializationIntegrationUseCase.cs
+++ b/src/AIQuantTradingResearch.Application/Datasets/DatasetMaterializationIntegrationUseCase.cs
@@ -1,0 +1,77 @@
+namespace AIQuantTradingResearch.Application.Datasets;
+
+internal sealed class DatasetMaterializationIntegrationUseCase : IDatasetMaterializationIntegrationUseCase
+{
+    private readonly IMaterializeDatasetUseCase materializeDataset;
+    private readonly IDatasetSnapshotStore snapshotStore;
+    private readonly IDatasetCatalog datasetCatalog;
+
+    public DatasetMaterializationIntegrationUseCase(
+        IMaterializeDatasetUseCase materializeDataset,
+        IDatasetSnapshotStore snapshotStore,
+        IDatasetCatalog datasetCatalog)
+    {
+        ArgumentNullException.ThrowIfNull(materializeDataset);
+        ArgumentNullException.ThrowIfNull(snapshotStore);
+        ArgumentNullException.ThrowIfNull(datasetCatalog);
+
+        this.materializeDataset = materializeDataset;
+        this.snapshotStore = snapshotStore;
+        this.datasetCatalog = datasetCatalog;
+    }
+
+    public DatasetMaterializationIntegrationResult Execute(DatasetDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var materialization = materializeDataset.Execute(definition)
+            ?? throw new InvalidOperationException("The dataset materialization use case returned no result.");
+
+        if (!materialization.IsSuccess)
+        {
+            return DatasetMaterializationIntegrationResult.Failed(materialization.Failure!.Value);
+        }
+
+        var snapshot = materialization.Snapshot!;
+        var persistence = snapshotStore.Store(snapshot)
+            ?? throw new InvalidOperationException("The dataset snapshot store returned no result.");
+
+        if (!persistence.HasOutcome)
+        {
+            return DatasetMaterializationIntegrationResult.Failed(MapFailure(persistence.Failure!.Value));
+        }
+
+        if (persistence.Outcome == DatasetSnapshotStoreOutcome.IntegrityConflict)
+        {
+            return DatasetMaterializationIntegrationResult.Failed(
+                DatasetMaterializationFailure.IntegrityConflict);
+        }
+
+        var registration = datasetCatalog.Register(new DatasetCatalogEntry(snapshot))
+            ?? throw new InvalidOperationException("The dataset catalog returned no registration result.");
+
+        if (!registration.HasOutcome)
+        {
+            return DatasetMaterializationIntegrationResult.Failed(MapFailure(registration.Failure!.Value));
+        }
+
+        if (registration.Outcome == DatasetCatalogRegistrationOutcome.IntegrityConflict)
+        {
+            return DatasetMaterializationIntegrationResult.Failed(
+                DatasetMaterializationFailure.IntegrityConflict);
+        }
+
+        return DatasetMaterializationIntegrationResult.Completed(
+            snapshot,
+            persistence.Outcome == DatasetSnapshotStoreOutcome.NewlyAccepted
+                ? DatasetMaterializationIntegrationOutcome.NewlyAccepted
+                : DatasetMaterializationIntegrationOutcome.EquivalentExisting);
+    }
+
+    private static DatasetMaterializationFailure MapFailure(DatasetStoreFailure failure) => failure switch
+    {
+        DatasetStoreFailure.Unavailable => DatasetMaterializationFailure.SnapshotStoreUnavailable,
+        DatasetStoreFailure.InvalidData => DatasetMaterializationFailure.IntegrityConflict,
+        _ => throw new InvalidOperationException("The dataset store returned an unknown failure."),
+    };
+}

--- a/src/AIQuantTradingResearch.Application/Datasets/DatasetSnapshotCandidate.cs
+++ b/src/AIQuantTradingResearch.Application/Datasets/DatasetSnapshotCandidate.cs
@@ -1,0 +1,314 @@
+using System.Collections.ObjectModel;
+using AIQuantTradingResearch.Domain;
+
+namespace AIQuantTradingResearch.Application.Datasets;
+
+public enum DatasetSourceAuthority
+{
+    AcceptedRelease11HistoricalObservations,
+}
+
+public sealed record DatasetCoverage
+{
+    public DatasetCoverage(
+        DateTimeOffset requestedFrom,
+        DateTimeOffset requestedTo,
+        int observationCount,
+        DateTimeOffset? firstObservationInstant,
+        DateTimeOffset? lastObservationInstant)
+    {
+        if (requestedFrom >= requestedTo)
+        {
+            throw new ArgumentException("Coverage boundaries must define a valid [from, to) interval.", nameof(requestedTo));
+        }
+
+        if (observationCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(observationCount), observationCount, "Observation count cannot be negative.");
+        }
+
+        if (observationCount == 0 && (firstObservationInstant is not null || lastObservationInstant is not null))
+        {
+            throw new ArgumentException("Empty coverage cannot have observed boundaries.");
+        }
+
+        if (observationCount > 0 && (firstObservationInstant is null || lastObservationInstant is null))
+        {
+            throw new ArgumentException("Non-empty coverage requires first and last observed instants.");
+        }
+
+        if (firstObservationInstant is not null
+            && (firstObservationInstant < requestedFrom || firstObservationInstant >= requestedTo
+                || lastObservationInstant < firstObservationInstant || lastObservationInstant >= requestedTo))
+        {
+            throw new ArgumentException("Observed coverage must remain within the requested [from, to) interval.");
+        }
+
+        RequestedFrom = requestedFrom;
+        RequestedTo = requestedTo;
+        ObservationCount = observationCount;
+        FirstObservationInstant = firstObservationInstant;
+        LastObservationInstant = lastObservationInstant;
+    }
+
+    public DateTimeOffset RequestedFrom { get; }
+
+    public DateTimeOffset RequestedTo { get; }
+
+    public int ObservationCount { get; }
+
+    public DateTimeOffset? FirstObservationInstant { get; }
+
+    public DateTimeOffset? LastObservationInstant { get; }
+}
+
+public sealed record DatasetProvenance
+{
+    public DatasetProvenance(
+        DatasetDefinition definition,
+        DatasetDefinitionIdentity definitionIdentity,
+        ResearchDatasetIdentity researchDatasetIdentity,
+        SourceStateIdentity sourceStateIdentity,
+        DatasetSnapshotIdentity snapshotIdentity,
+        DatasetVersion version,
+        DatasetSourceAuthority sourceAuthority,
+        int observationCount)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(definitionIdentity);
+        ArgumentNullException.ThrowIfNull(researchDatasetIdentity);
+        ArgumentNullException.ThrowIfNull(sourceStateIdentity);
+        ArgumentNullException.ThrowIfNull(snapshotIdentity);
+        ArgumentNullException.ThrowIfNull(version);
+
+        if (version.SnapshotIdentity != snapshotIdentity)
+        {
+            throw new ArgumentException("Dataset version must represent the same snapshot identity.", nameof(version));
+        }
+
+        if (!Enum.IsDefined(sourceAuthority))
+        {
+            throw new ArgumentOutOfRangeException(nameof(sourceAuthority), sourceAuthority, "Unknown dataset source authority.");
+        }
+
+        if (observationCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(observationCount), observationCount, "Observation count cannot be negative.");
+        }
+
+        Definition = definition;
+        DefinitionIdentity = definitionIdentity;
+        ResearchDatasetIdentity = researchDatasetIdentity;
+        SourceStateIdentity = sourceStateIdentity;
+        SnapshotIdentity = snapshotIdentity;
+        Version = version;
+        SourceAuthority = sourceAuthority;
+        ObservationCount = observationCount;
+        IdentityScheme = DatasetIdentityScheme.Name;
+    }
+
+    public DatasetDefinition Definition { get; }
+
+    public DatasetDefinitionIdentity DefinitionIdentity { get; }
+
+    public ResearchDatasetIdentity ResearchDatasetIdentity { get; }
+
+    public SourceStateIdentity SourceStateIdentity { get; }
+
+    public DatasetSnapshotIdentity SnapshotIdentity { get; }
+
+    public DatasetVersion Version { get; }
+
+    public DatasetSourceAuthority SourceAuthority { get; }
+
+    public int ObservationCount { get; }
+
+    public string IdentityScheme { get; }
+}
+
+public sealed record DatasetLineage
+{
+    public DatasetLineage(
+        DatasetDefinitionIdentity definitionIdentity,
+        SourceStateIdentity sourceStateIdentity,
+        IEnumerable<PriceObservation> sourceObservations)
+    {
+        ArgumentNullException.ThrowIfNull(definitionIdentity);
+        ArgumentNullException.ThrowIfNull(sourceStateIdentity);
+        ArgumentNullException.ThrowIfNull(sourceObservations);
+
+        var observations = sourceObservations.ToArray();
+
+        if (observations.Any(static observation => observation is null))
+        {
+            throw new ArgumentException("Lineage observations cannot contain null values.", nameof(sourceObservations));
+        }
+
+        ValidateObservations(observations, nameof(sourceObservations));
+
+        DefinitionIdentity = definitionIdentity;
+        SourceStateIdentity = sourceStateIdentity;
+        SourceObservations = Array.AsReadOnly(observations);
+    }
+
+    public DatasetDefinitionIdentity DefinitionIdentity { get; }
+
+    public SourceStateIdentity SourceStateIdentity { get; }
+
+    public IReadOnlyList<PriceObservation> SourceObservations { get; }
+
+    internal static void ValidateObservations(IReadOnlyList<PriceObservation> observations, string parameterName)
+    {
+        for (var index = 1; index < observations.Count; index++)
+        {
+            if (observations[index].Instant <= observations[index - 1].Instant)
+            {
+                throw new ArgumentException(
+                    "Observations must be unique and strictly ascending by semantic instant.",
+                    parameterName);
+            }
+        }
+    }
+}
+
+public sealed record DatasetSnapshotCandidate
+{
+    public DatasetSnapshotCandidate(
+        DatasetDefinition definition,
+        DatasetDefinitionIdentity definitionIdentity,
+        ResearchDatasetIdentity researchDatasetIdentity,
+        SourceStateIdentity sourceStateIdentity,
+        DatasetSnapshotIdentity snapshotIdentity,
+        DatasetVersion version,
+        IEnumerable<PriceObservation> observations,
+        DatasetCoverage coverage,
+        DatasetProvenance provenance,
+        DatasetLineage lineage)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(definitionIdentity);
+        ArgumentNullException.ThrowIfNull(researchDatasetIdentity);
+        ArgumentNullException.ThrowIfNull(sourceStateIdentity);
+        ArgumentNullException.ThrowIfNull(snapshotIdentity);
+        ArgumentNullException.ThrowIfNull(version);
+        ArgumentNullException.ThrowIfNull(observations);
+        ArgumentNullException.ThrowIfNull(coverage);
+        ArgumentNullException.ThrowIfNull(provenance);
+        ArgumentNullException.ThrowIfNull(lineage);
+
+        var observationSnapshot = observations.ToArray();
+
+        if (observationSnapshot.Any(static observation => observation is null))
+        {
+            throw new ArgumentException("Snapshot observations cannot contain null values.", nameof(observations));
+        }
+
+        DatasetLineage.ValidateObservations(observationSnapshot, nameof(observations));
+        ValidateConsistency(
+            definition,
+            definitionIdentity,
+            researchDatasetIdentity,
+            sourceStateIdentity,
+            snapshotIdentity,
+            version,
+            observationSnapshot,
+            coverage,
+            provenance,
+            lineage);
+
+        Definition = definition;
+        DefinitionIdentity = definitionIdentity;
+        ResearchDatasetIdentity = researchDatasetIdentity;
+        SourceStateIdentity = sourceStateIdentity;
+        SnapshotIdentity = snapshotIdentity;
+        Version = version;
+        Observations = Array.AsReadOnly(observationSnapshot);
+        Coverage = coverage;
+        Provenance = provenance;
+        Lineage = lineage;
+    }
+
+    public DatasetDefinition Definition { get; }
+
+    public DatasetDefinitionIdentity DefinitionIdentity { get; }
+
+    public ResearchDatasetIdentity ResearchDatasetIdentity { get; }
+
+    public SourceStateIdentity SourceStateIdentity { get; }
+
+    public DatasetSnapshotIdentity SnapshotIdentity { get; }
+
+    public DatasetVersion Version { get; }
+
+    public IReadOnlyList<PriceObservation> Observations { get; }
+
+    public DatasetCoverage Coverage { get; }
+
+    public DatasetProvenance Provenance { get; }
+
+    public DatasetLineage Lineage { get; }
+
+    private static void ValidateConsistency(
+        DatasetDefinition definition,
+        DatasetDefinitionIdentity definitionIdentity,
+        ResearchDatasetIdentity researchDatasetIdentity,
+        SourceStateIdentity sourceStateIdentity,
+        DatasetSnapshotIdentity snapshotIdentity,
+        DatasetVersion version,
+        PriceObservation[] observations,
+        DatasetCoverage coverage,
+        DatasetProvenance provenance,
+        DatasetLineage lineage)
+    {
+        if (version.SnapshotIdentity != snapshotIdentity
+            || coverage.RequestedFrom != definition.From
+            || coverage.RequestedTo != definition.To
+            || coverage.ObservationCount != observations.Length
+            || provenance.Definition != definition
+            || provenance.DefinitionIdentity != definitionIdentity
+            || provenance.ResearchDatasetIdentity != researchDatasetIdentity
+            || provenance.SourceStateIdentity != sourceStateIdentity
+            || provenance.SnapshotIdentity != snapshotIdentity
+            || provenance.Version != version
+            || provenance.ObservationCount != observations.Length
+            || lineage.DefinitionIdentity != definitionIdentity
+            || lineage.SourceStateIdentity != sourceStateIdentity
+            || !HaveSameObservations(observations, lineage.SourceObservations))
+        {
+            throw new ArgumentException("Snapshot candidate semantic facts must agree.");
+        }
+
+        if (observations.Length == 0)
+        {
+            return;
+        }
+
+        if (coverage.FirstObservationInstant != observations[0].Instant
+            || coverage.LastObservationInstant != observations[^1].Instant)
+        {
+            throw new ArgumentException("Coverage must preserve the first and last selected observation instants.");
+        }
+    }
+
+    private static bool HaveSameObservations(
+        PriceObservation[] left,
+        IReadOnlyList<PriceObservation> right)
+    {
+        if (left.Length != right.Count)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < left.Length; index++)
+        {
+            if (left[index].Instant.UtcTicks != right[index].Instant.UtcTicks
+                || left[index].Instant.Offset != right[index].Instant.Offset
+                || left[index].Price != right[index].Price)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/AIQuantTradingResearch.Application/Datasets/IMaterializeDatasetUseCase.cs
+++ b/src/AIQuantTradingResearch.Application/Datasets/IMaterializeDatasetUseCase.cs
@@ -1,0 +1,6 @@
+namespace AIQuantTradingResearch.Application.Datasets;
+
+public interface IMaterializeDatasetUseCase
+{
+    DatasetMaterializationResult Execute(DatasetDefinition definition);
+}

--- a/src/AIQuantTradingResearch.Application/Datasets/MaterializeDatasetUseCase.cs
+++ b/src/AIQuantTradingResearch.Application/Datasets/MaterializeDatasetUseCase.cs
@@ -1,0 +1,80 @@
+using AIQuantTradingResearch.Application.Persistence;
+using AIQuantTradingResearch.Domain;
+
+namespace AIQuantTradingResearch.Application.Datasets;
+
+internal sealed class MaterializeDatasetUseCase : IMaterializeDatasetUseCase
+{
+    private readonly IHistoricalObservationStore historicalObservationStore;
+
+    public MaterializeDatasetUseCase(IHistoricalObservationStore historicalObservationStore)
+    {
+        ArgumentNullException.ThrowIfNull(historicalObservationStore);
+        this.historicalObservationStore = historicalObservationStore;
+    }
+
+    public DatasetMaterializationResult Execute(DatasetDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var sourceResult = historicalObservationStore.Retrieve(definition.Target)
+            ?? throw new InvalidOperationException("The historical observation store returned no result.");
+
+        if (!sourceResult.IsSuccess)
+        {
+            return sourceResult.Failure switch
+            {
+                PersistenceFailure.Unavailable =>
+                    DatasetMaterializationResult.Failed(DatasetMaterializationFailure.SourceHistoryUnavailable),
+                PersistenceFailure.InvalidData =>
+                    DatasetMaterializationResult.Failed(DatasetMaterializationFailure.IntegrityConflict),
+                _ => throw new InvalidOperationException("The historical observation store returned an unknown failure."),
+            };
+        }
+
+        var history = sourceResult.Observations
+            ?? throw new InvalidOperationException("A successful historical observation result contained no observations.");
+
+        var observations = history
+            .Where(observation => observation.Instant >= definition.From && observation.Instant < definition.To)
+            .OrderBy(static observation => observation.Instant.UtcTicks)
+            .ToArray();
+
+        DatasetLineage.ValidateObservations(observations, nameof(history));
+
+        var definitionIdentity = DatasetIdentityComputer.ComputeDefinitionIdentity(definition);
+        var researchDatasetIdentity = DatasetIdentityComputer.ComputeResearchDatasetIdentity(definition);
+        var sourceStateIdentity = DatasetIdentityComputer.ComputeSourceStateIdentity(definition.Target, observations);
+        var snapshotIdentity = DatasetIdentityComputer.ComputeSnapshotIdentity(definitionIdentity, sourceStateIdentity);
+        var version = new DatasetVersion(snapshotIdentity);
+        var coverage = new DatasetCoverage(
+            definition.From,
+            definition.To,
+            observations.Length,
+            observations.Length == 0 ? null : observations[0].Instant,
+            observations.Length == 0 ? null : observations[^1].Instant);
+        var provenance = new DatasetProvenance(
+            definition,
+            definitionIdentity,
+            researchDatasetIdentity,
+            sourceStateIdentity,
+            snapshotIdentity,
+            version,
+            DatasetSourceAuthority.AcceptedRelease11HistoricalObservations,
+            observations.Length);
+        var lineage = new DatasetLineage(definitionIdentity, sourceStateIdentity, observations);
+        var snapshot = new DatasetSnapshotCandidate(
+            definition,
+            definitionIdentity,
+            researchDatasetIdentity,
+            sourceStateIdentity,
+            snapshotIdentity,
+            version,
+            observations,
+            coverage,
+            provenance,
+            lineage);
+
+        return DatasetMaterializationResult.Materialized(snapshot);
+    }
+}

--- a/src/AIQuantTradingResearch.Application/DependencyInjection.cs
+++ b/src/AIQuantTradingResearch.Application/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using AIQuantTradingResearch.Application.Datasets;
 using AIQuantTradingResearch.Application.Persistence;
 using AIQuantTradingResearch.Application.Research;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,6 +11,8 @@ public static class DependencyInjection
     {
         services.AddTransient<IResearchUseCase, ResearchUseCase>();
         services.AddTransient<IPersistHistoricalObservationsUseCase, PersistHistoricalObservationsUseCase>();
+        services.AddTransient<IMaterializeDatasetUseCase, MaterializeDatasetUseCase>();
+        services.AddTransient<IDatasetMaterializationIntegrationUseCase, DatasetMaterializationIntegrationUseCase>();
 
         return services;
     }

--- a/src/AIQuantTradingResearch.Infrastructure/DependencyInjection.cs
+++ b/src/AIQuantTradingResearch.Infrastructure/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using AIQuantTradingResearch.Application.Datasets;
 using AIQuantTradingResearch.Application.Research;
 using AIQuantTradingResearch.Application.Persistence;
 using AIQuantTradingResearch.Infrastructure.MarketData.TwelveData;
@@ -50,6 +51,8 @@ public static class DependencyInjection
         services.AddSingleton(storageConfiguration);
         services.AddSingleton<ISqliteConnectionFactory, SqliteConnectionFactory>();
         services.AddTransient<IHistoricalObservationStore, SqliteHistoricalObservationStore>();
+        services.AddTransient<IDatasetSnapshotStore, SqliteDatasetSnapshotStore>();
+        services.AddTransient<IDatasetCatalog, SqliteDatasetCatalog>();
 
         return services;
     }

--- a/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteConnectionFactory.cs
+++ b/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteConnectionFactory.cs
@@ -27,6 +27,11 @@ internal sealed class SqliteConnectionFactory : ISqliteConnectionFactory
             SqliteSchemaBootstrapper.Bootstrap(connection);
             return connection;
         }
+        catch (SqliteSchemaValidationException exception)
+        {
+            connection.Dispose();
+            throw new InvalidOperationException(exception.Message, exception);
+        }
         catch
         {
             connection.Dispose();

--- a/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetCatalog.cs
+++ b/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetCatalog.cs
@@ -1,0 +1,63 @@
+using AIQuantTradingResearch.Application.Datasets;
+
+namespace AIQuantTradingResearch.Infrastructure.Persistence.Sqlite;
+
+internal sealed class SqliteDatasetCatalog : IDatasetCatalog
+{
+    private readonly SqliteDatasetSnapshotStore snapshotStore;
+
+    public SqliteDatasetCatalog(ISqliteConnectionFactory connectionFactory)
+    {
+        ArgumentNullException.ThrowIfNull(connectionFactory);
+        snapshotStore = new SqliteDatasetSnapshotStore(connectionFactory);
+    }
+
+    public DatasetCatalogRegistrationResult Register(DatasetCatalogEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var result = snapshotStore.Store(ToSnapshotCandidate(entry));
+
+        if (!result.HasOutcome)
+        {
+            return DatasetCatalogRegistrationResult.Failed(result.Failure!.Value);
+        }
+
+        return DatasetCatalogRegistrationResult.Completed(result.Outcome!.Value switch
+        {
+            DatasetSnapshotStoreOutcome.NewlyAccepted => DatasetCatalogRegistrationOutcome.NewlyRegistered,
+            DatasetSnapshotStoreOutcome.EquivalentExisting => DatasetCatalogRegistrationOutcome.EquivalentExisting,
+            DatasetSnapshotStoreOutcome.IntegrityConflict => DatasetCatalogRegistrationOutcome.IntegrityConflict,
+            _ => throw new InvalidOperationException("The snapshot-store outcome is incompatible with catalog registration."),
+        });
+    }
+
+    public DatasetCatalogLookupResult Find(DatasetSnapshotIdentity snapshotIdentity)
+    {
+        ArgumentNullException.ThrowIfNull(snapshotIdentity);
+
+        var result = snapshotStore.Retrieve(snapshotIdentity);
+
+        if (result.IsFound)
+        {
+            return DatasetCatalogLookupResult.Found(new DatasetCatalogEntry(result.Snapshot!));
+        }
+
+        return result.IsNotFound
+            ? DatasetCatalogLookupResult.NotFound()
+            : DatasetCatalogLookupResult.Failed(result.Failure!.Value);
+    }
+
+    private static DatasetSnapshotCandidate ToSnapshotCandidate(DatasetCatalogEntry entry) =>
+        new(
+            entry.Definition,
+            entry.DefinitionIdentity,
+            entry.ResearchDatasetIdentity,
+            entry.SourceStateIdentity,
+            entry.SnapshotIdentity,
+            entry.Version,
+            entry.Lineage.SourceObservations,
+            entry.Coverage,
+            entry.Provenance,
+            entry.Lineage);
+}

--- a/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetEvidenceException.cs
+++ b/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetEvidenceException.cs
@@ -1,0 +1,9 @@
+namespace AIQuantTradingResearch.Infrastructure.Persistence.Sqlite;
+
+internal sealed class SqliteDatasetEvidenceException : InvalidOperationException
+{
+    public SqliteDatasetEvidenceException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetMapper.cs
+++ b/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetMapper.cs
@@ -1,0 +1,171 @@
+using System.Globalization;
+using AIQuantTradingResearch.Application.Datasets;
+using AIQuantTradingResearch.Domain;
+
+namespace AIQuantTradingResearch.Infrastructure.Persistence.Sqlite;
+
+internal static class SqliteDatasetMapper
+{
+    public static SqliteDatasetSnapshotRecord ToSnapshotRecord(DatasetCatalogEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        return new SqliteDatasetSnapshotRecord(
+            entry.SnapshotIdentity.Fingerprint,
+            entry.DefinitionIdentity.Fingerprint,
+            entry.ResearchDatasetIdentity.Fingerprint,
+            entry.SourceStateIdentity.Fingerprint,
+            entry.IdentityScheme,
+            entry.Target,
+            entry.RequestedFrom.UtcTicks,
+            OffsetMinutes(entry.RequestedFrom),
+            entry.RequestedTo.UtcTicks,
+            OffsetMinutes(entry.RequestedTo),
+            (int)entry.Definition.Ordering,
+            entry.ObservationCount,
+            entry.FirstObservationInstant?.UtcTicks,
+            entry.FirstObservationInstant is null ? null : OffsetMinutes(entry.FirstObservationInstant.Value),
+            entry.LastObservationInstant?.UtcTicks,
+            entry.LastObservationInstant is null ? null : OffsetMinutes(entry.LastObservationInstant.Value),
+            (int)entry.Provenance.SourceAuthority);
+    }
+
+    public static IReadOnlyList<SqliteDatasetObservationRecord> ToObservationRecords(
+        DatasetSnapshotCandidate snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        return snapshot.Observations
+            .Select((observation, ordinal) => new SqliteDatasetObservationRecord(
+                snapshot.SnapshotIdentity.Fingerprint,
+                ordinal,
+                observation.Instant.UtcTicks,
+                OffsetMinutes(observation.Instant),
+                observation.Price.ToString("G29", CultureInfo.InvariantCulture)))
+            .ToArray();
+    }
+
+    public static DatasetSnapshotCandidate ToSnapshotCandidate(
+        SqliteDatasetSnapshotRecord snapshotRecord,
+        IReadOnlyList<SqliteDatasetObservationRecord> observationRecords)
+    {
+        ArgumentNullException.ThrowIfNull(snapshotRecord);
+        ArgumentNullException.ThrowIfNull(observationRecords);
+
+        if (!string.Equals(snapshotRecord.IdentityScheme, DatasetIdentityScheme.Name, StringComparison.Ordinal))
+        {
+            throw new SqliteDatasetEvidenceException("The stored dataset identity scheme is incompatible.");
+        }
+
+        if (snapshotRecord.Ordering != (int)DatasetOrdering.SemanticInstantAscending)
+        {
+            throw new SqliteDatasetEvidenceException("The stored dataset ordering is incompatible.");
+        }
+
+        if (!Enum.IsDefined(typeof(DatasetSourceAuthority), snapshotRecord.SourceAuthority))
+        {
+            throw new SqliteDatasetEvidenceException("The stored dataset source authority is incompatible.");
+        }
+
+        if (snapshotRecord.ObservationCount != observationRecords.Count)
+        {
+            throw new SqliteDatasetEvidenceException("The stored dataset observation count is inconsistent.");
+        }
+
+        var snapshotIdentity = new DatasetSnapshotIdentity(snapshotRecord.SnapshotIdentity);
+        var definitionIdentity = new DatasetDefinitionIdentity(snapshotRecord.DefinitionIdentity);
+        var researchDatasetIdentity = new ResearchDatasetIdentity(snapshotRecord.ResearchDatasetIdentity);
+        var sourceStateIdentity = new SourceStateIdentity(snapshotRecord.SourceStateIdentity);
+        var definition = new DatasetDefinition(
+            snapshotRecord.Target,
+            ToInstant(snapshotRecord.RequestedFromUtcTicks, snapshotRecord.RequestedFromOffsetMinutes),
+            ToInstant(snapshotRecord.RequestedToUtcTicks, snapshotRecord.RequestedToOffsetMinutes));
+        var observations = ToObservations(snapshotIdentity, observationRecords);
+        var version = new DatasetVersion(snapshotIdentity);
+        var coverage = new DatasetCoverage(
+            definition.From,
+            definition.To,
+            snapshotRecord.ObservationCount,
+            ToNullableInstant(
+                snapshotRecord.FirstObservationUtcTicks,
+                snapshotRecord.FirstObservationOffsetMinutes),
+            ToNullableInstant(
+                snapshotRecord.LastObservationUtcTicks,
+                snapshotRecord.LastObservationOffsetMinutes));
+        var sourceAuthority = (DatasetSourceAuthority)snapshotRecord.SourceAuthority;
+        var provenance = new DatasetProvenance(
+            definition,
+            definitionIdentity,
+            researchDatasetIdentity,
+            sourceStateIdentity,
+            snapshotIdentity,
+            version,
+            sourceAuthority,
+            snapshotRecord.ObservationCount);
+        var lineage = new DatasetLineage(definitionIdentity, sourceStateIdentity, observations);
+
+        return new DatasetSnapshotCandidate(
+            definition,
+            definitionIdentity,
+            researchDatasetIdentity,
+            sourceStateIdentity,
+            snapshotIdentity,
+            version,
+            observations,
+            coverage,
+            provenance,
+            lineage);
+    }
+
+    public static DatasetCatalogEntry ToCatalogEntry(
+        SqliteDatasetSnapshotRecord snapshotRecord,
+        IReadOnlyList<SqliteDatasetObservationRecord> observationRecords) =>
+        new(ToSnapshotCandidate(snapshotRecord, observationRecords));
+
+    private static PriceObservation[] ToObservations(
+        DatasetSnapshotIdentity snapshotIdentity,
+        IReadOnlyList<SqliteDatasetObservationRecord> records)
+    {
+        var observations = new PriceObservation[records.Count];
+
+        for (var index = 0; index < records.Count; index++)
+        {
+            var record = records[index]
+                ?? throw new SqliteDatasetEvidenceException("Stored dataset observations cannot contain null records.");
+
+            if (!string.Equals(record.SnapshotIdentity, snapshotIdentity.Fingerprint, StringComparison.Ordinal)
+                || record.Ordinal != index)
+            {
+                throw new SqliteDatasetEvidenceException("Stored dataset observation membership or ordering is inconsistent.");
+            }
+
+            var price = decimal.Parse(record.PriceText, NumberStyles.Float, CultureInfo.InvariantCulture);
+            observations[index] = new PriceObservation(
+                ToInstant(record.InstantUtcTicks, record.OffsetMinutes),
+                price);
+        }
+
+        return observations;
+    }
+
+    private static DateTimeOffset? ToNullableInstant(long? utcTicks, short? offsetMinutes)
+    {
+        if (utcTicks is null && offsetMinutes is null)
+        {
+            return null;
+        }
+
+        if (utcTicks is null || offsetMinutes is null)
+        {
+            throw new SqliteDatasetEvidenceException("Stored dataset coverage has an incomplete instant representation.");
+        }
+
+        return ToInstant(utcTicks.Value, offsetMinutes.Value);
+    }
+
+    private static DateTimeOffset ToInstant(long utcTicks, short offsetMinutes) =>
+        new DateTimeOffset(utcTicks, TimeSpan.Zero).ToOffset(TimeSpan.FromMinutes(offsetMinutes));
+
+    private static short OffsetMinutes(DateTimeOffset instant) =>
+        checked((short)instant.Offset.TotalMinutes);
+}

--- a/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetObservationRecord.cs
+++ b/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetObservationRecord.cs
@@ -1,0 +1,8 @@
+namespace AIQuantTradingResearch.Infrastructure.Persistence.Sqlite;
+
+internal sealed record SqliteDatasetObservationRecord(
+    string SnapshotIdentity,
+    int Ordinal,
+    long InstantUtcTicks,
+    short OffsetMinutes,
+    string PriceText);

--- a/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetSchema.cs
+++ b/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetSchema.cs
@@ -1,0 +1,82 @@
+namespace AIQuantTradingResearch.Infrastructure.Persistence.Sqlite;
+
+internal static class SqliteDatasetSchema
+{
+    public const int Version = 2;
+
+    public const string SnapshotTableName = "dataset_snapshots";
+
+    public const string ObservationTableName = "dataset_snapshot_observations";
+
+    public const string CreateSnapshotTableStatement = """
+        CREATE TABLE IF NOT EXISTS dataset_snapshots (
+            snapshot_identity TEXT COLLATE BINARY NOT NULL
+                CHECK (length(snapshot_identity) = 64 AND snapshot_identity NOT GLOB '*[^0-9a-f]*'),
+            definition_identity TEXT COLLATE BINARY NOT NULL
+                CHECK (length(definition_identity) = 64 AND definition_identity NOT GLOB '*[^0-9a-f]*'),
+            research_dataset_identity TEXT COLLATE BINARY NOT NULL
+                CHECK (length(research_dataset_identity) = 64 AND research_dataset_identity NOT GLOB '*[^0-9a-f]*'),
+            source_state_identity TEXT COLLATE BINARY NOT NULL
+                CHECK (length(source_state_identity) = 64 AND source_state_identity NOT GLOB '*[^0-9a-f]*'),
+            identity_scheme TEXT COLLATE BINARY NOT NULL CHECK (identity_scheme = 'aiq-dataset-identity-v1'),
+            target TEXT COLLATE BINARY NOT NULL CHECK (length(target) > 0),
+            requested_from_utc_ticks INTEGER NOT NULL,
+            requested_from_offset_minutes INTEGER NOT NULL
+                CHECK (requested_from_offset_minutes BETWEEN -840 AND 840),
+            requested_to_utc_ticks INTEGER NOT NULL,
+            requested_to_offset_minutes INTEGER NOT NULL
+                CHECK (requested_to_offset_minutes BETWEEN -840 AND 840),
+            ordering INTEGER NOT NULL CHECK (ordering = 0),
+            observation_count INTEGER NOT NULL CHECK (observation_count >= 0),
+            first_observation_utc_ticks INTEGER,
+            first_observation_offset_minutes INTEGER
+                CHECK (first_observation_offset_minutes BETWEEN -840 AND 840),
+            last_observation_utc_ticks INTEGER,
+            last_observation_offset_minutes INTEGER
+                CHECK (last_observation_offset_minutes BETWEEN -840 AND 840),
+            source_authority INTEGER NOT NULL CHECK (source_authority = 0),
+            PRIMARY KEY (snapshot_identity),
+            CHECK (requested_from_utc_ticks < requested_to_utc_ticks),
+            CHECK (
+                requested_from_utc_ticks + requested_from_offset_minutes * 600000000
+                    BETWEEN 0 AND 3155378975999999999
+                AND requested_to_utc_ticks + requested_to_offset_minutes * 600000000
+                    BETWEEN 0 AND 3155378975999999999),
+            CHECK (
+                (observation_count = 0
+                    AND first_observation_utc_ticks IS NULL
+                    AND first_observation_offset_minutes IS NULL
+                    AND last_observation_utc_ticks IS NULL
+                    AND last_observation_offset_minutes IS NULL)
+                OR
+                (observation_count > 0
+                    AND first_observation_utc_ticks IS NOT NULL
+                    AND first_observation_offset_minutes IS NOT NULL
+                    AND last_observation_utc_ticks IS NOT NULL
+                    AND last_observation_offset_minutes IS NOT NULL
+                    AND first_observation_utc_ticks <= last_observation_utc_ticks
+                    AND first_observation_utc_ticks >= requested_from_utc_ticks
+                    AND last_observation_utc_ticks < requested_to_utc_ticks
+                    AND first_observation_utc_ticks + first_observation_offset_minutes * 600000000
+                        BETWEEN 0 AND 3155378975999999999
+                    AND last_observation_utc_ticks + last_observation_offset_minutes * 600000000
+                        BETWEEN 0 AND 3155378975999999999))
+        ) STRICT, WITHOUT ROWID;
+        """;
+
+    public const string CreateObservationTableStatement = """
+        CREATE TABLE IF NOT EXISTS dataset_snapshot_observations (
+            snapshot_identity TEXT COLLATE BINARY NOT NULL,
+            ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+            instant_utc_ticks INTEGER NOT NULL,
+            offset_minutes INTEGER NOT NULL CHECK (offset_minutes BETWEEN -840 AND 840),
+            price_text TEXT NOT NULL CHECK (length(price_text) > 0),
+            PRIMARY KEY (snapshot_identity, ordinal),
+            UNIQUE (snapshot_identity, instant_utc_ticks),
+            FOREIGN KEY (snapshot_identity) REFERENCES dataset_snapshots(snapshot_identity)
+                ON UPDATE RESTRICT ON DELETE RESTRICT,
+            CHECK (instant_utc_ticks + offset_minutes * 600000000
+                BETWEEN 0 AND 3155378975999999999)
+        ) STRICT, WITHOUT ROWID;
+        """;
+}

--- a/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetSnapshotRecord.cs
+++ b/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetSnapshotRecord.cs
@@ -1,0 +1,20 @@
+namespace AIQuantTradingResearch.Infrastructure.Persistence.Sqlite;
+
+internal sealed record SqliteDatasetSnapshotRecord(
+    string SnapshotIdentity,
+    string DefinitionIdentity,
+    string ResearchDatasetIdentity,
+    string SourceStateIdentity,
+    string IdentityScheme,
+    string Target,
+    long RequestedFromUtcTicks,
+    short RequestedFromOffsetMinutes,
+    long RequestedToUtcTicks,
+    short RequestedToOffsetMinutes,
+    int Ordering,
+    int ObservationCount,
+    long? FirstObservationUtcTicks,
+    short? FirstObservationOffsetMinutes,
+    long? LastObservationUtcTicks,
+    short? LastObservationOffsetMinutes,
+    int SourceAuthority);

--- a/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetSnapshotStore.cs
+++ b/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteDatasetSnapshotStore.cs
@@ -1,0 +1,390 @@
+using AIQuantTradingResearch.Application.Datasets;
+using Microsoft.Data.Sqlite;
+
+namespace AIQuantTradingResearch.Infrastructure.Persistence.Sqlite;
+
+internal sealed class SqliteDatasetSnapshotStore : IDatasetSnapshotStore
+{
+    private const string ReadSnapshotStatement = """
+        SELECT
+            snapshot_identity,
+            definition_identity,
+            research_dataset_identity,
+            source_state_identity,
+            identity_scheme,
+            target,
+            requested_from_utc_ticks,
+            requested_from_offset_minutes,
+            requested_to_utc_ticks,
+            requested_to_offset_minutes,
+            ordering,
+            observation_count,
+            first_observation_utc_ticks,
+            first_observation_offset_minutes,
+            last_observation_utc_ticks,
+            last_observation_offset_minutes,
+            source_authority
+        FROM dataset_snapshots
+        WHERE snapshot_identity = $snapshotIdentity;
+        """;
+
+    private const string ReadObservationsStatement = """
+        SELECT
+            snapshot_identity,
+            ordinal,
+            instant_utc_ticks,
+            offset_minutes,
+            price_text
+        FROM dataset_snapshot_observations
+        WHERE snapshot_identity = $snapshotIdentity
+        ORDER BY ordinal ASC;
+        """;
+
+    private const string InsertSnapshotStatement = """
+        INSERT INTO dataset_snapshots (
+            snapshot_identity,
+            definition_identity,
+            research_dataset_identity,
+            source_state_identity,
+            identity_scheme,
+            target,
+            requested_from_utc_ticks,
+            requested_from_offset_minutes,
+            requested_to_utc_ticks,
+            requested_to_offset_minutes,
+            ordering,
+            observation_count,
+            first_observation_utc_ticks,
+            first_observation_offset_minutes,
+            last_observation_utc_ticks,
+            last_observation_offset_minutes,
+            source_authority)
+        VALUES (
+            $snapshotIdentity,
+            $definitionIdentity,
+            $researchDatasetIdentity,
+            $sourceStateIdentity,
+            $identityScheme,
+            $target,
+            $requestedFromUtcTicks,
+            $requestedFromOffsetMinutes,
+            $requestedToUtcTicks,
+            $requestedToOffsetMinutes,
+            $ordering,
+            $observationCount,
+            $firstObservationUtcTicks,
+            $firstObservationOffsetMinutes,
+            $lastObservationUtcTicks,
+            $lastObservationOffsetMinutes,
+            $sourceAuthority);
+        """;
+
+    private const string InsertObservationStatement = """
+        INSERT INTO dataset_snapshot_observations (
+            snapshot_identity,
+            ordinal,
+            instant_utc_ticks,
+            offset_minutes,
+            price_text)
+        VALUES (
+            $snapshotIdentity,
+            $ordinal,
+            $instantUtcTicks,
+            $offsetMinutes,
+            $priceText);
+        """;
+
+    private readonly ISqliteConnectionFactory connectionFactory;
+
+    public SqliteDatasetSnapshotStore(ISqliteConnectionFactory connectionFactory)
+    {
+        ArgumentNullException.ThrowIfNull(connectionFactory);
+        this.connectionFactory = connectionFactory;
+    }
+
+    public DatasetSnapshotStoreResult Store(DatasetSnapshotCandidate snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var snapshotRecord = SqliteDatasetMapper.ToSnapshotRecord(new DatasetCatalogEntry(snapshot));
+        var observationRecords = SqliteDatasetMapper.ToObservationRecords(snapshot);
+
+        SqliteConnection connection;
+
+        try
+        {
+            connection = connectionFactory.OpenConnection();
+        }
+        catch (SqliteException exception) when (IsUnavailable(exception))
+        {
+            return DatasetSnapshotStoreResult.Failed(DatasetStoreFailure.Unavailable);
+        }
+        catch (SqliteException exception) when (IsInvalidData(exception))
+        {
+            return DatasetSnapshotStoreResult.Failed(DatasetStoreFailure.InvalidData);
+        }
+        catch (SqliteSchemaValidationException)
+        {
+            return DatasetSnapshotStoreResult.Failed(DatasetStoreFailure.InvalidData);
+        }
+        catch (InvalidOperationException exception)
+            when (exception.InnerException is SqliteSchemaValidationException)
+        {
+            return DatasetSnapshotStoreResult.Failed(DatasetStoreFailure.InvalidData);
+        }
+
+        using (connection)
+        using (var transaction = connection.BeginTransaction(deferred: false))
+        {
+            try
+            {
+                var existingSnapshot = ReadSnapshot(connection, transaction, snapshotRecord.SnapshotIdentity);
+
+                if (existingSnapshot is not null)
+                {
+                    var existingObservations = ReadObservations(
+                        connection,
+                        transaction,
+                        snapshotRecord.SnapshotIdentity);
+                    _ = SqliteDatasetMapper.ToSnapshotCandidate(existingSnapshot, existingObservations);
+
+                    return DatasetSnapshotStoreResult.Completed(
+                        IsEquivalent(existingSnapshot, existingObservations, snapshotRecord, observationRecords)
+                            ? DatasetSnapshotStoreOutcome.EquivalentExisting
+                            : DatasetSnapshotStoreOutcome.IntegrityConflict);
+                }
+
+                InsertSnapshot(connection, transaction, snapshotRecord);
+
+                foreach (var observationRecord in observationRecords)
+                {
+                    InsertObservation(connection, transaction, observationRecord);
+                }
+
+                transaction.Commit();
+                return DatasetSnapshotStoreResult.Completed(DatasetSnapshotStoreOutcome.NewlyAccepted);
+            }
+            catch (SqliteException exception) when (IsUnavailable(exception))
+            {
+                return DatasetSnapshotStoreResult.Failed(DatasetStoreFailure.Unavailable);
+            }
+            catch (SqliteException exception) when (IsInvalidData(exception))
+            {
+                return DatasetSnapshotStoreResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+            catch (InvalidCastException)
+            {
+                return DatasetSnapshotStoreResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+            catch (OverflowException)
+            {
+                return DatasetSnapshotStoreResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+            catch (FormatException)
+            {
+                return DatasetSnapshotStoreResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+            catch (ArgumentException)
+            {
+                return DatasetSnapshotStoreResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+            catch (SqliteDatasetEvidenceException)
+            {
+                return DatasetSnapshotStoreResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+        }
+    }
+
+    public DatasetSnapshotRetrievalResult Retrieve(DatasetSnapshotIdentity snapshotIdentity)
+    {
+        ArgumentNullException.ThrowIfNull(snapshotIdentity);
+
+        SqliteConnection connection;
+
+        try
+        {
+            connection = connectionFactory.OpenConnection();
+        }
+        catch (SqliteException exception) when (IsUnavailable(exception))
+        {
+            return DatasetSnapshotRetrievalResult.Failed(DatasetStoreFailure.Unavailable);
+        }
+        catch (SqliteException exception) when (IsInvalidData(exception))
+        {
+            return DatasetSnapshotRetrievalResult.Failed(DatasetStoreFailure.InvalidData);
+        }
+        catch (SqliteSchemaValidationException)
+        {
+            return DatasetSnapshotRetrievalResult.Failed(DatasetStoreFailure.InvalidData);
+        }
+        catch (InvalidOperationException exception)
+            when (exception.InnerException is SqliteSchemaValidationException)
+        {
+            return DatasetSnapshotRetrievalResult.Failed(DatasetStoreFailure.InvalidData);
+        }
+
+        using (connection)
+        {
+            try
+            {
+                var snapshotRecord = ReadSnapshot(connection, null, snapshotIdentity.Fingerprint);
+
+                if (snapshotRecord is null)
+                {
+                    return DatasetSnapshotRetrievalResult.NotFound();
+                }
+
+                var observationRecords = ReadObservations(connection, null, snapshotIdentity.Fingerprint);
+                return DatasetSnapshotRetrievalResult.Found(
+                    SqliteDatasetMapper.ToSnapshotCandidate(snapshotRecord, observationRecords));
+            }
+            catch (SqliteException exception) when (IsUnavailable(exception))
+            {
+                return DatasetSnapshotRetrievalResult.Failed(DatasetStoreFailure.Unavailable);
+            }
+            catch (SqliteException exception) when (IsInvalidData(exception))
+            {
+                return DatasetSnapshotRetrievalResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+            catch (InvalidCastException)
+            {
+                return DatasetSnapshotRetrievalResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+            catch (OverflowException)
+            {
+                return DatasetSnapshotRetrievalResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+            catch (FormatException)
+            {
+                return DatasetSnapshotRetrievalResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+            catch (ArgumentException)
+            {
+                return DatasetSnapshotRetrievalResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+            catch (SqliteDatasetEvidenceException)
+            {
+                return DatasetSnapshotRetrievalResult.Failed(DatasetStoreFailure.InvalidData);
+            }
+        }
+    }
+
+    private static bool IsEquivalent(
+        SqliteDatasetSnapshotRecord existingSnapshot,
+        IReadOnlyList<SqliteDatasetObservationRecord> existingObservations,
+        SqliteDatasetSnapshotRecord incomingSnapshot,
+        IReadOnlyList<SqliteDatasetObservationRecord> incomingObservations) =>
+        existingSnapshot == incomingSnapshot
+        && existingObservations.SequenceEqual(incomingObservations);
+
+    private static SqliteDatasetSnapshotRecord? ReadSnapshot(
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        string snapshotIdentity)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = ReadSnapshotStatement;
+        command.Parameters.AddWithValue("$snapshotIdentity", snapshotIdentity);
+        using var reader = command.ExecuteReader();
+
+        if (!reader.Read())
+        {
+            return null;
+        }
+
+        return new SqliteDatasetSnapshotRecord(
+            reader.GetString(0),
+            reader.GetString(1),
+            reader.GetString(2),
+            reader.GetString(3),
+            reader.GetString(4),
+            reader.GetString(5),
+            reader.GetInt64(6),
+            checked((short)reader.GetInt64(7)),
+            reader.GetInt64(8),
+            checked((short)reader.GetInt64(9)),
+            checked((int)reader.GetInt64(10)),
+            checked((int)reader.GetInt64(11)),
+            reader.IsDBNull(12) ? null : reader.GetInt64(12),
+            reader.IsDBNull(13) ? null : checked((short)reader.GetInt64(13)),
+            reader.IsDBNull(14) ? null : reader.GetInt64(14),
+            reader.IsDBNull(15) ? null : checked((short)reader.GetInt64(15)),
+            checked((int)reader.GetInt64(16)));
+    }
+
+    private static List<SqliteDatasetObservationRecord> ReadObservations(
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        string snapshotIdentity)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = ReadObservationsStatement;
+        command.Parameters.AddWithValue("$snapshotIdentity", snapshotIdentity);
+        using var reader = command.ExecuteReader();
+        var observations = new List<SqliteDatasetObservationRecord>();
+
+        while (reader.Read())
+        {
+            observations.Add(new SqliteDatasetObservationRecord(
+                reader.GetString(0),
+                checked((int)reader.GetInt64(1)),
+                reader.GetInt64(2),
+                checked((short)reader.GetInt64(3)),
+                reader.GetString(4)));
+        }
+
+        return observations;
+    }
+
+    private static void InsertSnapshot(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        SqliteDatasetSnapshotRecord record)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = InsertSnapshotStatement;
+        command.Parameters.AddWithValue("$snapshotIdentity", record.SnapshotIdentity);
+        command.Parameters.AddWithValue("$definitionIdentity", record.DefinitionIdentity);
+        command.Parameters.AddWithValue("$researchDatasetIdentity", record.ResearchDatasetIdentity);
+        command.Parameters.AddWithValue("$sourceStateIdentity", record.SourceStateIdentity);
+        command.Parameters.AddWithValue("$identityScheme", record.IdentityScheme);
+        command.Parameters.AddWithValue("$target", record.Target);
+        command.Parameters.AddWithValue("$requestedFromUtcTicks", record.RequestedFromUtcTicks);
+        command.Parameters.AddWithValue("$requestedFromOffsetMinutes", record.RequestedFromOffsetMinutes);
+        command.Parameters.AddWithValue("$requestedToUtcTicks", record.RequestedToUtcTicks);
+        command.Parameters.AddWithValue("$requestedToOffsetMinutes", record.RequestedToOffsetMinutes);
+        command.Parameters.AddWithValue("$ordering", record.Ordering);
+        command.Parameters.AddWithValue("$observationCount", record.ObservationCount);
+        command.Parameters.AddWithValue("$firstObservationUtcTicks", (object?)record.FirstObservationUtcTicks ?? DBNull.Value);
+        command.Parameters.AddWithValue("$firstObservationOffsetMinutes", (object?)record.FirstObservationOffsetMinutes ?? DBNull.Value);
+        command.Parameters.AddWithValue("$lastObservationUtcTicks", (object?)record.LastObservationUtcTicks ?? DBNull.Value);
+        command.Parameters.AddWithValue("$lastObservationOffsetMinutes", (object?)record.LastObservationOffsetMinutes ?? DBNull.Value);
+        command.Parameters.AddWithValue("$sourceAuthority", record.SourceAuthority);
+        command.ExecuteNonQuery();
+    }
+
+    private static void InsertObservation(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        SqliteDatasetObservationRecord record)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = InsertObservationStatement;
+        command.Parameters.AddWithValue("$snapshotIdentity", record.SnapshotIdentity);
+        command.Parameters.AddWithValue("$ordinal", record.Ordinal);
+        command.Parameters.AddWithValue("$instantUtcTicks", record.InstantUtcTicks);
+        command.Parameters.AddWithValue("$offsetMinutes", record.OffsetMinutes);
+        command.Parameters.AddWithValue("$priceText", record.PriceText);
+        command.ExecuteNonQuery();
+    }
+
+    private static bool IsUnavailable(SqliteException exception) =>
+        exception.SqliteErrorCode is 5 or 6 or 7 or 8 or 10 or 13 or 14 or 15;
+
+    private static bool IsInvalidData(SqliteException exception) =>
+        exception.SqliteErrorCode is 11 or 19 or 20 or 26;
+}

--- a/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteSchemaBootstrapper.cs
+++ b/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteSchemaBootstrapper.cs
@@ -5,21 +5,75 @@ namespace AIQuantTradingResearch.Infrastructure.Persistence.Sqlite;
 
 internal static class SqliteSchemaBootstrapper
 {
+    private const string EnableForeignKeysStatement = "PRAGMA foreign_keys = ON;";
     private const string ReadSchemaVersionStatement = "PRAGMA user_version;";
-    private const string WriteSchemaVersionStatement = "PRAGMA user_version = 1;";
-    private const string ReadTableDefinitionStatement = """
-        SELECT sql
-        FROM sqlite_schema
-        WHERE type = 'table' AND name = 'historical_observations';
-        """;
-    private const string ReadColumnsStatement = "PRAGMA table_info(historical_observations);";
+    private const string WriteSchemaVersionStatement = "PRAGMA user_version = 2;";
 
-    private static readonly ExpectedColumn[] ExpectedColumns =
+    private static readonly ExpectedColumn[] ExpectedHistoricalObservationColumns =
     {
-        new("target", "TEXT", 1),
-        new("instant_utc_ticks", "INTEGER", 2),
-        new("offset_minutes", "INTEGER", 0),
-        new("price_text", "TEXT", 0),
+        new("target", "TEXT", true, 1),
+        new("instant_utc_ticks", "INTEGER", true, 2),
+        new("offset_minutes", "INTEGER", true, 0),
+        new("price_text", "TEXT", true, 0),
+    };
+
+    private static readonly ExpectedColumn[] ExpectedDatasetSnapshotColumns =
+    {
+        new("snapshot_identity", "TEXT", true, 1),
+        new("definition_identity", "TEXT", true, 0),
+        new("research_dataset_identity", "TEXT", true, 0),
+        new("source_state_identity", "TEXT", true, 0),
+        new("identity_scheme", "TEXT", true, 0),
+        new("target", "TEXT", true, 0),
+        new("requested_from_utc_ticks", "INTEGER", true, 0),
+        new("requested_from_offset_minutes", "INTEGER", true, 0),
+        new("requested_to_utc_ticks", "INTEGER", true, 0),
+        new("requested_to_offset_minutes", "INTEGER", true, 0),
+        new("ordering", "INTEGER", true, 0),
+        new("observation_count", "INTEGER", true, 0),
+        new("first_observation_utc_ticks", "INTEGER", false, 0),
+        new("first_observation_offset_minutes", "INTEGER", false, 0),
+        new("last_observation_utc_ticks", "INTEGER", false, 0),
+        new("last_observation_offset_minutes", "INTEGER", false, 0),
+        new("source_authority", "INTEGER", true, 0),
+    };
+
+    private static readonly ExpectedColumn[] ExpectedDatasetObservationColumns =
+    {
+        new("snapshot_identity", "TEXT", true, 1),
+        new("ordinal", "INTEGER", true, 2),
+        new("instant_utc_ticks", "INTEGER", true, 0),
+        new("offset_minutes", "INTEGER", true, 0),
+        new("price_text", "TEXT", true, 0),
+    };
+
+    private static readonly string[] RequiredHistoricalObservationFragments =
+    {
+        "target TEXT COLLATE BINARY NOT NULL",
+        "offset_minutes INTEGER NOT NULL CHECK (offset_minutes BETWEEN -840 AND 840)",
+        "price_text TEXT NOT NULL CHECK (length(price_text) > 0)",
+        "PRIMARY KEY (target, instant_utc_ticks)",
+        "STRICT, WITHOUT ROWID",
+    };
+
+    private static readonly string[] RequiredDatasetSnapshotFragments =
+    {
+        "snapshot_identity TEXT COLLATE BINARY NOT NULL",
+        "identity_scheme = 'aiq-dataset-identity-v1'",
+        "target TEXT COLLATE BINARY NOT NULL",
+        "PRIMARY KEY (snapshot_identity)",
+        "observation_count = 0",
+        "first_observation_utc_ticks IS NULL",
+        "STRICT, WITHOUT ROWID",
+    };
+
+    private static readonly string[] RequiredDatasetObservationFragments =
+    {
+        "PRIMARY KEY (snapshot_identity, ordinal)",
+        "UNIQUE (snapshot_identity, instant_utc_ticks)",
+        "FOREIGN KEY (snapshot_identity) REFERENCES dataset_snapshots(snapshot_identity)",
+        "ON UPDATE RESTRICT ON DELETE RESTRICT",
+        "STRICT, WITHOUT ROWID",
     };
 
     public static void Bootstrap(SqliteConnection connection)
@@ -31,23 +85,35 @@ internal static class SqliteSchemaBootstrapper
             throw new InvalidOperationException("SQLite schema bootstrap requires an open connection.");
         }
 
+        EnableForeignKeys(connection);
+
         using var transaction = connection.BeginTransaction();
         var version = ReadSchemaVersion(connection, transaction);
 
         if (version == 0)
         {
             Execute(connection, transaction, SqliteHistoricalObservationSchema.CreateTableStatement);
-            ValidateSchema(connection, transaction);
+            ValidateHistoricalObservationSchema(connection, transaction);
+            CreateDatasetSchema(connection, transaction);
+            ValidateDatasetSchema(connection, transaction);
             Execute(connection, transaction, WriteSchemaVersionStatement);
         }
         else if (version == SqliteHistoricalObservationSchema.Version)
         {
-            ValidateSchema(connection, transaction);
+            ValidateHistoricalObservationSchema(connection, transaction);
+            CreateDatasetSchema(connection, transaction);
+            ValidateDatasetSchema(connection, transaction);
+            Execute(connection, transaction, WriteSchemaVersionStatement);
+        }
+        else if (version == SqliteDatasetSchema.Version)
+        {
+            ValidateHistoricalObservationSchema(connection, transaction);
+            ValidateDatasetSchema(connection, transaction);
         }
         else
         {
-            throw new InvalidOperationException(
-                $"Unsupported SQLite schema version '{version}'. Expected version '{SqliteHistoricalObservationSchema.Version}'.");
+            throw new SqliteSchemaValidationException(
+                $"Unsupported SQLite schema version '{version}'. Expected version '{SqliteDatasetSchema.Version}'.");
         }
 
         transaction.Commit();
@@ -61,68 +127,150 @@ internal static class SqliteSchemaBootstrapper
         command.Transaction = transaction;
         command.CommandText = ReadSchemaVersionStatement;
         return (long)(command.ExecuteScalar()
-            ?? throw new InvalidOperationException("SQLite returned no schema version."));
+            ?? throw new SqliteSchemaValidationException("SQLite returned no schema version."));
     }
 
-    private static void ValidateSchema(
+    private static void EnableForeignKeys(SqliteConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = EnableForeignKeysStatement;
+        command.ExecuteNonQuery();
+    }
+
+    private static void CreateDatasetSchema(
         SqliteConnection connection,
         SqliteTransaction transaction)
     {
-        var columns = ReadColumns(connection, transaction);
+        Execute(connection, transaction, SqliteDatasetSchema.CreateSnapshotTableStatement);
+        Execute(connection, transaction, SqliteDatasetSchema.CreateObservationTableStatement);
+    }
 
-        if (!columns.SequenceEqual(ExpectedColumns))
+    private static void ValidateHistoricalObservationSchema(
+        SqliteConnection connection,
+        SqliteTransaction transaction)
+    {
+        ValidateColumns(
+            connection,
+            transaction,
+            SqliteHistoricalObservationSchema.TableName,
+            ExpectedHistoricalObservationColumns);
+
+        ValidateTableDefinition(
+            connection,
+            transaction,
+            SqliteHistoricalObservationSchema.TableName,
+            RequiredHistoricalObservationFragments);
+    }
+
+    private static void ValidateDatasetSchema(
+        SqliteConnection connection,
+        SqliteTransaction transaction)
+    {
+        ValidateColumns(
+            connection,
+            transaction,
+            SqliteDatasetSchema.SnapshotTableName,
+            ExpectedDatasetSnapshotColumns);
+        ValidateColumns(
+            connection,
+            transaction,
+            SqliteDatasetSchema.ObservationTableName,
+            ExpectedDatasetObservationColumns);
+
+        ValidateTableDefinition(
+            connection,
+            transaction,
+            SqliteDatasetSchema.SnapshotTableName,
+            RequiredDatasetSnapshotFragments);
+        ValidateTableDefinition(
+            connection,
+            transaction,
+            SqliteDatasetSchema.ObservationTableName,
+            RequiredDatasetObservationFragments);
+        ValidateDatasetObservationForeignKey(connection, transaction);
+    }
+
+    private static void ValidateColumns(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string tableName,
+        IReadOnlyList<ExpectedColumn> expectedColumns)
+    {
+        var columns = ReadColumns(connection, transaction, tableName);
+
+        if (!columns.SequenceEqual(expectedColumns))
         {
-            throw new InvalidOperationException("The SQLite historical-observation table has an incompatible column definition.");
+            throw new SqliteSchemaValidationException($"The SQLite '{tableName}' table has an incompatible column definition.");
         }
+    }
 
+    private static void ValidateTableDefinition(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string tableName,
+        IReadOnlyList<string> requiredFragments)
+    {
         using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText = ReadTableDefinitionStatement;
+        command.CommandText = """
+            SELECT sql
+            FROM sqlite_schema
+            WHERE type = 'table' AND name = $tableName;
+            """;
+        command.Parameters.AddWithValue("$tableName", tableName);
         var definition = command.ExecuteScalar() as string
-            ?? throw new InvalidOperationException("The SQLite historical-observation table is missing.");
-
-        var requiredFragments = new[]
-        {
-            "target TEXT COLLATE BINARY NOT NULL",
-            "offset_minutes INTEGER NOT NULL CHECK (offset_minutes BETWEEN -840 AND 840)",
-            "price_text TEXT NOT NULL CHECK (length(price_text) > 0)",
-            "PRIMARY KEY (target, instant_utc_ticks)",
-            "STRICT, WITHOUT ROWID",
-        };
+            ?? throw new SqliteSchemaValidationException($"The SQLite '{tableName}' table is missing.");
 
         if (requiredFragments.Any(fragment =>
             !definition.Contains(fragment, StringComparison.OrdinalIgnoreCase)))
         {
-            throw new InvalidOperationException("The SQLite historical-observation table has incompatible constraints.");
+            throw new SqliteSchemaValidationException($"The SQLite '{tableName}' table has incompatible constraints.");
         }
     }
 
     private static List<ExpectedColumn> ReadColumns(
         SqliteConnection connection,
-        SqliteTransaction transaction)
+        SqliteTransaction transaction,
+        string tableName)
     {
         using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText = ReadColumnsStatement;
+        command.CommandText = $"PRAGMA table_info({tableName});";
         using var reader = command.ExecuteReader();
         var columns = new List<ExpectedColumn>();
 
         while (reader.Read())
         {
             var isNotNull = reader.GetInt64(3) == 1;
-
-            if (!isNotNull)
-            {
-                throw new InvalidOperationException("SQLite historical-observation columns must be non-nullable.");
-            }
-
             columns.Add(new ExpectedColumn(
                 reader.GetString(1),
                 reader.GetString(2),
+                isNotNull,
                 checked((int)reader.GetInt64(5))));
         }
 
         return columns;
+    }
+
+    private static void ValidateDatasetObservationForeignKey(
+        SqliteConnection connection,
+        SqliteTransaction transaction)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = $"PRAGMA foreign_key_list({SqliteDatasetSchema.ObservationTableName});";
+        using var reader = command.ExecuteReader();
+
+        if (!reader.Read()
+            || !string.Equals(reader.GetString(2), SqliteDatasetSchema.SnapshotTableName, StringComparison.Ordinal)
+            || !string.Equals(reader.GetString(3), "snapshot_identity", StringComparison.Ordinal)
+            || !string.Equals(reader.GetString(4), "snapshot_identity", StringComparison.Ordinal)
+            || !string.Equals(reader.GetString(5), "RESTRICT", StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(reader.GetString(6), "RESTRICT", StringComparison.OrdinalIgnoreCase)
+            || reader.Read())
+        {
+            throw new SqliteSchemaValidationException("The SQLite dataset-observation foreign key is incompatible.");
+        }
     }
 
     private static void Execute(
@@ -136,5 +284,9 @@ internal static class SqliteSchemaBootstrapper
         command.ExecuteNonQuery();
     }
 
-    private sealed record ExpectedColumn(string Name, string Type, int PrimaryKeyOrdinal);
+    private sealed record ExpectedColumn(
+        string Name,
+        string Type,
+        bool IsNotNull,
+        int PrimaryKeyOrdinal);
 }

--- a/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteSchemaValidationException.cs
+++ b/src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteSchemaValidationException.cs
@@ -1,0 +1,9 @@
+namespace AIQuantTradingResearch.Infrastructure.Persistence.Sqlite;
+
+internal sealed class SqliteSchemaValidationException : InvalidOperationException
+{
+    public SqliteSchemaValidationException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/AIQuantTradingResearch.Worker/DatasetMaterializationExecution.cs
+++ b/src/AIQuantTradingResearch.Worker/DatasetMaterializationExecution.cs
@@ -1,0 +1,37 @@
+using AIQuantTradingResearch.Application.Datasets;
+
+namespace AIQuantTradingResearch.Worker;
+
+internal sealed class DatasetMaterializationExecution
+{
+    private readonly IDatasetMaterializationIntegrationUseCase integrationUseCase;
+
+    public DatasetMaterializationExecution(IDatasetMaterializationIntegrationUseCase integrationUseCase)
+    {
+        ArgumentNullException.ThrowIfNull(integrationUseCase);
+        this.integrationUseCase = integrationUseCase;
+    }
+
+    public int Execute(DatasetDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var result = integrationUseCase.Execute(definition)
+            ?? throw new InvalidOperationException("The dataset materialization integration use case returned no result.");
+
+        if (result.IsSuccess)
+        {
+            var outcome = result.Outcome
+                ?? throw new InvalidOperationException("A successful dataset materialization result must contain an outcome.");
+
+            Console.WriteLine($"Dataset materialization outcome: {outcome}");
+            return 0;
+        }
+
+        var failure = result.Failure
+            ?? throw new InvalidOperationException("A failed dataset materialization result must contain a failure.");
+
+        Console.Error.WriteLine($"Dataset materialization failed: {failure}");
+        return 1;
+    }
+}

--- a/src/AIQuantTradingResearch.Worker/Program.cs
+++ b/src/AIQuantTradingResearch.Worker/Program.cs
@@ -1,17 +1,23 @@
 using AIQuantTradingResearch.Application;
+using AIQuantTradingResearch.Application.Datasets;
 using AIQuantTradingResearch.Application.Research;
 using AIQuantTradingResearch.Infrastructure;
 using AIQuantTradingResearch.Infrastructure.MarketData.TwelveData;
 using AIQuantTradingResearch.Infrastructure.Persistence.Sqlite;
 using AIQuantTradingResearch.Worker;
 using Microsoft.Extensions.DependencyInjection;
+using System.Globalization;
 
 var builder = Host.CreateApplicationBuilder(args);
 var apiKeyPath = $"{TwelveDataConfiguration.SectionName}:{TwelveDataConfiguration.ApiKeyName}";
 var databasePath = $"{SqliteStorageConfiguration.SectionName}:{SqliteStorageConfiguration.DatabasePathName}";
+const string datasetTargetPath = "Dataset:Target";
+const string datasetFromPath = "Dataset:From";
+const string datasetToPath = "Dataset:To";
 
 TwelveDataConfiguration twelveDataConfiguration;
 SqliteStorageConfiguration sqliteStorageConfiguration;
+DatasetDefinition datasetDefinition;
 
 try
 {
@@ -35,11 +41,39 @@ catch (ArgumentException)
     return 1;
 }
 
+try
+{
+    datasetDefinition = new DatasetDefinition(
+        builder.Configuration[datasetTargetPath] ?? string.Empty,
+        ParseRequiredTimestamp(builder.Configuration[datasetFromPath], datasetFromPath),
+        ParseRequiredTimestamp(builder.Configuration[datasetToPath], datasetToPath));
+}
+catch (ArgumentException)
+{
+    Console.Error.WriteLine("Invalid mandatory dataset configuration.");
+    return 1;
+}
+
 builder.Services.AddApplication();
 builder.Services.AddInfrastructure(twelveDataConfiguration, sqliteStorageConfiguration);
-builder.Services.AddTransient<PersistentMarketDataExecution>();
+builder.Services.AddTransient<DatasetMaterializationExecution>();
 
 using var host = builder.Build();
-var execution = host.Services.GetRequiredService<PersistentMarketDataExecution>();
-var request = new ResearchRequest("AAPL", 3);
-return execution.Execute(request);
+var execution = host.Services.GetRequiredService<DatasetMaterializationExecution>();
+return execution.Execute(datasetDefinition);
+
+static DateTimeOffset ParseRequiredTimestamp(string? value, string configurationPath)
+{
+    if (string.IsNullOrWhiteSpace(value)
+        || !DateTimeOffset.TryParseExact(
+            value,
+            "O",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var timestamp))
+    {
+        throw new ArgumentException($"Missing or invalid mandatory configuration: {configurationPath}.");
+    }
+
+    return timestamp;
+}

--- a/tests/AIQuantTradingResearch.Application.Tests/DatasetApplicationTests.cs
+++ b/tests/AIQuantTradingResearch.Application.Tests/DatasetApplicationTests.cs
@@ -1,0 +1,287 @@
+using System.Globalization;
+using AIQuantTradingResearch.Application.Datasets;
+using AIQuantTradingResearch.Application.Persistence;
+using AIQuantTradingResearch.Domain;
+using Xunit;
+
+namespace AIQuantTradingResearch.Application.Tests;
+
+public sealed class DatasetApplicationTests
+{
+    private static readonly DateTimeOffset From = new(2024, 1, 1, 0, 0, 0, TimeSpan.FromHours(-3));
+    private static readonly DateTimeOffset To = From.AddDays(3);
+
+    [Fact]
+    public void DatasetDefinitionPreservesExactTargetAndRequiresValidHalfOpenInterval()
+    {
+        var definition = new DatasetDefinition("aapl ", From, To);
+
+        Assert.Equal("aapl ", definition.Target);
+        Assert.Equal(From, definition.From);
+        Assert.Equal(To, definition.To);
+        Assert.Equal(DatasetOrdering.SemanticInstantAscending, definition.Ordering);
+        Assert.Throws<ArgumentException>(() => new DatasetDefinition("AAPL", From, From));
+        Assert.Throws<ArgumentException>(() => new DatasetDefinition("AAPL", To, From));
+        Assert.Throws<ArgumentException>(() => new DatasetDefinition(" ", From, To));
+    }
+
+    [Fact]
+    public void TypedIdentitiesRequireCanonicalFingerprintsAndVersionPreservesSnapshotIdentity()
+    {
+        const string fingerprint = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        var definition = new DatasetDefinitionIdentity(fingerprint);
+        var research = new ResearchDatasetIdentity(fingerprint);
+        var source = new SourceStateIdentity(fingerprint);
+        var snapshot = new DatasetSnapshotIdentity(fingerprint);
+        var version = new DatasetVersion(snapshot);
+
+        Assert.Equal(DatasetIdentityScheme.Name, definition.Scheme);
+        Assert.Equal(fingerprint, research.Fingerprint);
+        Assert.Equal(fingerprint, source.Fingerprint);
+        Assert.Same(snapshot, version.SnapshotIdentity);
+        Assert.Throws<ArgumentException>(() => new DatasetSnapshotIdentity(fingerprint.ToUpperInvariant()));
+        Assert.Throws<ArgumentException>(() => new DatasetSnapshotIdentity("abc"));
+    }
+
+    [Fact]
+    public void MaterializationSelectsHalfOpenWindowPreservesFidelityAndBuildsCatalogEvidence()
+    {
+        var before = new PriceObservation(From.AddTicks(-1), 1.0000000000000000000000000001m);
+        var included = new PriceObservation(From, 2.1234567890123456789012345678m);
+        var middle = new PriceObservation(From.AddDays(1), 3.5m);
+        var excluded = new PriceObservation(To, 4m);
+        var store = new StubHistoryStore(HistoricalObservationResult.Retrieved([before, included, middle, excluded]));
+        var result = new MaterializeDatasetUseCase(store).Execute(new DatasetDefinition("AAPL", From, To));
+
+        var snapshot = Assert.IsType<DatasetSnapshotCandidate>(result.Snapshot);
+        Assert.True(result.IsSuccess);
+        Assert.Equal("AAPL", store.LastTarget);
+        Assert.Equal([included, middle], snapshot.Observations);
+        Assert.Equal(included.Instant, snapshot.Coverage.FirstObservationInstant);
+        Assert.Equal(middle.Instant, snapshot.Coverage.LastObservationInstant);
+        Assert.Equal(included.Price, snapshot.Observations[0].Price);
+        Assert.Equal(TimeSpan.FromHours(-3), snapshot.Observations[0].Instant.Offset);
+        Assert.Equal(snapshot.DefinitionIdentity, snapshot.Provenance.DefinitionIdentity);
+        Assert.Equal(snapshot.SourceStateIdentity, snapshot.Lineage.SourceStateIdentity);
+        var catalog = new DatasetCatalogEntry(snapshot);
+        Assert.Equal(snapshot.SnapshotIdentity, catalog.SnapshotIdentity);
+        Assert.Equal(snapshot.Version, catalog.Version);
+        Assert.Equal(2, catalog.ObservationCount);
+        Assert.False(catalog.IsEmpty);
+    }
+
+    [Fact]
+    public void MaterializationIsDeterministicAcrossCultureAndEmptySelection()
+    {
+        var definition = new DatasetDefinition("AAPL", From, To);
+        var observations = new[] { new PriceObservation(From.AddDays(1), 12.3400m) };
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("pt-BR");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("pt-BR");
+            var first = Materialize(definition, observations);
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("tr-TR");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("tr-TR");
+            var second = Materialize(definition, observations);
+            var empty = Materialize(definition, []);
+
+            Assert.Equal(first.DefinitionIdentity, second.DefinitionIdentity);
+            Assert.Equal(first.ResearchDatasetIdentity, second.ResearchDatasetIdentity);
+            Assert.Equal(first.SourceStateIdentity, second.SourceStateIdentity);
+            Assert.Equal(first.SnapshotIdentity, second.SnapshotIdentity);
+            Assert.Equal(first.Version, second.Version);
+            Assert.Empty(empty.Observations);
+            Assert.True(new DatasetCatalogEntry(empty).IsEmpty);
+            Assert.Null(empty.Coverage.FirstObservationInstant);
+            Assert.Null(empty.Coverage.LastObservationInstant);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
+    }
+
+    [Fact]
+    public void MaterializationIdentityChangesForRelevantInputButNotOutsideWindow()
+    {
+        var definition = new DatasetDefinition("AAPL", From, To);
+        var baseline = Materialize(definition, [new PriceObservation(From.AddDays(1), 10m)]);
+        var changed = Materialize(definition, [new PriceObservation(From.AddDays(1), 11m)]);
+        var outside = Materialize(definition, [new PriceObservation(From.AddDays(1), 10m), new PriceObservation(To.AddDays(1), 99m)]);
+        var changedDefinition = Materialize(new DatasetDefinition("AAPL", From, To.AddDays(1)), [new PriceObservation(From.AddDays(1), 10m)]);
+
+        Assert.NotEqual(baseline.SourceStateIdentity, changed.SourceStateIdentity);
+        Assert.NotEqual(baseline.SnapshotIdentity, changed.SnapshotIdentity);
+        Assert.Equal(baseline.SourceStateIdentity, outside.SourceStateIdentity);
+        Assert.Equal(baseline.SnapshotIdentity, outside.SnapshotIdentity);
+        Assert.NotEqual(baseline.DefinitionIdentity, changedDefinition.DefinitionIdentity);
+        Assert.NotEqual(baseline.ResearchDatasetIdentity, changedDefinition.ResearchDatasetIdentity);
+        Assert.NotEqual(baseline.SnapshotIdentity, changedDefinition.SnapshotIdentity);
+    }
+
+    [Theory]
+    [InlineData(PersistenceFailure.Unavailable, DatasetMaterializationFailure.SourceHistoryUnavailable)]
+    [InlineData(PersistenceFailure.InvalidData, DatasetMaterializationFailure.IntegrityConflict)]
+    public void MaterializationMapsHistoricalFailures(PersistenceFailure sourceFailure, DatasetMaterializationFailure expectedFailure)
+    {
+        var result = new MaterializeDatasetUseCase(new StubHistoryStore(HistoricalObservationResult.Failed(sourceFailure)))
+            .Execute(new DatasetDefinition("AAPL", From, To));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(expectedFailure, result.Failure);
+    }
+
+    [Fact]
+    public void HistoricalResultRejectsDuplicateSemanticInstants()
+    {
+        var instant = From.AddDays(1);
+        Assert.Throws<ArgumentException>(() => HistoricalObservationResult.Retrieved([
+            new PriceObservation(instant, 1m),
+            new PriceObservation(instant, 2m),
+        ]));
+    }
+
+    [Theory]
+    [InlineData(DatasetSnapshotStoreOutcome.NewlyAccepted, DatasetCatalogRegistrationOutcome.NewlyRegistered, DatasetMaterializationIntegrationOutcome.NewlyAccepted)]
+    [InlineData(DatasetSnapshotStoreOutcome.NewlyAccepted, DatasetCatalogRegistrationOutcome.EquivalentExisting, DatasetMaterializationIntegrationOutcome.NewlyAccepted)]
+    [InlineData(DatasetSnapshotStoreOutcome.EquivalentExisting, DatasetCatalogRegistrationOutcome.NewlyRegistered, DatasetMaterializationIntegrationOutcome.EquivalentExisting)]
+    [InlineData(DatasetSnapshotStoreOutcome.EquivalentExisting, DatasetCatalogRegistrationOutcome.EquivalentExisting, DatasetMaterializationIntegrationOutcome.EquivalentExisting)]
+    public void IntegrationComposesAcceptedOutcomes(
+        DatasetSnapshotStoreOutcome snapshotOutcome,
+        DatasetCatalogRegistrationOutcome catalogOutcome,
+        DatasetMaterializationIntegrationOutcome expectedOutcome)
+    {
+        var candidate = Materialize(new DatasetDefinition("AAPL", From, To), []);
+        var materializer = new StubMaterializer(DatasetMaterializationResult.Materialized(candidate));
+        var store = new StubSnapshotStore(DatasetSnapshotStoreResult.Completed(snapshotOutcome));
+        var catalog = new StubCatalog(DatasetCatalogRegistrationResult.Completed(catalogOutcome));
+
+        var result = new DatasetMaterializationIntegrationUseCase(materializer, store, catalog).Execute(candidate.Definition);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedOutcome, result.Outcome);
+        Assert.Equal(1, store.StoreCalls);
+        Assert.Equal(1, catalog.RegisterCalls);
+        Assert.Equal(candidate.SnapshotIdentity, catalog.LastEntry!.SnapshotIdentity);
+        Assert.Equal(candidate.Lineage, catalog.LastEntry.Lineage);
+    }
+
+    [Theory]
+    [InlineData(DatasetStoreFailure.Unavailable, DatasetMaterializationFailure.SnapshotStoreUnavailable)]
+    [InlineData(DatasetStoreFailure.InvalidData, DatasetMaterializationFailure.IntegrityConflict)]
+    public void IntegrationMapsStoreFailuresWithoutCallingCatalog(DatasetStoreFailure storeFailure, DatasetMaterializationFailure expectedFailure)
+    {
+        var candidate = Materialize(new DatasetDefinition("AAPL", From, To), []);
+        var store = new StubSnapshotStore(DatasetSnapshotStoreResult.Failed(storeFailure));
+        var catalog = new StubCatalog(DatasetCatalogRegistrationResult.Completed(DatasetCatalogRegistrationOutcome.NewlyRegistered));
+
+        var result = new DatasetMaterializationIntegrationUseCase(
+            new StubMaterializer(DatasetMaterializationResult.Materialized(candidate)), store, catalog).Execute(candidate.Definition);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(expectedFailure, result.Failure);
+        Assert.Equal(0, catalog.RegisterCalls);
+    }
+
+    [Theory]
+    [InlineData(DatasetCatalogRegistrationOutcome.IntegrityConflict, null)]
+    [InlineData(null, DatasetStoreFailure.Unavailable)]
+    [InlineData(null, DatasetStoreFailure.InvalidData)]
+    public void IntegrationMapsCatalogConflictAndFailures(
+        DatasetCatalogRegistrationOutcome? catalogOutcome,
+        DatasetStoreFailure? catalogFailure)
+    {
+        var candidate = Materialize(new DatasetDefinition("AAPL", From, To), []);
+        var registration = catalogOutcome is not null
+            ? DatasetCatalogRegistrationResult.Completed(catalogOutcome.Value)
+            : DatasetCatalogRegistrationResult.Failed(catalogFailure!.Value);
+
+        var result = new DatasetMaterializationIntegrationUseCase(
+            new StubMaterializer(DatasetMaterializationResult.Materialized(candidate)),
+            new StubSnapshotStore(DatasetSnapshotStoreResult.Completed(DatasetSnapshotStoreOutcome.NewlyAccepted)),
+            new StubCatalog(registration)).Execute(candidate.Definition);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            catalogOutcome == DatasetCatalogRegistrationOutcome.IntegrityConflict || catalogFailure == DatasetStoreFailure.InvalidData
+                ? DatasetMaterializationFailure.IntegrityConflict
+                : DatasetMaterializationFailure.SnapshotStoreUnavailable,
+            result.Failure);
+    }
+
+    [Fact]
+    public void IntegrationStopsOnMaterializationOrIntegrityConflict()
+    {
+        var definition = new DatasetDefinition("AAPL", From, To);
+        var candidate = Materialize(definition, []);
+        var failingStore = new StubSnapshotStore(DatasetSnapshotStoreResult.Completed(DatasetSnapshotStoreOutcome.IntegrityConflict));
+        var catalog = new StubCatalog(DatasetCatalogRegistrationResult.Completed(DatasetCatalogRegistrationOutcome.NewlyRegistered));
+        var conflict = new DatasetMaterializationIntegrationUseCase(
+            new StubMaterializer(DatasetMaterializationResult.Materialized(candidate)), failingStore, catalog).Execute(definition);
+        var materializationFailure = new DatasetMaterializationIntegrationUseCase(
+            new StubMaterializer(DatasetMaterializationResult.Failed(DatasetMaterializationFailure.SourceHistoryUnavailable)),
+            new StubSnapshotStore(DatasetSnapshotStoreResult.Completed(DatasetSnapshotStoreOutcome.NewlyAccepted)), catalog).Execute(definition);
+
+        Assert.Equal(DatasetMaterializationFailure.IntegrityConflict, conflict.Failure);
+        Assert.Equal(0, catalog.RegisterCalls);
+        Assert.Equal(DatasetMaterializationFailure.SourceHistoryUnavailable, materializationFailure.Failure);
+    }
+
+    private static DatasetSnapshotCandidate Materialize(DatasetDefinition definition, IReadOnlyList<PriceObservation> observations) =>
+        new MaterializeDatasetUseCase(new StubHistoryStore(HistoricalObservationResult.Retrieved(observations)))
+            .Execute(definition).Snapshot!;
+
+    private sealed class StubHistoryStore(HistoricalObservationResult retrieval) : IHistoricalObservationStore
+    {
+        public string? LastTarget { get; private set; }
+
+        public ObservationPersistenceResult Persist(string target, IReadOnlyList<PriceObservation> observations) =>
+            throw new NotSupportedException();
+
+        public HistoricalObservationResult Retrieve(string target)
+        {
+            LastTarget = target;
+            return retrieval;
+        }
+    }
+
+    private sealed class StubMaterializer(DatasetMaterializationResult result) : IMaterializeDatasetUseCase
+    {
+        public DatasetMaterializationResult Execute(DatasetDefinition definition) => result;
+    }
+
+    private sealed class StubSnapshotStore(DatasetSnapshotStoreResult storeResult) : IDatasetSnapshotStore
+    {
+        public int StoreCalls { get; private set; }
+
+        public DatasetSnapshotStoreResult Store(DatasetSnapshotCandidate snapshot)
+        {
+            StoreCalls++;
+            return storeResult;
+        }
+
+        public DatasetSnapshotRetrievalResult Retrieve(DatasetSnapshotIdentity snapshotIdentity) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class StubCatalog(DatasetCatalogRegistrationResult registrationResult) : IDatasetCatalog
+    {
+        public int RegisterCalls { get; private set; }
+
+        public DatasetCatalogEntry? LastEntry { get; private set; }
+
+        public DatasetCatalogRegistrationResult Register(DatasetCatalogEntry entry)
+        {
+            RegisterCalls++;
+            LastEntry = entry;
+            return registrationResult;
+        }
+
+        public DatasetCatalogLookupResult Find(DatasetSnapshotIdentity snapshotIdentity) =>
+            throw new NotSupportedException();
+    }
+}

--- a/tests/AIQuantTradingResearch.Infrastructure.Tests/SqliteDatasetTests.cs
+++ b/tests/AIQuantTradingResearch.Infrastructure.Tests/SqliteDatasetTests.cs
@@ -1,0 +1,229 @@
+using AIQuantTradingResearch.Application.Datasets;
+using AIQuantTradingResearch.Application.Persistence;
+using AIQuantTradingResearch.Application.Research;
+using AIQuantTradingResearch.Domain;
+using AIQuantTradingResearch.Infrastructure;
+using AIQuantTradingResearch.Infrastructure.MarketData.TwelveData;
+using AIQuantTradingResearch.Infrastructure.Persistence.Sqlite;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AIQuantTradingResearch.Infrastructure.Tests;
+
+public sealed class SqliteDatasetTests
+{
+    [Fact]
+    public void MapperRoundTripPreservesDatasetEvidenceIncludingOffsetsAndDecimals()
+    {
+        var snapshot = Snapshot('a', price: 12.34567890123456789012345678m);
+
+        var record = SqliteDatasetMapper.ToSnapshotRecord(new DatasetCatalogEntry(snapshot));
+        var observations = SqliteDatasetMapper.ToObservationRecords(snapshot);
+        var reconstructed = SqliteDatasetMapper.ToSnapshotCandidate(record, observations);
+
+        AssertSnapshotEquivalent(snapshot, reconstructed);
+    }
+
+    [Fact]
+    public void StorePersistsRetrievesAndKeepsEquivalentEvidenceAcrossInstances()
+    {
+        using var database = new DatasetDatabase();
+        var snapshot = Snapshot('a');
+        var first = new SqliteDatasetSnapshotStore(database.Factory);
+
+        Assert.Equal(DatasetSnapshotStoreOutcome.NewlyAccepted, first.Store(snapshot).Outcome);
+        var retrieved = first.Retrieve(snapshot.SnapshotIdentity);
+        Assert.True(retrieved.IsFound);
+        AssertSnapshotEquivalent(snapshot, retrieved.Snapshot!);
+
+        var second = new SqliteDatasetSnapshotStore(database.Factory);
+        Assert.Equal(DatasetSnapshotStoreOutcome.EquivalentExisting, second.Store(snapshot).Outcome);
+        AssertSnapshotEquivalent(snapshot, second.Retrieve(snapshot.SnapshotIdentity).Snapshot!);
+    }
+
+    [Fact]
+    public void StoreSupportsEmptyAndMultipleVersionsButRejectsConflictingSameIdentityWithoutOverwrite()
+    {
+        using var database = new DatasetDatabase();
+        var store = new SqliteDatasetSnapshotStore(database.Factory);
+        var nonEmpty = Snapshot('a');
+        var empty = Snapshot('b', empty: true);
+
+        Assert.Equal(DatasetSnapshotStoreOutcome.NewlyAccepted, store.Store(nonEmpty).Outcome);
+        Assert.Equal(DatasetSnapshotStoreOutcome.NewlyAccepted, store.Store(empty).Outcome);
+        Assert.Empty(store.Retrieve(empty.SnapshotIdentity).Snapshot!.Observations);
+        Assert.Equal(2, Count(database.Factory, "SELECT COUNT(*) FROM dataset_snapshots;"));
+
+        var conflict = Snapshot('a', price: 99m);
+        Assert.Equal(DatasetSnapshotStoreOutcome.IntegrityConflict, store.Store(conflict).Outcome);
+        AssertSnapshotEquivalent(nonEmpty, store.Retrieve(nonEmpty.SnapshotIdentity).Snapshot!);
+    }
+
+    [Fact]
+    public void CatalogRegistersEquivalentEvidenceAndProvidesExactHitOrMiss()
+    {
+        using var database = new DatasetDatabase();
+        var catalog = new SqliteDatasetCatalog(database.Factory);
+        var snapshot = Snapshot('c');
+        var entry = new DatasetCatalogEntry(snapshot);
+
+        Assert.Equal(DatasetCatalogRegistrationOutcome.NewlyRegistered, catalog.Register(entry).Outcome);
+        Assert.Equal(DatasetCatalogRegistrationOutcome.EquivalentExisting, catalog.Register(entry).Outcome);
+        var found = catalog.Find(snapshot.SnapshotIdentity).Entry!;
+        Assert.Equal(entry.SnapshotIdentity, found.SnapshotIdentity);
+        Assert.Equal(entry.Version, found.Version);
+        Assert.Equal(entry.Definition, found.Definition);
+        Assert.Equal(entry.Coverage, found.Coverage);
+        Assert.Equal(entry.Provenance, found.Provenance);
+        Assert.Equal(entry.Lineage.SourceObservations, found.Lineage.SourceObservations);
+        Assert.True(catalog.Find(new DatasetSnapshotIdentity(Fingerprint('d'))).IsNotFound);
+    }
+
+    [Fact]
+    public void StoreRollsBackDescriptorWhenMembershipWriteFailsAndMapsInvalidEvidence()
+    {
+        using var database = new DatasetDatabase();
+        var store = new SqliteDatasetSnapshotStore(database.Factory);
+        var snapshot = Snapshot('e');
+        using (var connection = database.Factory.OpenConnection())
+        {
+            Execute(connection, "CREATE TRIGGER reject_dataset_membership BEFORE INSERT ON dataset_snapshot_observations BEGIN SELECT RAISE(ABORT, 'test failure'); END;");
+        }
+
+        Assert.Equal(DatasetStoreFailure.InvalidData, store.Store(snapshot).Failure);
+        Assert.True(store.Retrieve(snapshot.SnapshotIdentity).IsNotFound);
+        Assert.Equal(0L, Count(database.Factory, "SELECT COUNT(*) FROM dataset_snapshots;"));
+    }
+
+    [Fact]
+    public void RetrieveMapsMalformedPersistedDatasetEvidenceToInvalidDataWithoutRepair()
+    {
+        using var database = new DatasetDatabase();
+        var store = new SqliteDatasetSnapshotStore(database.Factory);
+        var snapshot = Snapshot('f');
+        Assert.Equal(DatasetSnapshotStoreOutcome.NewlyAccepted, store.Store(snapshot).Outcome);
+        using (var connection = database.Factory.OpenConnection())
+        {
+            Execute(connection, "PRAGMA ignore_check_constraints = ON;");
+            Execute(connection, "UPDATE dataset_snapshot_observations SET price_text = 'malformed';");
+        }
+
+        var result = store.Retrieve(snapshot.SnapshotIdentity);
+
+        Assert.Equal(DatasetStoreFailure.InvalidData, result.Failure);
+        Assert.Equal(1L, Count(database.Factory, "SELECT COUNT(*) FROM dataset_snapshot_observations;"));
+    }
+
+    [Fact]
+    public void VersionOneDatabaseUpgradesToVersionTwoWithoutHistoricalDataLoss()
+    {
+        using var database = new DatasetDatabase(createDirectory: true);
+        using (var connection = new SqliteConnection($"Data Source={database.Path}"))
+        {
+            connection.Open();
+            Execute(connection, SqliteHistoricalObservationSchema.CreateTableStatement);
+            Execute(connection, "INSERT INTO historical_observations VALUES ('AAPL', 638396748000000000, -180, '123.45');");
+            Execute(connection, "PRAGMA user_version = 1;");
+        }
+
+        using var upgraded = database.Factory.OpenConnection();
+        Assert.Equal(2L, Scalar<long>(upgraded, "PRAGMA user_version;"));
+        Assert.Equal(1L, Scalar<long>(upgraded, "SELECT COUNT(*) FROM historical_observations;"));
+        Assert.Equal(1L, Scalar<long>(upgraded, "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'dataset_snapshots';"));
+    }
+
+    [Fact]
+    public void DatasetRegistrationsResolveWithoutCreatingDatabaseOrProviderCall()
+    {
+        using var database = new DatasetDatabase(createDirectory: false);
+        var services = new ServiceCollection();
+        services.AddInfrastructure(new TwelveDataConfiguration("offline-placeholder"), database.Configuration);
+
+        _ = Assert.Single(services, static x => x.ServiceType == typeof(IDatasetSnapshotStore));
+        _ = Assert.Single(services, static x => x.ServiceType == typeof(IDatasetCatalog));
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+        Assert.IsType<SqliteDatasetSnapshotStore>(provider.GetRequiredService<IDatasetSnapshotStore>());
+        Assert.IsType<SqliteDatasetCatalog>(provider.GetRequiredService<IDatasetCatalog>());
+        _ = provider.GetRequiredService<IHistoricalObservationStore>();
+        _ = provider.GetRequiredService<IObservationSource>();
+        Assert.False(File.Exists(database.Path));
+    }
+
+    private static DatasetSnapshotCandidate Snapshot(char identityCharacter, bool empty = false, decimal price = 12.34567890123456789012345678m)
+    {
+        var from = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.FromHours(-3));
+        var to = from.AddDays(3);
+        var definition = new DatasetDefinition(" AAPL ", from, to);
+        var definitionIdentity = new DatasetDefinitionIdentity(Fingerprint('1'));
+        var researchIdentity = new ResearchDatasetIdentity(Fingerprint('2'));
+        var sourceIdentity = new SourceStateIdentity(Fingerprint('3'));
+        var snapshotIdentity = new DatasetSnapshotIdentity(Fingerprint(identityCharacter));
+        var observations = empty ? Array.Empty<PriceObservation>() : [new PriceObservation(from.AddDays(1), price)];
+        var coverage = new DatasetCoverage(from, to, observations.Length, observations.FirstOrDefault()?.Instant, observations.LastOrDefault()?.Instant);
+        var version = new DatasetVersion(snapshotIdentity);
+        var provenance = new DatasetProvenance(definition, definitionIdentity, researchIdentity, sourceIdentity, snapshotIdentity, version, DatasetSourceAuthority.AcceptedRelease11HistoricalObservations, observations.Length);
+        var lineage = new DatasetLineage(definitionIdentity, sourceIdentity, observations);
+        return new DatasetSnapshotCandidate(definition, definitionIdentity, researchIdentity, sourceIdentity, snapshotIdentity, version, observations, coverage, provenance, lineage);
+    }
+
+    private static string Fingerprint(char character) => new(character, 64);
+
+    private static void AssertSnapshotEquivalent(DatasetSnapshotCandidate expected, DatasetSnapshotCandidate actual)
+    {
+        Assert.Equal(expected.Definition, actual.Definition);
+        Assert.Equal(expected.DefinitionIdentity, actual.DefinitionIdentity);
+        Assert.Equal(expected.ResearchDatasetIdentity, actual.ResearchDatasetIdentity);
+        Assert.Equal(expected.SourceStateIdentity, actual.SourceStateIdentity);
+        Assert.Equal(expected.SnapshotIdentity, actual.SnapshotIdentity);
+        Assert.Equal(expected.Version, actual.Version);
+        Assert.Equal(expected.Coverage, actual.Coverage);
+        Assert.Equal(expected.Provenance, actual.Provenance);
+        Assert.Equal(expected.Observations, actual.Observations);
+        Assert.Equal(expected.Lineage.SourceObservations, actual.Lineage.SourceObservations);
+    }
+
+    private static long Count(SqliteConnectionFactory factory, string sql)
+    {
+        using var connection = factory.OpenConnection();
+        return Scalar<long>(connection, sql);
+    }
+
+    private static void Execute(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    private static T Scalar<T>(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return (T)command.ExecuteScalar()!;
+    }
+
+    private sealed class DatasetDatabase : IDisposable
+    {
+        private readonly string directory;
+
+        public DatasetDatabase(bool createDirectory = true)
+        {
+            directory = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"aiq-wp14-dataset-{Guid.NewGuid():N}");
+            if (createDirectory) Directory.CreateDirectory(directory);
+            Path = System.IO.Path.Combine(directory, "dataset.sqlite");
+            Configuration = new SqliteStorageConfiguration(Path);
+            Factory = new SqliteConnectionFactory(Configuration);
+        }
+
+        public string Path { get; }
+        public SqliteStorageConfiguration Configuration { get; }
+        public SqliteConnectionFactory Factory { get; }
+
+        public void Dispose()
+        {
+            SqliteConnection.ClearAllPools();
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/AIQuantTradingResearch.Infrastructure.Tests/SqlitePersistenceTests.cs
+++ b/tests/AIQuantTradingResearch.Infrastructure.Tests/SqlitePersistenceTests.cs
@@ -16,12 +16,12 @@ public sealed class SqlitePersistenceTests
         new(2024, 3, 10, 0, 0, 0, TimeSpan.FromHours(-4));
 
     [Fact]
-    public void OpenConnectionBootstrapsExactVersionOneStrictWithoutRowIdSchema()
+    public void OpenConnectionBootstrapsExactVersionTwoStrictWithoutRowIdSchema()
     {
         using var database = new TestDatabase();
         using var connection = database.Factory.OpenConnection();
 
-        Assert.Equal(1L, Scalar<long>(connection, "PRAGMA user_version;"));
+        Assert.Equal(2L, Scalar<long>(connection, "PRAGMA user_version;"));
         Assert.Equal(4L, Scalar<long>(connection, "SELECT COUNT(*) FROM pragma_table_info('historical_observations');"));
         using (var columns = connection.CreateCommand())
         {
@@ -64,13 +64,13 @@ public sealed class SqlitePersistenceTests
         using (var connection = new SqliteConnection($"Data Source={database.Path}"))
         {
             connection.Open();
-            Execute(connection, "PRAGMA user_version = 2;");
+            Execute(connection, "PRAGMA user_version = 3;");
         }
 
         Assert.Throws<InvalidOperationException>(() => database.Factory.OpenConnection());
         using var verification = new SqliteConnection($"Data Source={database.Path}");
         verification.Open();
-        Assert.Equal(2L, Scalar<long>(verification, "PRAGMA user_version;"));
+        Assert.Equal(3L, Scalar<long>(verification, "PRAGMA user_version;"));
     }
 
     [Fact]


### PR DESCRIPTION
# Pull Request

## Summary

Establishes the accepted Release 1.2 Research Dataset Foundation as one deterministic, review-ready integration candidate.

The release turns accepted Release 1.1 historical observations into immutable, reproducible, versioned, and cataloged research dataset snapshots while keeping Release 1.3 pipeline behavior out of scope.

---

## Motivation

Release 1.2 provides the smallest provider- and storage-independent Application model plus Infrastructure-owned SQLite persistence needed to materialize reusable research datasets reproducibly.

---

## Related Issue

Closes #136

---

## Type of Change

* [x] Feature
* [ ] Bug Fix
* [x] Documentation
* [ ] Refactoring
* [ ] Performance Improvement
* [ ] Security
* [x] Infrastructure
* [ ] DevOps
* [x] Research
* [x] Test

---

## Engineering Principles

* [x] Simplicity
* [x] Maintainability
* [x] Reliability
* [ ] Observability
* [x] Security
* [ ] Performance
* [x] Documentation
* [ ] Automation
* [x] Reproducibility
* [x] Continuous Improvement

---

## Validation

* [x] Build completed successfully
* [x] Unit tests passed
* [x] Integration tests passed
* [x] Manual testing completed
* [x] Documentation reviewed
* [x] Static analysis passed

Additional validation details:

- Deterministic dataset definition uses exact target and `[from, to)` selection.
- `aiq-dataset-identity-v1` uses canonical SHA-256 identities with immutable snapshot/version semantics and bounded provenance/lineage.
- Application contracts, materialization, catalog model, and integration remain provider/storage independent.
- SQLite schema v2 supports non-destructive v1-to-v2 evolution and preserves Release 1.1 historical observations.
- Snapshot/catalog persistence proves immutability, equivalence, conflicts, atomicity, typed lookup, fidelity, and failure mapping.
- DI and Worker execute one bounded offline path; repeated equivalent execution yields `EquivalentExisting`.
- Release tests: Domain 11/11, Application 60/60, Infrastructure 87/87, Architecture 13/13; total 171/171, skipped 0.
- Release canonical verification, Gitleaks, diff checks, documentation link audit, and fresh-checkout verification passed with zero build warnings/errors and zero database residue.

---

## Documentation

* [ ] No
* [x] README
* [x] Architecture
* [ ] Engineering Handbook
* [x] Roadmap
* [ ] Changelog
* [ ] Other

Documentation now distinguishes implemented Release 1.2 dataset behavior from future Release 1.3 pipeline orchestration.

---

## Dependencies

* [x] No
* [ ] Yes

No package, project, or project-reference changes were introduced.

---

## Architectural Impact

* [ ] No
* [x] Yes

* [ ] Engineering Decision Log updated
* [ ] ADR created or updated

The accepted dependency graph remains Domain -> none, Application -> Domain, Infrastructure -> Application, Worker -> Application and Infrastructure. SQLite remains confined to Infrastructure, and Release 1.3 scheduling, streaming, DAG, refresh-loop, and feature-pipeline behavior is explicitly excluded.

---

## Breaking Changes

* [x] No
* [ ] Yes

---

## Risks

The bounded Worker path requires valid external configuration. Dataset snapshots are intentionally immutable; contradictory same-identity evidence fails without mutation. Human review and explicit merge authorization remain required.

---

## Reviewer Checklist

* [ ] The implementation aligns with the Project Constitution.
* [ ] Code follows the Coding Standards.
* [ ] Documentation has been updated where appropriate.
* [ ] Tests are adequate for the change.
* [ ] No unnecessary dependencies were introduced.
* [ ] Architectural implications have been considered.
* [ ] The change is maintainable and well structured.

---

## Additional Notes

- Exact candidate: 71 files in commit `d30b3099d6d144c5d9e0d1a475f94a9d0f24b8da`.
- Fresh detached-checkout validation passed on that exact SHA.
- Auto-merge is not enabled; this PR must not be merged without explicit human authorization.
- No tag, GitHub Release, milestone closure, or Release 1.3 work is included.