### PR TITLE
Docs: Add remaining Release 1.9 prompt authorities

### DIFF
--- a/docs/roadmap/release-1.9/prompts/release-1.9-pr-240-review-checks-merge-authority-chat-bootstrap.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-pr-240-review-checks-merge-authority-chat-bootstrap.md
@@ -1,0 +1,22 @@
+Execute `release-1.9-pr-240-review-checks-merge-authority-codex-prompt.md` as the sole authority using GPT-5.6 Terra.
+
+Review PR #240 — `Docs: Showcase completed Release 1.9`.
+
+Require:
+- base `main`;
+- head `docs/release-1.9-showcase-readme`;
+- frozen head SHA `77fcbc59b01b12626e0b49c09a9fa30bc872116f`;
+- exactly one commit;
+- exactly two changed paths:
+  - `README.md`
+  - `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+Review the diff against the newly accepted README baseline: Current closed milestone 1.9/#58, Current accepted milestone 1.10/#59, accepted table formatting, Python badge, completed 1.8/1.9 descriptions, showcase link, and deterministic/replay governed .NET → JSON → Python/Streamlit semantics.
+
+Require all repository-required checks/reviews and mergeability gates to pass. Recheck `v1.9.0`, the published Release, milestone #58, milestone #59, and #233–#237 before merge.
+
+If every gate passes, merge PR #240 using repository policy. Do not bypass protection, rewrite the branch, delete the branch, push tags, or mutate Release/milestone/issues/Project state.
+
+After merge, perform idempotent verification of the merged PR, exact 2/2 payload, resulting `origin/main`, merged README/guide state, and unchanged Release 1.9 lifecycle state.
+
+End with the exact authority terminal marker.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-pr-240-review-checks-merge-authority-codex-prompt.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-pr-240-review-checks-merge-authority-codex-prompt.md
@@ -1,0 +1,423 @@
+# Release 1.9 — PR #240 Review / Checks / Merge Authority
+
+## Model
+Use **GPT-5.6 Terra**.
+
+## Purpose
+Review, validate, and—only if every gate passes—merge:
+
+**PR #240 — Docs: Showcase completed Release 1.9**
+
+This is a narrow documentation-only merge authority.
+
+The PR is expected to contain exactly two accepted paths:
+
+1. `README.md`
+2. `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+Expected PR head SHA:
+
+`77fcbc59b01b12626e0b49c09a9fa30bc872116f`
+
+Expected branch:
+
+`docs/release-1.9-showcase-readme`
+
+Expected base:
+
+`main`
+
+Expected commit count:
+
+`1`
+
+Do not merge if any of these frozen expectations drift materially.
+
+---
+
+# Release state to preserve
+
+Treat as binding:
+
+- Release 1.9 remains completed/accepted.
+- tag `v1.9.0` must remain anchored to:
+  `e4958721c9a581efbb2552134c00bc146c73f047`
+- GitHub Release `v1.9.0` remains published, non-draft, non-prerelease.
+- milestone #58 remains Closed, 0 open / 13 closed.
+- milestone #59 remains Open.
+- #233–#237 remain Closed / Done.
+- PR #238 remains merged.
+- PR #239 remains merged.
+- PR #240 is documentation-only.
+
+The merge of PR #240 must NOT retarget or recreate `v1.9.0`.
+
+---
+
+# Phase 0 — Read-only entry verification
+
+Before any mutation, read back PR #240 and record:
+
+- number;
+- title;
+- URL;
+- state;
+- draft status;
+- base branch;
+- head branch;
+- head SHA;
+- commit count;
+- changed-file count;
+- mergeability / merge state;
+- review decision if available;
+- required checks / status checks;
+- labels if relevant;
+- exact changed paths.
+
+Use paginated PR files API or equivalent authoritative source.
+
+Expected:
+
+- state = Open;
+- draft = false;
+- base = `main`;
+- head = `docs/release-1.9-showcase-readme`;
+- head SHA = `77fcbc59b01b12626e0b49c09a9fa30bc872116f`;
+- commit count = `1`;
+- changed-file count = `2`.
+
+If head SHA changed:
+BLOCK.
+
+If commit count is no longer 1:
+BLOCK unless the additional commit is proven to be an authorized no-op metadata artifact, which normally should not occur.
+
+---
+
+# Phase 1 — Frozen payload gate
+
+Require exact path set:
+
+```text
+README.md
+docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md
+```
+
+No third path is allowed.
+
+Use paginated files enumeration and compare exact set equality.
+
+Report:
+
+`RELEASE 1.9 PR #240 FROZEN PAYLOAD: PASS — 2/2 PATHS`
+
+If any unexpected path exists:
+BLOCK and do not merge.
+
+---
+
+# Phase 2 — Diff review
+
+Review the PR diff for both files.
+
+## README must preserve accepted baseline
+
+Require:
+
+- Current closed milestone = Release 1.9 / #58.
+- Current accepted milestone = Release 1.10 / #59.
+- 1.8 completed.
+- 1.9 completed.
+- 1.10 remains planned/accepted as next milestone.
+- truthful Python badge/tag preserved.
+- completed 1.8 and 1.9 descriptions preserved.
+- Release 1.9 showcase-guide front-door link valid.
+- accepted table-formatting changes preserved.
+- no stale current-state `1.9 Planned`.
+- no contradiction implying Release 1.9 is unfinished.
+
+## Showcase guide must preserve
+
+- deterministic simulated/replay disclosure;
+- governed .NET → canonical JSON → Python/Streamlit boundary;
+- no direct Streamlit → SQLite/provider bypass;
+- no live broker/provider overclaim;
+- valid repository-local instructions and links.
+
+## Technical scope
+
+Require:
+- no source code changes;
+- no test changes;
+- no package/dependency changes;
+- no schema changes;
+- no CI/config/runtime changes;
+- no secrets/local machine material.
+
+Technical impact must remain:
+
+`NONE — DOCUMENTATION-ONLY`
+
+If diff semantics drift from the accepted documentation baseline:
+BLOCK.
+
+---
+
+# Phase 3 — Checks / review gate
+
+Inspect all checks/statuses currently associated with PR #240.
+
+Require all repository-required checks to be successful or otherwise satisfy repository merge policy.
+
+If checks are:
+- pending: STOP/BLOCK;
+- failing: STOP/BLOCK;
+- cancelled/skipped where repository policy requires success: STOP/BLOCK;
+- absent and repository policy does not require checks: record that fact explicitly.
+
+Inspect review state.
+
+If branch protection requires approval:
+require it.
+
+If no approval is required:
+record that approval is not a merge gate.
+
+Do not self-approve unless explicitly authorized by repository policy and current account role, and even then this authority prefers read-only review inspection.
+
+---
+
+# Phase 4 — Mergeability gate
+
+Require PR #240 to be mergeable against current `main`.
+
+Verify:
+- no merge conflict;
+- no base-branch protection blocker;
+- no stale-head requirement;
+- no unresolved required conversation if enforced;
+- no unexpected required status.
+
+If branch must be updated/rebased before merge:
+BLOCK.
+Do not rewrite the branch under this authority.
+
+---
+
+# Phase 5 — Pre-merge release integrity check
+
+Immediately before merge, read-only verify:
+
+- `v1.9.0` still targets:
+  `e4958721c9a581efbb2552134c00bc146c73f047`
+- GitHub Release `v1.9.0` remains published;
+- milestone #58 remains Closed 0/13;
+- milestone #59 remains Open;
+- #233–#237 remain Closed / Done.
+
+If any release lifecycle drift is discovered:
+BLOCK.
+
+---
+
+# Phase 6 — Merge
+
+Only if every prior gate passes, merge PR #240.
+
+Use the repository's allowed/preferred merge method.
+
+Do not:
+- force merge;
+- bypass required checks;
+- bypass branch protection;
+- retarget base;
+- alter PR payload;
+- amend PR head;
+- push tags;
+- mutate Release/milestone/issues/Project state.
+
+Record:
+- merge method;
+- merge timestamp;
+- merge commit SHA;
+- PR final state.
+
+If the repository allows multiple methods and no explicit policy is discoverable, prefer the method consistent with recent repository practice.
+
+---
+
+# Phase 7 — Post-merge verification
+
+After merge, perform idempotent read-only verification.
+
+## Main branch
+
+Verify:
+- PR #240 state = Merged;
+- merged head SHA = expected frozen head;
+- current `origin/main` contains the merge;
+- record resulting `origin/main` SHA.
+
+## Payload
+
+Reconfirm PR #240 still reports exactly two changed paths:
+
+```text
+README.md
+docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md
+```
+
+## Release integrity
+
+Verify again:
+- `v1.9.0` still targets `e4958721c9a581efbb2552134c00bc146c73f047`;
+- GitHub Release unchanged and published;
+- milestone #58 remains Closed 0/13;
+- milestone #59 remains Open;
+- #233–#237 remain Closed / Done.
+
+## Documentation state
+
+Verify merged `main` now contains:
+- accepted README baseline;
+- Release 1.9 showcase guide;
+- valid README → guide link.
+
+No post-merge correction is authorized here.
+
+---
+
+# Branch deletion
+
+Branch deletion is NOT authorized under this authority.
+
+Leave:
+
+`docs/release-1.9-showcase-readme`
+
+unchanged after merge unless repository automation removes it automatically.
+
+If GitHub auto-deletes it:
+record that as platform behavior, not an explicit mutation requested by this authority.
+
+---
+
+# Allowed mutations
+
+## Repository content
+None.
+
+## Git
+None locally required by this authority.
+
+## GitHub
+Exactly one possible mutation:
+- merge PR #240.
+
+No other GitHub mutation is authorized.
+
+---
+
+# Acceptance criteria
+
+PASS only if:
+
+1. PR #240 head SHA exactly matches `77fcbc59b01b12626e0b49c09a9fa30bc872116f`;
+2. PR remains one commit before merge;
+3. exact frozen payload = 2/2 paths;
+4. documentation diff matches accepted baseline;
+5. technical impact = none;
+6. all required checks pass;
+7. all required review gates pass;
+8. PR is mergeable;
+9. release integrity passes before merge;
+10. merge succeeds without bypass;
+11. post-merge PR state = Merged;
+12. post-merge payload still exact 2/2;
+13. release tag/Release/milestones/issues remain unchanged.
+
+---
+
+# Required success report
+
+## PR identity
+- PR #240
+- title
+- URL
+- base/head
+- frozen head SHA
+- commit count
+
+## Frozen payload
+
+```text
+README.md
+docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md
+```
+
+`RELEASE 1.9 PR #240 FROZEN PAYLOAD: PASS — 2/2 PATHS`
+
+## Review/checks
+- required checks: PASS
+- review gate: PASS / NOT REQUIRED
+- mergeability: PASS
+
+## Merge
+- merge method
+- merge commit SHA
+- merged timestamp
+- final PR state
+
+## Post-merge
+- resulting `origin/main` SHA
+- README baseline present: PASS
+- showcase guide present: PASS
+- README → guide link: PASS
+
+## Release integrity
+- `v1.9.0` target unchanged
+- GitHub Release unchanged
+- milestone #58 Closed 0/13
+- milestone #59 Open
+- #233–#237 unchanged
+
+## Technical impact
+
+`NONE — DOCUMENTATION-ONLY`
+
+## Mutation markers
+
+`RELEASE 1.9 PR #240 REVIEW/CHECKS/MERGE REPOSITORY MUTATIONS: ZERO`
+
+`RELEASE 1.9 PR #240 REVIEW/CHECKS/MERGE GIT MUTATIONS: ZERO`
+
+`RELEASE 1.9 PR #240 REVIEW/CHECKS/MERGE GITHUB MUTATIONS: PR #240 MERGE ONLY`
+
+## Completion
+
+`RELEASE 1.9 PR #240 MERGED — DOCUMENTATION PAYLOAD ACCEPTED ON MAIN`
+
+Terminal:
+
+`RELEASE 1.9 PR #240 REVIEW/CHECKS/MERGE AUTHORITY COMPLETE`
+
+---
+
+# Required blocked report
+
+If any gate fails, report:
+
+- exact failing phase;
+- current PR state;
+- current head SHA;
+- check/review status;
+- changed-file count and path set;
+- mergeability state;
+- whether any mutation occurred;
+- minimum next authority needed.
+
+Terminal:
+
+`RELEASE 1.9 PR #240 REVIEW/CHECKS/MERGE AUTHORITY BLOCKED`
+
+Do not emit COMPLETE unless PR #240 is merged and all post-merge integrity checks pass.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-prompts-14-md-git-pr-creation-authority-chat-bootstrap.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-prompts-14-md-git-pr-creation-authority-chat-bootstrap.md
@@ -1,0 +1,21 @@
+Execute `release-1.9-prompts-14-md-git-pr-creation-authority-codex-prompt.md` as the sole authority using GPT-5.6 Terra.
+
+Discover the exact currently unmerged Markdown files under:
+
+`docs/roadmap/release-1.9/prompts`
+
+Expected count: exactly 14.
+
+Before any Git mutation, freeze and print the exact 14-path manifest. Every path must be under that folder and end in `.md`. If the count is not exactly 14, BLOCK.
+
+Review the 14 files only for scope/classification: they must be Release 1.9 prompt/authority/governance documentation. Do not rewrite them.
+
+Create/use branch `docs/release-1.9-prompts` from current `origin/main`, stage exactly the frozen 14 paths, create one commit `docs: add remaining Release 1.9 prompt authorities`, push only that branch, and create one PR targeting `main` titled `Docs: Add remaining Release 1.9 prompt authorities`.
+
+After PR creation, use authoritative paginated file enumeration to prove the PR contains exactly the frozen 14 Markdown paths and nothing else.
+
+Preserve `v1.9.0`, the published Release, milestone #58, milestone #59, #233–#237, PR #240, and unrelated user work.
+
+Do not force push, push tags, merge, delete branches, or mutate Release/milestone/issues/Project state.
+
+STOP after PR creation and 14/14 frozen-payload verification. End with the exact terminal marker.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-prompts-14-md-git-pr-creation-authority-codex-prompt.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-prompts-14-md-git-pr-creation-authority-codex-prompt.md
@@ -1,0 +1,400 @@
+# Release 1.9 — Prompts Folder 14-Markdown Git/PR Creation Authority
+
+## Model
+
+Use **GPT-5.6 Terra**.
+
+## Purpose
+
+Create one narrow documentation/governance pull request containing the **exact 14 currently unmerged Markdown files** under:
+
+`docs/roadmap/release-1.9/prompts`
+
+This authority must discover and freeze the exact 14-file manifest before any Git mutation, then package only those files into one commit and one PR targeting `main`.
+
+STOP before merge.
+
+## Scope boundary
+
+Only Markdown files under:
+
+`docs/roadmap/release-1.9/prompts`
+
+Expected unmerged count: `14`.
+
+No file outside this folder is authorized. No non-Markdown file is authorized.
+
+If the exact unmerged count is not 14, BLOCK before staging.
+
+## Current main baseline
+
+Expected current `origin/main`:
+
+`35ec644576275570aee522872c770e6c06e7879d`
+
+Verify at entry. If `origin/main` advanced, record it and continue only if the 14-file prompts-only scope remains provable and safe.
+
+Do not reset or overwrite user work.
+
+## Published state to preserve
+
+- Release 1.9 completed/accepted.
+- `v1.9.0` remains anchored to `e4958721c9a581efbb2552134c00bc146c73f047`.
+- GitHub Release `v1.9.0` remains published.
+- milestone #58 remains Closed 0/13.
+- milestone #59 remains Open.
+- #233–#237 remain Closed / Done.
+- PR #240 remains merged.
+
+## Phase 0 — Entry-state audit
+
+Record:
+
+- current branch;
+- current HEAD;
+- `origin/main`;
+- `git status --short`;
+- staged paths;
+- untracked paths;
+- all working-tree changes;
+- all files under `docs/roadmap/release-1.9/prompts`.
+
+Do not reset, clean, stash, or discard unrelated work.
+
+If unrelated staged changes cannot be safely isolated, BLOCK.
+
+## Phase 1 — Discover exact unmerged manifest
+
+Determine the exact Markdown files under `docs/roadmap/release-1.9/prompts` that are not represented on current `origin/main`.
+
+Include as applicable:
+
+- untracked Markdown files;
+- modified Markdown files;
+- locally committed-but-unmerged Markdown files.
+
+Use authoritative Git comparisons, not filename assumptions.
+
+Require:
+
+1. every path is under `docs/roadmap/release-1.9/prompts/`;
+2. every path ends in `.md`;
+3. exact count = `14`;
+4. none is already identical to `origin/main`;
+5. no out-of-folder dependency is required.
+
+Sort and print the manifest before staging.
+
+State:
+
+`RELEASE 1.9 PROMPTS PR CANDIDATE MANIFEST: 14/14 MD PATHS DISCOVERED`
+
+If count != 14, BLOCK.
+
+## Phase 2 — Content classification
+
+Read/review all 14 Markdown files.
+
+Require each to be Release 1.9 prompt/authority/governance documentation.
+
+Require:
+
+- no source/test/package/schema/config/runtime changes;
+- no secrets;
+- no binary files;
+- no generated runtime artifacts.
+
+Prompt artifacts may contain model assignments, governance authorities, validation instructions, Git/GitHub execution instructions, terminal markers, and historical Release 1.9 evidence.
+
+Do not rewrite prompt contents merely for style.
+
+If any file is not clearly in scope, BLOCK and identify it.
+
+## Phase 3 — Freeze manifest
+
+Freeze the exact 14-path set discovered above.
+
+No thirteenth path may enter afterward.
+
+All staging, commit, push, and PR verification must use exact set equality against this manifest.
+
+## Phase 4 — Branch
+
+Create or safely reuse:
+
+`docs/release-1.9-prompts`
+
+from current `origin/main`.
+
+If it already exists, inspect it and require no unrelated commits. Do not force-reset or overwrite user work.
+
+Record branch name and starting SHA.
+
+## Phase 5 — Staging
+
+Stage exactly the frozen 14 Markdown paths.
+
+After staging, verify:
+
+`git diff --cached --name-only`
+
+Require exact staged set = frozen manifest and staged count = 14.
+
+If any unexpected path appears, BLOCK unless it was staged by this authority and can be safely unstaged without disturbing user work.
+
+## Phase 6 — Commit
+
+Create exactly one commit.
+
+Preferred message:
+
+`docs: add remaining Release 1.9 prompt authorities`
+
+Verify:
+
+- one commit created;
+- changed-file count = 14;
+- every committed path is under `docs/roadmap/release-1.9/prompts/`;
+- every path ends in `.md`;
+- committed set = frozen manifest.
+
+Record commit SHA and parent SHA.
+
+## Phase 7 — Push
+
+Push only the dedicated branch.
+
+Allowed: set upstream.
+
+Forbidden:
+
+- force push;
+- push tags;
+- push `main`;
+- delete branches;
+- mutate unrelated refs.
+
+## Phase 8 — Pull request creation
+
+Create exactly one PR targeting `main`.
+
+Preferred title:
+
+`Docs: Add remaining Release 1.9 prompt authorities`
+
+Preferred body:
+
+```markdown
+## Summary
+
+Adds the remaining Release 1.9 prompt/authority Markdown artifacts under:
+
+`docs/roadmap/release-1.9/prompts`
+
+## Scope
+
+Documentation/governance only.
+
+- 14 Markdown files
+- no source code
+- no tests
+- no packages
+- no schema/config changes
+- no Release/tag/milestone/issue/Project lifecycle changes
+
+## Validation
+
+- exact 14-file manifest frozen before staging;
+- staged set = committed set = PR payload;
+- every path is under `docs/roadmap/release-1.9/prompts/`;
+- every path is Markdown;
+- Release 1.9 published state remains unchanged.
+
+## Technical impact
+
+None.
+```
+
+Do not add unrelated issue-closing keywords.
+
+## Phase 9 — PR frozen-payload verification
+
+Immediately read back:
+
+- PR number;
+- URL;
+- title;
+- state;
+- base/head;
+- head SHA;
+- commit count;
+- changed-file count;
+- exact changed paths.
+
+Use paginated PR files API or equivalent authoritative source.
+
+Require:
+
+- state = Open;
+- base = `main`;
+- commit count = `1`;
+- changed-file count = `14`;
+- exact PR path set = frozen manifest;
+- every path under `docs/roadmap/release-1.9/prompts/`;
+- every path ends in `.md`.
+
+State:
+
+`RELEASE 1.9 PROMPTS PR FROZEN PAYLOAD: PASS — 14/14 MD PATHS`
+
+If any mismatch exists, BLOCK and do not merge.
+
+## Phase 10 — Release integrity
+
+Read-only verify:
+
+- `v1.9.0` still targets `e4958721c9a581efbb2552134c00bc146c73f047`;
+- GitHub Release remains published;
+- milestone #58 remains Closed 0/13;
+- milestone #59 remains Open;
+- #233–#237 remain Closed / Done;
+- PR #240 remains merged.
+
+## Stop boundary
+
+STOP after successful PR creation + 14/14 frozen-payload verification.
+
+Not authorized:
+
+- PR merge;
+- review approval;
+- branch deletion;
+- tag mutation;
+- GitHub Release mutation;
+- milestone mutation;
+- issue mutation;
+- Project mutation.
+
+A separate review/checks/merge authority is required.
+
+## Allowed mutations
+
+### Repository content
+
+Zero new content edits. Package the existing 14 prompt Markdown files as-is.
+
+### Git
+
+Allowed:
+
+- dedicated branch creation/switch;
+- stage exact 14 frozen paths;
+- one commit;
+- branch push.
+
+### GitHub
+
+Allowed:
+
+- exactly one PR creation.
+
+## Acceptance criteria
+
+PASS only if:
+
+1. exactly 14 unmerged `.md` files are discovered;
+2. all 14 are under `docs/roadmap/release-1.9/prompts/`;
+3. all 14 are Release 1.9 prompt/governance artifacts;
+4. manifest frozen before staging;
+5. staged set = manifest;
+6. commit set = manifest;
+7. PR set = manifest;
+8. changed-file count = 14;
+9. no other path enters PR;
+10. Release lifecycle state unchanged;
+11. PR remains open/unmerged.
+
+## Required success report
+
+### Entry
+
+- current branch
+- current HEAD
+- `origin/main`
+
+### Frozen manifest
+
+Print all 14 paths in sorted order.
+
+`RELEASE 1.9 PROMPTS PR CANDIDATE MANIFEST: 14/14 MD PATHS DISCOVERED`
+
+### Branch
+
+- branch name
+- starting SHA
+
+### Commit
+
+- commit SHA
+- parent SHA
+- message
+- changed-file count = 14
+
+### Push
+
+- remote branch
+- pushed SHA
+
+### PR
+
+- PR number
+- URL
+- title
+- base/head
+- head SHA
+- state
+- commit count
+- changed-file count = 14
+
+### Frozen payload
+
+`RELEASE 1.9 PROMPTS PR FROZEN PAYLOAD: PASS — 14/14 MD PATHS`
+
+### Release integrity
+
+- `v1.9.0`: unchanged
+- GitHub Release: unchanged
+- milestone #58: Closed 0/13
+- milestone #59: Open
+- #233–#237: unchanged
+- PR #240: merged
+
+### Technical impact
+
+`NONE — PROMPT/GOVERNANCE DOCUMENTATION ONLY`
+
+### Mutation markers
+
+`RELEASE 1.9 PROMPTS PR AUTHORITY REPOSITORY CONTENT MUTATIONS: ZERO — EXISTING 14 MD FILES PACKAGED AS-IS`
+
+`RELEASE 1.9 PROMPTS PR AUTHORITY GIT MUTATIONS: BRANCH + 14-PATH STAGE + ONE COMMIT + PUSH ONLY`
+
+`RELEASE 1.9 PROMPTS PR AUTHORITY GITHUB MUTATIONS: ONE PR CREATED ONLY`
+
+### Next step
+
+`RELEASE 1.9 PROMPTS PR CREATED — SEPARATE REVIEW/CHECKS/MERGE AUTHORITY REQUIRED`
+
+Terminal:
+
+`RELEASE 1.9 PROMPTS 14-MD GIT/PR CREATION AUTHORITY COMPLETE`
+
+## Required blocked report
+
+Report exact discovered count, complete candidate manifest, unexpected/out-of-scope paths, staged conflicts, content-classification failures, mutations already performed, and PR state if already created.
+
+Terminal:
+
+`RELEASE 1.9 PROMPTS 14-MD GIT/PR CREATION AUTHORITY BLOCKED`
+
+Do not emit COMPLETE unless the PR is open/unmerged and frozen to exactly the discovered 14 Markdown paths.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-readme-completion-reconciliation-authority-chat-bootstrap.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-readme-completion-reconciliation-authority-chat-bootstrap.md
@@ -1,0 +1,9 @@
+Execute `release-1.9-readme-completion-reconciliation-authority-codex-prompt.md` as the sole authority using GPT-5.6 Terra.
+
+Modify only root `README.md` and preserve the accepted Release 1.9 showcase-guide link.
+
+Perform four narrow reconciliations: add the Python tag/badge; advance Current closed milestone and Current accepted milestone to 1.9 — Real-Time Financial Data Visualization; update Engineering capability so 1.8 and 1.9 are completed/accepted while 1.10 OpenTelemetry & Pipeline Observability remains planned; and add concise completed-milestone descriptions for 1.8 (#56) and 1.9 (#58).
+
+Sweep stale current-state `1.9 Planned` wording, validate touched links, and inspect the final diff. Preserve deterministic/replay and governed .NET → JSON → Python/Streamlit semantics.
+
+Do not stage, commit, branch, push, create a PR, merge, or mutate any GitHub lifecycle state. End with the exact terminal marker.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-readme-completion-reconciliation-authority-codex-prompt.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-readme-completion-reconciliation-authority-codex-prompt.md
@@ -1,0 +1,145 @@
+# Release 1.9 — README Completion-Reconciliation Authority
+
+## Model
+Use **GPT-5.6 Terra**.
+
+## Purpose
+Reconcile only the root `README.md` so the front door accurately reflects that **1.9 — Real-Time Financial Data Visualization is finished and accepted**, while preserving the already accepted Release 1.9 showcase-guide link.
+
+## Sole writable path
+`README.md`
+
+No other repository path may be modified.
+
+## State to preserve
+- Release 1.9 is completed/accepted.
+- `v1.9.0` remains the published release tag and must not be mutated.
+- milestone #58 remains Closed, 0 open / 13 closed.
+- 1.10 — OpenTelemetry & Pipeline Observability remains planned.
+- accepted showcase guide: `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`.
+
+## Entry gate
+Read the full README and `git status`. Preserve unrelated user work. Do not reset, clean, stash, stage, or discard anything.
+
+Identify the existing tag/badge area, Current closed milestone, Current accepted milestone, Engineering capability progression, 1.8/1.9 milestone descriptions, and every current-state occurrence of `1.9 Planned`.
+
+If safe hunk-level preservation is impossible, STOP.
+
+## Reconciliation 1 — Python tag
+Insert an appropriate Python tag/badge consistent with the README's existing visual convention.
+
+- Keep the change minimal.
+- Use truthful Python wording.
+- Do not add unrelated badges.
+- Do not claim a version unless the existing convention requires it and the repository proves it.
+
+## Reconciliation 2 — Current milestone status
+Update both:
+- `Current closed milestone`
+- `Current accepted milestone`
+
+to identify:
+
+**1.9 — Real-Time Financial Data Visualization**
+
+Remove stale current-state language presenting 1.9 as planned.
+
+## Reconciliation 3 — Engineering capability
+Reconcile the existing progression to current state:
+
+- **1.8 — Python & AI Engineering Foundation** — completed/accepted
+- **1.9 — Real-Time Financial Data Visualization** — completed/accepted
+- **1.10 — OpenTelemetry & Pipeline Observability** — planned
+
+Preserve the README's existing formatting and link style. Remove `Planned:` from 1.9; retain planned status for 1.10.
+
+## Reconciliation 4 — Finished milestone descriptions
+
+### 1.8 — Python & AI Engineering Foundation
+Add/preserve a concise description communicating:
+- governed Python engineering foundation;
+- deterministic .NET/Python interoperability boundary;
+- Python as an accepted first-class engineering capability;
+- no unsupported generic AI/ML overclaim.
+
+Milestone:
+`https://github.com/samuel-santos-engineer/AIQuantTradingResearch/milestone/56`
+
+### 1.9 — Real-Time Financial Data Visualization
+Add/preserve a concise description communicating:
+- independently owned Python/Streamlit presentation;
+- canonical .NET-produced JSON visualization handoff;
+- deterministic/replay behavior;
+- governed cross-language boundary;
+- no direct Streamlit → SQLite/provider bypass.
+
+Milestone:
+`https://github.com/samuel-santos-engineer/AIQuantTradingResearch/milestone/58`
+
+Do not label 1.9 as planned.
+
+## Consistency sweep
+Search the complete README and require:
+- no stale current-state `1.9 Planned: Real-Time Financial Data Visualization`;
+- 1.8 completed;
+- 1.9 completed/accepted;
+- 1.10 planned;
+- showcase-guide link preserved;
+- milestone numbering unchanged.
+
+Do not expand into unrelated README cleanup.
+
+## Link validation
+Validate touched links, including:
+- milestone #56;
+- milestone #58;
+- showcase guide;
+- any Python badge/tag target changed or introduced.
+
+## Validation
+Inspect the final diff. Require:
+- only intended README reconciliation hunks;
+- no executable/config changes;
+- no secrets/local material;
+- no unnecessary whole-file reformat/line-ending rewrite.
+
+No full technical test rerun is required.
+
+## Git/GitHub boundary
+Do NOT stage, commit, branch, push, create a PR, merge, or mutate tags, Releases, milestones, issues, or Project state.
+
+A later documentation PR authority will include the accepted showcase guide plus this reconciled README.
+
+## Acceptance criteria
+PASS only if:
+1. Python tag is present and consistent.
+2. Current closed milestone = 1.9.
+3. Current accepted milestone = 1.9.
+4. Engineering capability shows 1.8 completed, 1.9 completed, 1.10 planned.
+5. 1.8 has a concise finished-milestone description.
+6. 1.9 has a concise finished-milestone description.
+7. #56/#58 links are correct.
+8. stale current-state 1.9 Planned wording is gone.
+9. showcase-guide link remains.
+10. only README was modified by this authority.
+11. Git/GitHub mutations are zero.
+
+## Required success report
+Report each reconciliation and exact resulting milestone/progression text, link validation, stale-language sweep, and showcase-guide preservation.
+
+`RELEASE 1.9 README COMPLETION RECONCILIATION REPOSITORY MUTATIONS: README.md ONLY`
+
+`RELEASE 1.9 README COMPLETION RECONCILIATION GIT MUTATIONS: ZERO`
+
+`RELEASE 1.9 README COMPLETION RECONCILIATION GITHUB MUTATIONS: ZERO`
+
+`RELEASE 1.9 README COMPLETION RECONCILED — DOCUMENTATION PR AUTHORITY MAY PROCEED`
+
+Terminal:
+
+`RELEASE 1.9 README COMPLETION-RECONCILIATION AUTHORITY COMPLETE`
+
+## Blocked terminal
+If any conflict prevents safe reconciliation, report it precisely and end:
+
+`RELEASE 1.9 README COMPLETION-RECONCILIATION AUTHORITY BLOCKED`

--- a/docs/roadmap/release-1.9/prompts/release-1.9-readme-reviewed-drift-acceptance-reclassification-authority-chat-bootstrap.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-readme-reviewed-drift-acceptance-reclassification-authority-chat-bootstrap.md
@@ -1,0 +1,11 @@
+Execute `release-1.9-readme-reviewed-drift-acceptance-reclassification-authority-codex-prompt.md` as the sole authority using GPT-5.6 Luna.
+
+The prior documentation Git/PR authority blocked because `README.md` changed after acceptance. The user has now explicitly reviewed and accepted those changes.
+
+Treat the current README as a candidate new baseline. In particular, accept the intentional `Current accepted milestone → Release 1.10 / milestone #59` update and the reviewed table-formatting changes, provided the README remains internally coherent and Release 1.9 is still clearly completed.
+
+Preserve the Python badge, Release 1.8/1.9 completed descriptions, Release 1.9 showcase-guide link, deterministic/replay disclosure, and governed .NET → canonical JSON → Python/Streamlit boundary.
+
+Classify every README diff hunk. Prefer zero mutation and accept the README as-is. Do not stage, commit, branch, push, create a PR, merge, or mutate GitHub lifecycle state.
+
+On success, re-baseline the current README as the accepted state for a reissued narrow two-file documentation Git/PR authority. End with the exact terminal marker.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-readme-reviewed-drift-acceptance-reclassification-authority-codex-prompt.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-readme-reviewed-drift-acceptance-reclassification-authority-codex-prompt.md
@@ -1,0 +1,301 @@
+# Release 1.9 — README Reviewed Drift Acceptance / Reclassification Authority
+
+## Model
+Use **GPT-5.6 Luna**.
+
+## Purpose
+Accept and reclassify the current reviewed `README.md` state as the new canonical documentation baseline for the pending Release 1.9 showcase-guide documentation PR.
+
+The prior Git/PR creation authority blocked because the README had post-acceptance drift.
+
+The user has now explicitly reviewed and accepted that drift.
+
+This authority is therefore a **documentation acceptance/reclassification authority**, not an implementation authority and not a Git/GitHub mutation authority.
+
+---
+
+# Sole subject
+
+`README.md`
+
+The existing showcase guide remains separately accepted:
+
+`docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+Do not rewrite the guide under this authority.
+
+---
+
+# User-approved drift
+
+Treat the following current README changes as intentionally accepted, subject only to consistency/safety verification:
+
+1. `Current accepted milestone` now points to:
+   **Release 1.10 / milestone #59**
+   rather than Release 1.9 / #58.
+
+2. Existing table-formatting changes in the README are user-reviewed and should be accepted if they are documentation-only and semantically coherent.
+
+Do not automatically revert these items to the prior Release 1.9 wording.
+
+---
+
+# Interpretation rule
+
+The README may now legitimately distinguish:
+
+- **Current closed milestone** = Release 1.9 / milestone #58
+- **Current accepted milestone** = Release 1.10 / milestone #59
+
+if that is the user's intended current project state and the surrounding README content is internally consistent.
+
+Do not force both fields to 1.9 merely because the earlier reconciliation authority did so.
+
+This authority supersedes the previous accepted README snapshot for PR-packaging purposes.
+
+---
+
+# Entry-state verification
+
+Read:
+
+- complete current `README.md`;
+- `git status --short`;
+- current diff for `README.md`;
+- current milestone/progression sections;
+- current tag/badge area;
+- current Release 1.9 showcase-guide link;
+- current 1.8 / 1.9 / 1.10 milestone descriptions;
+- current table-formatting changes.
+
+Preserve all unrelated user work.
+
+Do not:
+- reset;
+- clean;
+- stash;
+- stage;
+- commit;
+- branch;
+- push.
+
+---
+
+# Classification task
+
+Classify every current README diff hunk into one of:
+
+- `ACCEPTED USER-REVIEWED DRIFT`
+- `PREVIOUSLY ACCEPTED RELEASE 1.9 DOCUMENTATION`
+- `UNRELATED / UNCLASSIFIED`
+- `BLOCKING`
+
+The goal is to determine whether the entire current README can be accepted as one documentation payload for the later PR.
+
+---
+
+# Required consistency checks
+
+## 1. Release 1.9 completion remains truthful
+
+Require that README still clearly communicates:
+
+- Release 1.9 — Real-Time Financial Data Visualization is completed;
+- milestone #58 is a finished milestone;
+- Release 1.9 showcase guide remains discoverable;
+- no stale wording incorrectly says 1.9 is planned.
+
+## 2. Release 1.10 current-state wording
+
+If `Current accepted milestone` is Release 1.10 / #59:
+
+- accept it as intentional;
+- verify surrounding wording does not simultaneously claim 1.10 is merely future/planned in a contradictory way;
+- reconcile only if necessary to remove direct internal contradiction.
+
+Do not infer implementation details beyond what README currently states.
+
+## 3. Engineering progression
+
+Ensure the README's 1.8 / 1.9 / 1.10 progression is internally coherent.
+
+Accept user-reviewed progression changes unless they directly contradict the current milestone labels.
+
+## 4. Python tag
+
+Preserve the accepted truthful Python badge/tag.
+
+## 5. Finished milestone descriptions
+
+Preserve the accepted concise descriptions for:
+- 1.8 — Python & AI Engineering Foundation;
+- 1.9 — Real-Time Financial Data Visualization.
+
+Do not weaken governed-boundary language.
+
+## 6. Showcase-guide link
+
+Require link to:
+
+`docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+to remain valid.
+
+## 7. Deterministic/replay architecture language
+
+Preserve:
+- .NET → canonical JSON → Python/Streamlit boundary;
+- simulated/replay disclosure;
+- no direct Streamlit → SQLite/provider bypass;
+- no live-provider/broker overclaim.
+
+## 8. Table-formatting changes
+
+Accept user-reviewed table-formatting changes if:
+
+- Markdown remains valid/readable;
+- no content was accidentally dropped;
+- no broken links introduced;
+- no unrelated semantic change is hidden in formatting-only edits.
+
+If table edits materially alter project meaning beyond the user's reviewed scope:
+classify precisely and BLOCK only that ambiguity.
+
+---
+
+# Link validation
+
+Validate touched/current README links relevant to this drift, including:
+
+- milestone #56;
+- milestone #58;
+- milestone #59 if present;
+- Release 1.9 showcase guide;
+- badge/tag destinations materially changed by the drift.
+
+---
+
+# Mutation boundary
+
+This authority may make **zero repository mutations** unless an extremely narrow correction is required solely to resolve a direct contradiction introduced by the reviewed drift.
+
+Default behavior is read-only acceptance/reclassification.
+
+If a correction is necessary:
+- modify only `README.md`;
+- report exact hunk;
+- do not expand scope.
+
+Preferred outcome:
+`README.md accepted as-is`.
+
+---
+
+# Re-baselining rule
+
+If all checks pass, declare the **current README contents** to be the new accepted README baseline for the pending documentation PR.
+
+This new baseline supersedes the prior frozen README snapshot used by the blocked Git/PR authority.
+
+The pending documentation PR payload remains exactly two paths:
+
+1. `README.md`
+2. `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+But future Git/PR packaging must compare against this newly accepted README state, not the earlier 1.9-only snapshot.
+
+---
+
+# Git/GitHub boundary
+
+Not authorized:
+
+- staging;
+- commit;
+- branch creation;
+- push;
+- PR creation;
+- merge;
+- tag mutation;
+- GitHub Release mutation;
+- milestone mutation;
+- issue/Project mutation.
+
+A new/reissued documentation Git/PR authority is required after this acceptance completes.
+
+---
+
+# Acceptance criteria
+
+PASS only if:
+
+1. current README drift is fully classified;
+2. user-reviewed 1.10 accepted-milestone update is accepted;
+3. user-reviewed table-formatting changes are safe;
+4. Release 1.9 remains clearly completed;
+5. Release 1.9 showcase guide link remains valid;
+6. 1.8/1.9 descriptions remain coherent;
+7. deterministic/replay architecture semantics remain intact;
+8. no broken relevant links;
+9. no unclassified material README drift remains;
+10. no Git/GitHub mutation occurred.
+
+---
+
+# Required success report
+
+## Drift classification
+
+Report:
+- `Current accepted milestone → Release 1.10 / #59`: ACCEPTED
+- table-formatting changes: ACCEPTED
+- previously accepted Release 1.9 README content: PRESERVED
+- unclassified drift: NONE
+
+## Current README state
+
+Record resulting:
+- Current closed milestone
+- Current accepted milestone
+- 1.8 / 1.9 / 1.10 progression
+- showcase-guide link status
+
+## Re-baseline marker
+
+`README CURRENT USER-REVIEWED STATE: ACCEPTED AS NEW DOCUMENTATION BASELINE`
+
+## PR payload marker
+
+`PENDING DOCUMENTATION PR PAYLOAD REMAINS EXACTLY TWO PATHS — README.md + RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+## Mutations
+
+`RELEASE 1.9 README REVIEWED DRIFT ACCEPTANCE REPOSITORY MUTATIONS: ZERO`
+
+`RELEASE 1.9 README REVIEWED DRIFT ACCEPTANCE GIT MUTATIONS: ZERO`
+
+`RELEASE 1.9 README REVIEWED DRIFT ACCEPTANCE GITHUB MUTATIONS: ZERO`
+
+## Next step
+
+`README DRIFT RECLASSIFIED — REISSUE NARROW DOCUMENTATION GIT/PR CREATION AUTHORITY AGAINST NEW BASELINE`
+
+Terminal:
+
+`RELEASE 1.9 README REVIEWED DRIFT ACCEPTANCE/RECLASSIFICATION AUTHORITY COMPLETE`
+
+---
+
+# Required blocked report
+
+Report:
+
+- exact unclassified or contradictory README hunk;
+- whether a minimal README-only correction is required;
+- whether the two-file PR payload can still be preserved.
+
+Terminal:
+
+`RELEASE 1.9 README REVIEWED DRIFT ACCEPTANCE/RECLASSIFICATION AUTHORITY BLOCKED`
+
+Do not emit COMPLETE unless the current reviewed README is fully accepted as the new baseline.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-showcase-guide-readme-front-door-documentation-authority-chat-bootstrap.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-showcase-guide-readme-front-door-documentation-authority-chat-bootstrap.md
@@ -1,0 +1,14 @@
+Execute `release-1.9-showcase-guide-readme-front-door-documentation-authority-codex-prompt.md` as the sole authority using GPT-5.6 Terra.
+
+Add the prepared showcase guide at:
+`docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+and add one concise front-door link from root `README.md`.
+
+Only those two paths are writable. Audit every runnable command and repository path against the current checkout, especially eng scripts, Worker project path, Python/Streamlit entry point, Python tests, and canonical interoperability/Python/signing docs. Correct stale documentation rather than implementation.
+
+Preserve the explicit deterministic simulated/replay-data disclosure and the governed .NET → canonical JSON handoff → Python/Streamlit architecture. No direct SQLite/provider bypass and no Streamlit Worker supervision.
+
+Validate local Markdown links and preserve unrelated dirty work. Do not stage, commit, branch, push, create a PR, merge, or mutate `v1.9.0`, its GitHub Release, milestone #58, issues, or Project state.
+
+On success require a separate narrow documentation PR creation authority. End with the exact terminal marker.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-showcase-guide-readme-front-door-documentation-authority-codex-prompt.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-showcase-guide-readme-front-door-documentation-authority-codex-prompt.md
@@ -1,0 +1,192 @@
+# Release 1.9 — Showcase Guide + README Front-Door Documentation Authority
+
+## Model
+Use **GPT-5.6 Terra**.
+
+## Purpose
+Add the prepared Release 1.9 showcase/local-run guide and one concise front-door reference from the root `README.md`.
+
+This is documentation-only. It must not reopen or mutate the published Release 1.9 lifecycle.
+
+## Published state to preserve
+- PR #238 merged.
+- PR #239 governance follow-up merged.
+- tag `v1.9.0` remains anchored to `e4958721c9a581efbb2552134c00bc146c73f047`.
+- GitHub Release `v1.9.0` remains published, non-draft, non-prerelease.
+- milestone #58 remains Closed, 0 open / 13 closed.
+- #233–#237 remain Closed / Done.
+- accepted Release 1.9 baseline: .NET 339/339, Python 17/17, schema v4, Streamlit 1.61.1, `pip check` clean.
+
+## Source and destination
+Use the prepared artifact:
+`RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+Destination:
+`docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+If the artifact is not directly mounted, use its supplied content as canonical. Do not invent a materially different guide.
+
+## Exact writable paths
+Only:
+1. `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+2. `README.md`
+
+No other path may change.
+
+## Entry-state gate
+Read current branch, HEAD, `origin/main`, `git status`, staged paths, current README, `docs/guides/`, and the canonical interoperability/Python/signing documentation.
+
+Preserve all unrelated dirty work. Do not reset, clean, stash, or discard it.
+
+If either writable path contains unrelated user edits that cannot be safely preserved, STOP.
+
+## Guide requirements
+The guide must substantially explain:
+- why Release 1.9 matters;
+- .NET → atomic canonical JSON handoff → Python/Streamlit architecture;
+- deterministic simulated/replay-data disclosure;
+- prerequisites and environment setup;
+- build/test verification;
+- Worker producer and Streamlit consumer startup;
+- Ready/WarmUp/Empty/Failed semantics;
+- refresh/restart/lifecycle behavior;
+- Windows atomic-replacement robustness;
+- Smart App Control local-signing boundary;
+- troubleshooting;
+- accepted Release 1.9 quality baseline;
+- a useful technical showcase/demo narrative;
+- explicit non-claims: no live broker/provider connectivity.
+
+Preserve:
+- no Streamlit → SQLite bypass;
+- no Streamlit → market-provider bypass;
+- no Streamlit supervision of Worker;
+- governed JSON handoff ownership.
+
+## Command/path truthfulness audit
+Before acceptance, verify every runnable command and referenced repository path against the current checkout, especially:
+- `eng` scripts;
+- Worker `.csproj`;
+- Python presentation entry point;
+- Python test invocation;
+- Streamlit command;
+- interoperability guide;
+- Python developer guide;
+- Smart App Control signing guide.
+
+If the prepared guide is stale, correct the guide only. Never modify implementation to make documentation true.
+
+Do not present illustrative commands as canonical commands unless verified.
+
+## README front door
+Modify root `README.md` minimally.
+
+Add one discoverable link in the most appropriate existing navigation/getting-started/documentation/release section.
+
+Preferred anchor text:
+`Release 1.9 showcase and local run guide`
+
+Target:
+`docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+A concise description may say it covers running the .NET → JSON handoff → Streamlit demonstration, architecture, and troubleshooting.
+
+Avoid a redundant large README section.
+
+## Link and consistency validation
+Verify:
+- README link resolves;
+- new guide local links resolve;
+- referenced repository files exist;
+- repository navigation uses relative links;
+- schema language is v4;
+- Streamlit 1.61.1 is correct where stated;
+- 339/339 and 17/17 are described as Release 1.9 acceptance evidence;
+- simulated/replay disclosure is explicit;
+- no live connectivity overclaim exists.
+
+Cross-check with:
+- `README.md`
+- `docs/architecture/design/DOTNET_PYTHON_INTEROPERABILITY.md`
+- `docs/guides/PYTHON_DEVELOPER_ENVIRONMENT.md`
+- `docs/development/WINDOWS_SMART_APP_CONTROL_LOCAL_SIGNING.md`
+- `docs/project/ROADMAP.md`
+
+## Validation
+At minimum:
+1. inspect diff for both authorized paths;
+2. validate Markdown links;
+3. validate commands/paths;
+4. verify no secrets/local signing material;
+5. verify only the two authorized paths changed by this authority.
+
+Run an existing cheap docs/lint check if available.
+
+This is documentation-only; do not rerun the full 339/339 + 17/17 matrix unless repository policy explicitly requires it.
+
+## Git/GitHub boundary
+Repository documentation edits are authorized.
+
+Not authorized:
+- staging;
+- commit;
+- branch;
+- push;
+- PR;
+- merge;
+- tag;
+- GitHub Release;
+- milestone;
+- issue/Project mutation.
+
+A separate PR authority is required.
+
+## Forbidden repository paths
+Do not modify:
+- `src/`
+- `tests/`
+- `python/`
+- project/package/dependency files;
+- schema/migrations;
+- signing scripts/config;
+- `Directory.Build.local.props`;
+- roadmap authority artifacts;
+- workflows;
+- generated/runtime/test outputs.
+
+## Acceptance criteria
+PASS only if:
+1. guide exists at exact destination;
+2. commands/paths are truthful;
+3. architecture matches Release 1.9;
+4. simulated/replay disclosure is explicit;
+5. README has one useful front-door reference;
+6. README link resolves;
+7. guide links resolve;
+8. no executable/config behavior changed;
+9. only two authorized documentation paths were changed;
+10. published Release 1.9 lifecycle state was not mutated.
+
+## Required success report
+Report exact files changed, command/path audit, link audit, architecture/disclosure consistency, README section used, and:
+
+`RELEASE 1.9 SHOWCASE GUIDE AUTHORITY REPOSITORY MUTATIONS: TWO DOCUMENTATION PATHS ONLY — GUIDE + README`
+
+`RELEASE 1.9 SHOWCASE GUIDE AUTHORITY GIT MUTATIONS: ZERO`
+
+`RELEASE 1.9 SHOWCASE GUIDE AUTHORITY GITHUB MUTATIONS: ZERO`
+
+`RELEASE 1.9 SHOWCASE GUIDE ACCEPTED — SEPARATE NARROW DOCUMENTATION PR CREATION AUTHORITY REQUIRED`
+
+Terminal:
+
+`RELEASE 1.9 SHOWCASE GUIDE + README FRONT-DOOR DOCUMENTATION AUTHORITY COMPLETE`
+
+## Required blocked report
+State the exact conflicting path/content, unavailable source, command/link inconsistency, mutations already made, and minimum reconciliation needed.
+
+Terminal:
+
+`RELEASE 1.9 SHOWCASE GUIDE + README FRONT-DOOR DOCUMENTATION AUTHORITY BLOCKED`
+
+Do not emit COMPLETE unless both guide and README reference are validated.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-showcase-readme-documentation-git-pr-creation-authority-chat-bootstrap.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-showcase-readme-documentation-git-pr-creation-authority-chat-bootstrap.md
@@ -1,0 +1,14 @@
+Execute `release-1.9-showcase-readme-documentation-git-pr-creation-authority-codex-prompt.md` as the sole authority using GPT-5.6 Terra.
+
+Package exactly these two already accepted documentation paths:
+
+- `README.md`
+- `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+Create/use branch `docs/release-1.9-showcase-readme` from current `origin/main`, stage exactly those two paths, create one commit with preferred message `docs: showcase completed Release 1.9`, push only that branch, and create one PR targeting `main` with preferred title `Docs: Showcase completed Release 1.9`.
+
+After PR creation, read back the PR and prove the frozen payload is exactly 2/2 paths using the paginated files API or equivalent authoritative source.
+
+Preserve `v1.9.0`, the published GitHub Release, milestone #58, #233–#237, and unrelated user work. Do not force push, push tags, merge, delete branches, or mutate milestone/issues/Project/Release state.
+
+STOP after PR creation and frozen-payload verification. End with the exact terminal marker.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-showcase-readme-documentation-git-pr-creation-authority-codex-prompt.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-showcase-readme-documentation-git-pr-creation-authority-codex-prompt.md
@@ -1,0 +1,261 @@
+# Release 1.9 — Showcase Guide + README Documentation Git/PR Creation Authority
+
+## Model
+Use **GPT-5.6 Terra**.
+
+## Purpose
+Package the already accepted Release 1.9 documentation-only payload into one narrow Git commit and one GitHub pull request, then STOP before merge.
+
+## Exact authorized payload
+Only:
+1. `README.md`
+2. `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+No other path may be staged, committed, pushed as content, or included in the PR.
+
+## Published state to preserve
+- Release 1.9 is completed/accepted.
+- PR #238 merged.
+- PR #239 governance follow-up merged.
+- tag `v1.9.0` remains anchored to `e4958721c9a581efbb2552134c00bc146c73f047`.
+- GitHub Release `v1.9.0` remains published.
+- milestone #58 remains Closed, 0 open / 13 closed.
+- #233–#237 remain Closed / Done.
+- accepted baseline remains .NET 339/339, Python 17/17, schema v4, Streamlit 1.61.1.
+
+## Phase 0 — Entry-state verification
+Record current branch, HEAD, `origin/main`, `git status --short`, staged paths, untracked paths, and diffs for the two authorized files.
+
+Preserve unrelated user work exactly. Do not reset, clean, stash, or discard.
+
+If unrelated staged changes cannot be safely isolated, BLOCK.
+
+## Phase 1 — Accepted-diff verification
+Verify the current accepted content is intact.
+
+README must still contain:
+- Python badge/tag;
+- Current closed milestone = Release 1.9 / #58;
+- Current accepted milestone = Release 1.9 / #58;
+- 1.8 completed;
+- 1.9 completed/accepted;
+- 1.10 planned;
+- concise completed descriptions for 1.8 and 1.9;
+- no stale current-state `1.9 Planned`;
+- showcase-guide front-door link.
+
+Guide must remain at:
+`docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+and preserve:
+- deterministic simulated/replay disclosure;
+- governed .NET → canonical JSON → Python/Streamlit boundary;
+- no direct Streamlit → SQLite/provider bypass;
+- no live broker/provider overclaim.
+
+If material drift exists, BLOCK rather than silently rewriting.
+
+## Phase 2 — Branch
+Create or safely reuse:
+
+`docs/release-1.9-showcase-readme`
+
+from current `origin/main`.
+
+Do not overwrite unrelated commits.
+
+Record branch name and starting SHA.
+
+## Phase 3 — Staging
+Stage exactly:
+
+- `README.md`
+- `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+Verify with `git diff --cached --name-only`.
+
+Expected exact set:
+
+```text
+README.md
+docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md
+```
+
+If any third path is staged, BLOCK unless it was staged by this authority and can be safely unstaged without disturbing user work.
+
+## Phase 4 — Commit
+Create exactly one commit:
+
+`docs: showcase completed Release 1.9`
+
+Verify:
+- one commit created by this authority;
+- changed-file count = 2;
+- exact path set = the two authorized paths.
+
+## Phase 5 — Push
+Push only the dedicated documentation branch.
+
+Allowed:
+- set upstream if needed.
+
+Forbidden:
+- force push;
+- pushing tags;
+- pushing `main`;
+- deleting branches;
+- mutating unrelated refs.
+
+## Phase 6 — Pull request creation
+Create exactly one PR targeting `main`.
+
+Preferred title:
+
+`Docs: Showcase completed Release 1.9`
+
+Preferred body:
+
+```markdown
+## Summary
+
+- adds the Release 1.9 showcase and local-run guide;
+- updates the front-door README to reflect Release 1.9 as completed/accepted;
+- adds Python to the visible engineering stack;
+- advances the current closed/accepted milestone to Release 1.9;
+- preserves Release 1.10 as the next planned milestone.
+
+## Scope
+
+Documentation only.
+
+Changed paths:
+- `README.md`
+- `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+## Validation
+
+- repository paths and guide links validated;
+- milestone links #56 and #58 validated;
+- stale current-state `1.9 Planned` wording removed;
+- deterministic/replay and governed .NET → JSON → Python/Streamlit semantics preserved;
+- no executable/configuration changes;
+- no GitHub Release/tag/milestone/issue/Project lifecycle changes.
+
+## Technical impact
+
+None. Existing Release 1.9 acceptance evidence remains unchanged.
+```
+
+Do not add unrelated issue-closing keywords.
+
+## Phase 7 — Frozen-payload verification
+Immediately read back the PR and record:
+- PR number;
+- URL;
+- title;
+- state;
+- base/head;
+- head SHA;
+- commit count;
+- changed-file count;
+- exact changed paths.
+
+Use paginated PR files API or equivalent authoritative source.
+
+Require exact payload:
+
+```text
+README.md
+docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md
+```
+
+Require changed-file count = `2`.
+
+If anything differs, BLOCK and do not merge.
+
+## Phase 8 — Release integrity
+Read-only verify:
+- `v1.9.0` still resolves to `e4958721c9a581efbb2552134c00bc146c73f047`;
+- GitHub Release remains published;
+- milestone #58 remains Closed 0/13;
+- #233–#237 remain Closed / Done.
+
+## Phase 9 — Stop boundary
+STOP after successful PR creation + frozen-payload verification.
+
+Not authorized:
+- PR merge;
+- approval;
+- merge queue mutation;
+- branch deletion;
+- tag mutation;
+- GitHub Release mutation;
+- milestone mutation;
+- issue/Project mutation.
+
+A separate review/checks/merge authority is required.
+
+## Required success report
+
+### Branch
+- name
+- starting SHA
+
+### Commit
+- commit SHA
+- message
+- exact two-file manifest
+
+### Push
+- remote branch
+- pushed SHA
+
+### PR
+- number
+- URL
+- title
+- base/head
+- head SHA
+- state
+- commit count
+- changed-file count
+
+### Frozen payload
+
+```text
+README.md
+docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md
+```
+
+`RELEASE 1.9 DOCUMENTATION PR FROZEN PAYLOAD: PASS — 2/2 PATHS`
+
+### Release integrity
+- `v1.9.0`: unchanged
+- GitHub Release: unchanged
+- milestone #58: Closed 0/13
+- #233–#237: unchanged
+
+### Technical impact
+`NONE — DOCUMENTATION-ONLY`
+
+### Mutation markers
+`RELEASE 1.9 DOCUMENTATION PR AUTHORITY REPOSITORY CONTENT MUTATIONS: ZERO BEYOND PRE-ACCEPTED README + GUIDE`
+
+`RELEASE 1.9 DOCUMENTATION PR AUTHORITY GIT MUTATIONS: BRANCH + TWO-PATH STAGE + ONE COMMIT + PUSH ONLY`
+
+`RELEASE 1.9 DOCUMENTATION PR AUTHORITY GITHUB MUTATIONS: ONE PR CREATED ONLY`
+
+`RELEASE 1.9 DOCUMENTATION PR CREATED — SEPARATE REVIEW/CHECKS/MERGE AUTHORITY REQUIRED`
+
+Terminal:
+
+`RELEASE 1.9 SHOWCASE + README DOCUMENTATION GIT/PR CREATION AUTHORITY COMPLETE`
+
+## Required blocked report
+Report exact blocker, current branch/HEAD, staged/untracked conflicts, payload mismatch, mutations already performed, PR state if created, and minimum reconciliation needed.
+
+Terminal:
+
+`RELEASE 1.9 SHOWCASE + README DOCUMENTATION GIT/PR CREATION AUTHORITY BLOCKED`
+
+Do not emit COMPLETE unless the PR is open/unmerged and frozen to exactly the two accepted documentation paths.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-showcase-readme-documentation-git-pr-creation-authority-v2-chat-bootstrap.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-showcase-readme-documentation-git-pr-creation-authority-v2-chat-bootstrap.md
@@ -1,0 +1,19 @@
+Execute `release-1.9-showcase-readme-documentation-git-pr-creation-authority-v2-codex-prompt.md` as the sole authority using GPT-5.6 Terra.
+
+Use the newly accepted current README baseline:
+- Current closed milestone = Release 1.9 / #58.
+- Current accepted milestone = Release 1.10 / #59.
+- reviewed table-formatting changes accepted.
+- Python badge, completed 1.8/1.9 descriptions, showcase-guide link, deterministic/replay disclosure, and governed .NET → canonical JSON → Python/Streamlit boundary remain accepted.
+
+Package exactly:
+- `README.md`
+- `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+Create/use `docs/release-1.9-showcase-readme` from current `origin/main`, stage exactly those two paths, create one commit `docs: showcase completed Release 1.9`, push only that branch, and create one PR targeting `main` titled `Docs: Showcase completed Release 1.9`.
+
+After PR creation, read back the PR and prove the frozen payload is exactly 2/2 paths using the paginated files API or equivalent authoritative source.
+
+Preserve `v1.9.0`, the published GitHub Release, milestone #58, milestone #59, #233–#237, and unrelated user work. Do not force push, push tags, merge, delete branches, or mutate milestone/issues/Project/Release state.
+
+STOP after PR creation and frozen-payload verification. End with the exact V2 terminal marker.

--- a/docs/roadmap/release-1.9/prompts/release-1.9-showcase-readme-documentation-git-pr-creation-authority-v2-codex-prompt.md
+++ b/docs/roadmap/release-1.9/prompts/release-1.9-showcase-readme-documentation-git-pr-creation-authority-v2-codex-prompt.md
@@ -1,0 +1,207 @@
+# Release 1.9 — Showcase Guide + README Documentation Git/PR Creation Authority (Reissued)
+
+## Model
+Use **GPT-5.6 Terra**.
+
+## Purpose
+Package the already accepted Release 1.9 documentation-only payload into one narrow Git commit and one GitHub pull request.
+
+This is the reissued authority after README drift acceptance/reclassification. The current user-reviewed `README.md` is now the canonical accepted baseline for PR packaging.
+
+This authority may create/use a dedicated documentation branch, stage exactly the two accepted paths, create one commit, push that branch, create one PR targeting `main`, and verify the frozen PR payload. STOP before merge.
+
+## Canonical accepted README baseline
+The current `README.md` is accepted as-is, including:
+- Current closed milestone = Release 1.9 / #58.
+- Current accepted milestone = Release 1.10 / #59.
+- 1.8 completed.
+- 1.9 completed.
+- 1.10 planned/accepted as next milestone.
+- Python badge/tag present.
+- completed 1.8 and 1.9 descriptions present.
+- Release 1.9 showcase-guide front-door link present.
+- deterministic/replay disclosure preserved.
+- governed .NET → canonical JSON → Python/Streamlit boundary preserved.
+- no direct Streamlit → SQLite/provider bypass.
+- reviewed table-formatting changes accepted.
+
+Do NOT compare README against the older snapshot where Current accepted milestone was 1.9. Do NOT revert the accepted 1.10 / #59 state.
+
+## Exact authorized payload
+Only:
+1. `README.md`
+2. `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+No other path may be staged, committed, or included in the PR.
+
+## Published state to preserve
+- Release 1.9 completed/accepted.
+- PR #238 merged.
+- PR #239 governance follow-up merged.
+- `v1.9.0` remains anchored to `e4958721c9a581efbb2552134c00bc146c73f047`.
+- GitHub Release `v1.9.0` remains published.
+- milestone #58 remains Closed 0/13.
+- milestone #59 remains Open.
+- #233–#237 remain Closed / Done.
+- accepted baseline remains .NET 339/339, Python 17/17, schema v4, Streamlit 1.61.1.
+
+## Phase 0 — Entry-state verification
+Record current branch, HEAD, `origin/main`, `git status --short`, staged paths, untracked paths, working-tree diff for the two authorized files, and unrelated dirty work.
+
+Preserve unrelated user work. Do not reset, clean, stash, or discard. If unrelated staged changes cannot be safely isolated, BLOCK.
+
+## Phase 1 — Accepted-content gate
+README must match the newly accepted baseline above. In particular, `Current accepted milestone = Release 1.10 / #59` is expected and must not be treated as drift.
+
+Showcase guide must remain at:
+`docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+and preserve simulated/replay disclosure, governed .NET → JSON → Python/Streamlit flow, no direct SQLite/provider bypass, and no live broker/provider overclaim.
+
+If either file has new material drift after this re-baseline, BLOCK rather than rewriting.
+
+## Phase 2 — Branch
+Create or safely reuse:
+`docs/release-1.9-showcase-readme`
+
+The branch must be based on current `origin/main`. If it exists, inspect history and require no unrelated commits. Do not force-reset user work.
+
+Record branch name and starting SHA.
+
+## Phase 3 — Staging
+Stage exactly:
+- `README.md`
+- `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+Verify with:
+`git diff --cached --name-only`
+
+Expected exact set:
+
+```text
+README.md
+docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md
+```
+
+If any third path is staged, BLOCK unless it was staged by this authority and can be safely unstaged without disturbing user work.
+
+## Phase 4 — Commit
+Create exactly one commit:
+
+`docs: showcase completed Release 1.9`
+
+Verify commit SHA, parent SHA, message, changed-file count = 2, and exact committed path set = the two authorized paths.
+
+## Phase 5 — Push
+Push only the dedicated documentation branch. Set upstream if needed.
+
+Forbidden: force push, pushing tags, pushing `main`, deleting branches, mutating unrelated refs.
+
+## Phase 6 — Pull request creation
+Create exactly one PR targeting `main`.
+
+Preferred title:
+`Docs: Showcase completed Release 1.9`
+
+Preferred body:
+
+```markdown
+## Summary
+
+- adds the Release 1.9 showcase and local-run guide;
+- updates the front-door README to reflect Release 1.9 as completed;
+- preserves Release 1.10 / milestone #59 as the current accepted next milestone;
+- keeps Python visible in the engineering stack;
+- preserves the reviewed README table-formatting changes.
+
+## Scope
+
+Documentation only.
+
+Changed paths:
+- `README.md`
+- `docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md`
+
+## Validation
+
+- current README user-reviewed baseline accepted;
+- milestone links #56, #58, and #59 validated as applicable;
+- Release 1.9 remains completed;
+- Release 1.10 / #59 remains current accepted/next milestone;
+- deterministic/replay and governed .NET → JSON → Python/Streamlit semantics preserved;
+- no executable/configuration changes;
+- no tag/Release/milestone/issue/Project lifecycle changes.
+
+## Technical impact
+
+None. Existing Release 1.9 acceptance evidence remains unchanged.
+```
+
+Do not add unrelated issue-closing keywords.
+
+## Phase 7 — Frozen-payload verification
+Immediately read back PR number, URL, title, state, base/head, head SHA, commit count, changed-file count, and exact changed paths.
+
+Use paginated PR files API or equivalent authoritative source.
+
+Require changed-file count = `2` and exact set:
+
+```text
+README.md
+docs/guides/RELEASE_1.9_SHOWCASE_AND_LOCAL_RUN_GUIDE.md
+```
+
+If payload differs, BLOCK. Do not merge.
+
+## Phase 8 — Release integrity
+Read-only verify:
+- `v1.9.0` still resolves to `e4958721c9a581efbb2552134c00bc146c73f047`;
+- GitHub Release remains published;
+- milestone #58 remains Closed 0/13;
+- milestone #59 remains Open;
+- #233–#237 remain Closed / Done.
+
+## Phase 9 — Stop boundary
+STOP after successful PR creation + frozen-payload verification.
+
+Not authorized:
+- merge;
+- approval;
+- merge queue mutation;
+- branch deletion;
+- tag mutation;
+- GitHub Release mutation;
+- milestone mutation;
+- issue/Project mutation.
+
+A separate review/checks/merge authority is required.
+
+## Required success report
+Report baseline gate, branch, commit, push, PR metadata, and exact frozen payload.
+
+State:
+
+`RELEASE 1.9 DOCUMENTATION PR FROZEN PAYLOAD: PASS — 2/2 PATHS`
+
+`NONE — DOCUMENTATION-ONLY`
+
+`RELEASE 1.9 DOCUMENTATION PR AUTHORITY REPOSITORY CONTENT MUTATIONS: ZERO BEYOND PRE-ACCEPTED README + GUIDE`
+
+`RELEASE 1.9 DOCUMENTATION PR AUTHORITY GIT MUTATIONS: BRANCH + TWO-PATH STAGE + ONE COMMIT + PUSH ONLY`
+
+`RELEASE 1.9 DOCUMENTATION PR AUTHORITY GITHUB MUTATIONS: ONE PR CREATED ONLY`
+
+`RELEASE 1.9 DOCUMENTATION PR CREATED — SEPARATE REVIEW/CHECKS/MERGE AUTHORITY REQUIRED`
+
+Terminal:
+
+`RELEASE 1.9 SHOWCASE + README DOCUMENTATION GIT/PR CREATION AUTHORITY V2 COMPLETE`
+
+## Required blocked report
+Report exact blocking state, current branch/HEAD, staged/untracked conflicts, any new post-rebaseline README drift, payload mismatch, mutations already performed, PR state if created, and minimum reconciliation needed.
+
+Terminal:
+
+`RELEASE 1.9 SHOWCASE + README DOCUMENTATION GIT/PR CREATION AUTHORITY V2 BLOCKED`
+
+Do not emit COMPLETE unless the PR is open/unmerged and frozen to exactly the two accepted documentation paths.


### PR DESCRIPTION
## Summary

Adds the remaining Release 1.9 prompt/authority Markdown artifacts under:

`docs/roadmap/release-1.9/prompts`

## Scope

Documentation/governance only.

- 14 Markdown files
- no source code
- no tests
- no packages
- no schema/config changes
- no Release/tag/milestone/issue/Project lifecycle changes

## Validation

- exact 14-file manifest frozen before staging;
- staged set = committed set = PR payload;
- every path is under `docs/roadmap/release-1.9/prompts/`;
- every path is Markdown;
- Release 1.9 published state remains unchanged.

## Technical impact

None.