### PR TITLE
Docs: publish Initiative-1.11 Azure F1 feasibility governance

### DIFF
--- a/docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_EXECUTION_PLAN.md
+++ b/docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_EXECUTION_PLAN.md
@@ -1,0 +1,79 @@
+# Azure F1 Feasibility Execution Plan
+
+## Authority and ordering
+
+Exactly six sequential work packages are defined. No predecessor may be bypassed:
+
+`WP01 → WP02 → WP03 → WP04 → WP05 → WP06`
+
+Each represented issue, if later authorized, must remain open until its exact acceptance marker passes; then it is closed and its Project status is set to Done, unless a later authority explicitly defers that lifecycle.
+
+## Work packages
+
+### WP01 — Feasibility Contract, Evidence Matrix & Resource Plan
+
+Model: GPT-5.6 Luna. Freeze the matrix, resource inventory, security/redaction, strict-zero accounting, cleanup, allowed probe paths, and PASS/NOT FEASIBLE rules. No Azure resources.
+
+Acceptance: `AZURE F1 WP01 — FEASIBILITY CONTRACT & RESOURCE PLAN: PASS`
+
+### WP01 completion record
+
+`AZURE F1 WP01 — FEASIBILITY CONTRACT & RESOURCE PLAN: PASS`
+
+`AZURE F1 WP01 LIFECYCLE: ARTIFACT-GOVERNED — NO GITHUB ISSUE BY DESIGN`
+
+This is the completed WP01 planning record. It records contract and resource-plan readiness only; it does not claim empirical Azure feasibility, create Azure resources, or authorize WP02 execution.
+
+### WP02 — Minimal Docker + App Service F1 Execution Probe
+
+Model: GPT-5.6 Terra. Using only an isolated probe, prove actual F1 availability, custom Linux Docker startup, public HTTPS where available, `/home` enablement/writability, restart/recycle, image redeployment, and exact resource inventory.
+
+Acceptance: `AZURE F1 WP02 — APP SERVICE F1 EXECUTION PROBE: PASS`
+
+### WP03 — Persistent SQLite Filesystem, Locking & Journal Qualification
+
+Model: GPT-5.6 Terra. Test CRUD, transactions, bounded concurrent reads/writes, lock/busy behavior, restart/recycle/redeployment persistence, integrity/quick checks, interruption recovery where safe, rollback-journal, and WAL. Select no journal mode until evidence exists.
+
+Acceptance: `AZURE F1 WP03 — SQLITE PERSISTENCE & JOURNAL QUALIFICATION: PASS`
+
+### WP04 — Twelve Data Outbound Connectivity, Secrets & Failure Isolation
+
+Model: GPT-5.6 Terra. Prove DNS/TLS/HTTPS, safe secret injection, one minimal real request only under a later explicit execution authority, timeout/error behavior, no secret leakage, and isolation from product architecture.
+
+Acceptance: `AZURE F1 WP04 — TWELVE DATA CONNECTIVITY & SECRET ISOLATION: PASS`
+
+### WP05 — F1 Resource Envelope & Strict-Zero-Cost Qualification
+
+Model: GPT-5.6 Terra. Measure cold start, memory, CPU and CPU-minute usage, storage/image/log growth, headroom, registry/monitoring costs, full resource inventory, and actual recurring cost.
+
+Acceptance: `AZURE F1 WP05 — RESOURCE ENVELOPE & STRICT-ZERO-COST: PASS`; required proof includes `ACTUAL RECURRING INFRASTRUCTURE COST: $0.00`.
+
+### WP06 — Feasibility Acceptance, Cleanup & Architecture Decision
+
+Primary model: GPT-5.6 Luna. Terra may perform only explicitly authorized validation/cleanup. Reconcile all evidence, select exactly `FEASIBLE` or `NOT FEASIBLE`, and prove cleanup/disposition and zero unintended recurring cost. No Phase B authorization follows automatically.
+
+Acceptance: `AZURE F1 WP06 — FEASIBILITY ACCEPTANCE & CLEANUP: PASS`
+
+## Current documentation evidence
+
+Access date: 2026-08-30. These sources establish hypotheses only:
+
+| Source | URL | Claim | Evidence class |
+|---|---|---|---|
+| Configure a Custom Container | https://learn.microsoft.com/en-us/azure/app-service/configure-custom-container | Linux custom-container `/home` persistence is controlled by App Service storage settings; writes outside persistent paths are not durable | Documentation, not empirical |
+| Quickstart: Run a Custom Container on App Service | https://learn.microsoft.com/en-us/azure/app-service/quickstart-custom-container | F1 is presented as a selectable App Service tier and custom-container workflow exists | Documentation, not empirical |
+| App Service Plans overview | https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans | Free/Shared tiers are distinct from dedicated tiers; availability/features depend on OS, region, and tier | Documentation, not empirical |
+| App Service pricing | https://azure.microsoft.com/en-us/pricing/details/app-service/ | Pricing must be checked for the actual account/region and does not by itself prove zero total cost | Documentation/pricing context, not empirical |
+| Operating System Functionality | https://learn.microsoft.com/en-us/azure/app-service/operating-system-functionality | App Service applications can make outbound network connections; exact candidate behavior still requires execution | Documentation, not empirical |
+
+## Execution stop rules
+
+Stop immediately before broader mutation if an Azure subscription/region, F1 capability, registry path, secret policy, cost, or cleanup authority is unavailable. Preserve redacted evidence. `NOT FEASIBLE` is an accepted terminal decision. No fallback to Hugging Face, Container Apps/Azure Files, or Release 2.0 is automatic.
+
+## GitHub representation boundary
+
+This planning authority creates no milestone, issue, Project item, Release option, label, or other GitHub object. The initiative is non-release work and must not be assigned the `2.0` Project Release value or an invented `1.11` value. Any later issue tracking, if needed, requires a separate governance decision and must preserve the canonical `1.10 -> 2.0` sequence. No issue or Project item may be closed from this planning authority.
+
+## Next authority
+
+After WP01’s exact acceptance and any separately authorized governance lifecycle, the next execution authority is GPT-5.6 Terra for WP02. Terra may create only the isolated resources explicitly named by the accepted WP01 contract.

--- a/docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_FEASIBILITY_CONTRACT.md
+++ b/docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_FEASIBILITY_CONTRACT.md
@@ -1,0 +1,57 @@
+# Azure F1 Feasibility Contract
+
+## Contract invariants
+
+1. Recurring infrastructure cost must be exactly `$0.00`; estimates are not proof.
+2. Azure-specific concerns remain outside Domain/Application and product contracts.
+3. The feasibility database is isolated from the production database and is never the canonical product store.
+4. Secrets are supplied only through approved secret injection and never written to committed evidence, logs, images, command output, or URLs.
+5. Every temporary resource has an owner, cost record, cleanup authority, and final disposition.
+6. WAL is not presumed safe. Rollback-journal and WAL behavior must both be tested and the selected mode must follow evidence.
+7. No Phase B or production architecture change occurs before the exact feasibility decision.
+
+## Evidence contract
+
+Evidence is stored only under the initiative evidence structure defined by `AZURE_F1_FILE_MANIFEST.md`. Each record contains UTC timestamp, test identifier, resource identity at the minimum necessary sensitivity, command/procedure, observed result, artifact hash where useful, and PASS/FAIL classification.
+
+Redact API keys, tokens, passwords, connection strings, private keys, subscription identifiers when not required for reproducibility, host dumps, cookies, and personal data. Preserve only bounded facts needed to reproduce the decision. Do not commit raw environment dumps, Azure CLI profiles, Docker credentials, or provider responses containing secrets.
+
+## Mandatory feasibility matrix
+
+| ID | Required proof | Owner | Evidence |
+|---|---|---|---|
+| F01 | F1 available in the actual subscription and region | Terra | `availability/` |
+| F02 | Custom Linux Docker runs on actual F1 | Terra | `startup/` |
+| F03 | Persistent `/home` is explicitly enabled and writable | Terra | `home-storage/` |
+| F04 | SQLite is created beneath `/home` | Terra | `sqlite-crud/` |
+| F05 | INSERT/UPDATE/SELECT succeed | Terra | `sqlite-crud/` |
+| F06 | Commit/rollback transactions behave correctly | Terra | `sqlite-transactions/` |
+| F07 | Bounded concurrent readers/writer are characterized | Terra | `sqlite-concurrency/` |
+| F08 | Lock/busy behavior and recovery are characterized | Terra | `sqlite-concurrency/` |
+| F09 | Data survives app restart | Terra | `restart/` |
+| F10 | Data survives container restart/recycle | Terra | `restart/` |
+| F11 | Data survives image redeployment | Terra | `redeployment/` |
+| F12 | `PRAGMA integrity_check` passes | Terra | `sqlite-integrity/` |
+| F13 | `PRAGMA quick_check` passes | Terra | `sqlite-integrity/` |
+| F14 | Journal and locking mode are qualified | Terra | `sqlite-journal/` |
+| F15 | WAL and rollback-journal are explicitly compared | Terra | `sqlite-journal/` |
+| F16 | Twelve Data DNS/TLS/HTTPS succeeds | Terra | `twelve-data/` |
+| F17 | Secret injection occurs without leakage | Terra | `secrets/` |
+| F18 | Provider timeout/error isolation is proven | Terra | `twelve-data/` |
+| F19 | Public HTTPS behavior is acceptable, if available at zero cost | Terra | `https/` |
+| F20 | CPU/memory/CPU-minute envelope fits F1 with headroom | Terra | `resources/` |
+| F21 | Storage/image/log envelope fits with headroom | Terra | `resources/` |
+| F22 | Every created resource is inventoried | Terra | `inventory/` |
+| F23 | Actual recurring cost is `$0.00` | Terra | `cost/` |
+| F24 | No production architecture change is required | Luna | `acceptance/` |
+| F25 | Cleanup or explicit retention disposition is proven | Luna/Terra | `cleanup/` |
+
+Every row is mandatory. A documentation claim may be recorded as context but cannot replace an empirical row.
+
+## Resource lifecycle
+
+Resources are temporary by default. Before creation, record purpose, type, region, SKU, owner, authority, expected cost, and cleanup command. After execution, record creation time, actual inventory, observed cost, and deletion/read-back. Retention requires a later explicit authority. Failure paths must attempt bounded cleanup and must report anything not deleted.
+
+## Security and failure rules
+
+Use least privilege, no persistent developer credentials, no public secret exposure, and no broad firewall or monitoring exceptions. A provider outage, unsupported F1 capability, non-writable `/home`, unsafe locking mode, cost ambiguity, or cleanup failure is a bounded FAIL/NOT FEASIBLE result—not a reason to weaken the contract.

--- a/docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_FEASIBILITY_DEFINITION.md
+++ b/docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_FEASIBILITY_DEFINITION.md
@@ -1,0 +1,45 @@
+# Azure F1 Public Reference Deployment — Feasibility Definition
+
+## Governance identity
+
+This is a non-release feasibility initiative: **Public Reference Deployment / Azure App Service F1 Feasibility Qualification**. It is not Release 1.11, does not modify Release 2.0, and does not create a numbered release boundary.
+
+The canonical product sequence remains `1.10 → 2.0`. Milestone #60 remains `Phase 5 - Release 2.0: Lightweight Machine Learning Evaluation`; no Release 1.11 milestone, Project Release option, or work-package issues are created by this initiative.
+
+## Question
+
+Can a minimal, provider-independent reference deployment run on Azure App Service Linux F1 with a custom Docker container, persistent `/home`, writable SQLite, and bounded Twelve Data HTTPS access at an actual recurring infrastructure cost of `$0.00`?
+
+The answer is empirical. Documentation, pricing pages, local Docker execution, or an architectural diagram cannot produce a `FEASIBLE` result.
+
+## Frozen target and exclusions
+
+- Candidate: Azure App Service Linux F1 + custom Docker + persistent `/home` + SQLite.
+- Local database hypothesis: `/app/data/aiquant.db`.
+- Azure database hypothesis: `/home/data/aiquant.db`.
+- Hugging Face Docker Spaces: abandoned.
+- Azure Container Apps/Azure Files: deferred.
+- Azure is deployment infrastructure only; it must not enter Domain, Application, market-data, analytics, persistence abstractions, or canonical pipeline semantics.
+- Release 1.10, schema v4, canonical JSON handoff, Worker/Streamlit independence, and production persistence remain unchanged.
+- No production deployment, Phase B implementation, Azure SDK in product layers, migration, provider redesign, or hidden paid dependency is authorized.
+
+## Decision gate
+
+WP06 must emit exactly one result:
+
+- `AZURE APP SERVICE F1 REFERENCE DEPLOYMENT: FEASIBLE`, only when every mandatory evidence row passes and cleanup/cost proof is complete; or
+- `AZURE APP SERVICE F1 REFERENCE DEPLOYMENT: NOT FEASIBLE`, when any mandatory row fails or the strict-zero/provider-independence contract cannot be satisfied.
+
+`NOT FEASIBLE` is valid and does not authorize an architectural compromise or automatic fallback.
+
+## Model map
+
+- GPT-5.6 Luna: contract, reconciliation, acceptance, and architecture decision.
+- GPT-5.6 Terra: isolated probe implementation, empirical execution, measurement, and explicitly authorized cleanup.
+- GPT-5.6 Sol: supporting analysis only; never substitutes for Luna or Terra.
+
+Selected planning model: GPT-5.6 Luna. No Azure mutation is authorized by this artifact.
+
+## Acceptance boundary
+
+Phase A qualifies only the hosting substrate and deployment hypothesis. A `FEASIBLE` result permits a later Luna decision about public reference deployment; it does not authorize Phase B, production cutover, release tagging, or changes to the product architecture.

--- a/docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_FILE_MANIFEST.md
+++ b/docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_FILE_MANIFEST.md
@@ -1,0 +1,64 @@
+# Azure F1 Feasibility File Manifest
+
+This initiative is non-release planning and feasibility evidence. It is not Release 1.11 and does not modify Release 2.0.
+
+## Planning and governance paths
+
+The four planning artifacts are:
+
+- `docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_FEASIBILITY_DEFINITION.md`
+- `docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_FEASIBILITY_CONTRACT.md`
+- `docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_EXECUTION_PLAN.md`
+- `docs/roadmap/initiatives/azure-f1-public-reference-deployment/AZURE_F1_FILE_MANIFEST.md`
+
+Only these planning paths are writable under the current Luna authority.
+
+## Isolated probe paths
+
+Future Terra execution requires a separately authorized, isolated probe directory beneath this initiative. Exact filenames are not authorized here. The probe must not modify `src/`, product `.csproj` files, production Docker/deployment files, schema/migrations, Python/Streamlit production paths, or canonical handoff code.
+
+## Evidence paths
+
+Future evidence belongs beneath an explicitly excluded-from-commit structure:
+
+```text
+evidence/
+  availability/
+  inventory/
+  startup/
+  https/
+  home-storage/
+  sqlite-crud/
+  sqlite-transactions/
+  sqlite-concurrency/
+  sqlite-journal/
+  sqlite-integrity/
+  restart/
+  redeployment/
+  twelve-data/
+  secrets/
+  resources/
+  cost/
+  cleanup/
+  acceptance/
+```
+
+Evidence is temporary unless a later authority explicitly authorizes retention. Raw secrets, tokens, keys, subscription credentials, Docker credentials, unrestricted environment dumps, and unredacted provider responses are forbidden.
+
+## Generated and temporary exclusions
+
+Never stage or commit Azure CLI profiles, Terraform/state files, Docker credentials, `.env` files, private keys/certificates, raw logs, process dumps, image layers, container databases, SQLite `-wal`/`-shm`/journal files, caches, `bin/`, `obj/`, `.pytest_cache/`, or temporary resource exports.
+
+## Forbidden production paths/actions
+
+- Domain/Application Azure SDKs or Azure-specific contracts.
+- Production persistence replacement, schema migration, or canonical-database synchronization redesign.
+- Production Dockerfile, App Service deployment, CI/CD, registry publication, or public cutover.
+- Release 2.0 capability edits or fake Release 1.11 taxonomy.
+- Production Worker/Streamlit supervision or direct UI/SQLite bypass.
+- Twelve Data provider-abstraction redesign.
+- Any Phase B implementation before WP06 decision.
+
+## Path and mutation gate
+
+Every future Terra change must enumerate exact paths before mutation, prove it is isolated feasibility work, and separate repository/Git/GitHub/Azure mutation accounting. No Azure resource or live provider request is authorized by this manifest alone.


### PR DESCRIPTION
## Summary
Publishes four new planning/governance artifacts for Initiative-1.11.

- Initiative-1.11 is a non-release initiative; `Initiative-1.11 ≠ Product Release 1.11`.
- Product Release 1.11 remains abandoned.
- Azure App Service Linux F1 is the sole feasibility candidate; feasibility is not yet accepted.
- The strict recurring infrastructure-cost target is `$0.00`.
- WP01 is accepted; WP02 remains pending empirical execution.
- Current numbered product releases retain the Phase 5 baseline; milestone #62 remains the Phase 4 initiative milestone.

This publication makes no Azure-resource, issue, milestone, Project, application, test, package, or schema mutation.

## Validation
- Exact payload: four new Markdown governance artifacts.
- `git diff --check` passed.
- No conflict markers, secrets, or trailing whitespace.
- No unsupported empirical Azure feasibility or cost PASS claim.