### PR TITLE
Docs: publish Release 1.12 planning artifacts

### DIFF
--- a/docs/roadmap/release-1.12/RELEASE_1.12_DEFINITION.md
+++ b/docs/roadmap/release-1.12/RELEASE_1.12_DEFINITION.md
@@ -1,0 +1,37 @@
+# Phase 4 - Release 1.12: Public Reference Deployment Implementation & Stabilization
+
+## Governance
+
+Release 1.12 is the product release following Release 1.10 and preceding Release 2.0. Product Release 1.11 remains abandoned/nonexistent. Initiative-1.11 is a completed, non-release feasibility predecessor and is not reclassified as Release 1.12.
+
+Model map: GPT-5.6 Luna owns contract, architecture, governance, and final acceptance; GPT-5.6 Terra owns implementation and empirical execution under explicit WP authority; GPT-5.6 Sol provides supporting analysis only. Selected planning model: GPT-5.6 Luna.
+
+## Capability and inherited feasibility
+
+Release 1.12 makes the already-qualified bounded reference deployment reproducible and supportable. It consumes, and does not repeat, Initiative-1.11 feasibility evidence:
+
+- Azure App Service Linux F1 in West Central US with custom Docker and public HTTPS.
+- Persistent `/home` with SQLite; DELETE journal mode is selected and WAL is not selected.
+- Public/free GHCR distribution and bounded Twelve Data connectivity with runtime-only secrets.
+- Public Streamlit/System Health reference presentation and the existing .NET/Python boundaries.
+- `ACTUAL RECURRING INFRASTRUCTURE COST: $0.00`.
+
+The result is a bounded recruiter/reference/demo environment, not production hosting. F1 limitations remain 60 CPU minutes/day, 1 GB storage, shared capacity, throttling, cold starts, and no SLA.
+
+## Scope
+
+In scope: deterministic container composition; free image publication; reproducible F1 provisioning; `/home` SQLite initialization/update/recovery; secret-safe bounded Twelve Data refresh; public Streamlit/System Health; restart/recycle/redeploy recovery; low-cost diagnostics; deployment, rollback, secret rotation, cost, teardown, and acceptance runbooks.
+
+Out of scope: Azure SQL, Azure Files, Container Apps, mandatory ACR, paid tiers/networking/monitoring, live trading, orders, portfolio management, ML, backtesting, production SLA/HA claims, unrelated schema migration, parallel pipelines, and any Streamlit SQLite/provider/Worker-supervision bypass.
+
+Release sequence: `1.10 → 1.12 → 2.0 → 2.1 → 2.2 → 2.3`. Release 2.0 remains Lightweight Machine Learning Evaluation and does not absorb deployment scope.
+
+## Contracts and acceptance
+
+The canonical pipeline remains .NET-owned with atomic JSON/read-model handoff to Python and Streamlit. Provenance must remain deterministic, replay, or simulated where applicable; no live-market claim is permitted. Existing schema and protocol contracts remain unchanged unless separately authorized.
+
+Release acceptance requires every WP marker, reproducible image digest/provenance, HTTPS, persistent `/home`, SQLite integrity with DELETE mode, bounded Twelve Data success/failure behavior, secret absence from Git/images/logs/public output, truthful health, restart/recycle/redeploy recovery, no-bypass checks, complete resource inventory, `$0.00` recurring infrastructure, and cleanup evidence.
+
+## Boundary
+
+This definition authorizes planning only. It creates no Azure resources, Docker/GHCR state, provider requests, implementation, tag, GitHub Release, or merge. Each WP requires its own authority and explicit model map.

--- a/docs/roadmap/release-1.12/RELEASE_1.12_EXECUTION_PLAN.md
+++ b/docs/roadmap/release-1.12/RELEASE_1.12_EXECUTION_PLAN.md
@@ -1,0 +1,48 @@
+# Release 1.12 Execution Plan
+
+Authoritative identity: `Phase 4 - Release 1.12: Public Reference Deployment Implementation & Stabilization`.
+
+## Dependencies and work packages
+
+The dependency graph is:
+
+`WP01 → WP02 → WP03 → WP04 → WP05 → WP06 → WP07 → WP08`
+
+1. **WP01 — Release Contract, Deployment Architecture & Reproducibility Boundary** — GPT-5.6 Luna. Freeze manifests, invariants, deployment boundary, and acceptance evidence.
+2. **WP02 — Productionized Container & Runtime Composition** — GPT-5.6 Terra. Build the minimal reproducible application image without changing product architecture.
+3. **WP03 — GHCR Publication & Azure F1 Deployment Automation** — GPT-5.6 Terra. Publish free-registry digests and automate only the approved F1 resource envelope.
+4. **WP04 — Persistent SQLite Initialization, Data Update & Recovery** — GPT-5.6 Terra. Implement and validate `/home` initialization, update, integrity, recovery, and DELETE journal operation.
+5. **WP05 — Twelve Data Runtime Configuration, Secrets & Bounded Automation** — GPT-5.6 Terra. Add only secret-safe bounded refresh and deterministic failure isolation.
+6. **WP06 — Public Streamlit/System Health Deployment & Truthful Diagnostics** — GPT-5.6 Terra. Connect only governed read models and expose truthful bounded health/provenance.
+7. **WP07 — Deployment Stability, Recovery, Cost & No-Bypass Validation** — GPT-5.6 Terra. Validate restarts, recycles, redeployments, cost, security, and architecture boundaries.
+8. **WP08 — Documentation, Operational Runbook & Release Acceptance** — GPT-5.6 Luna final acceptance; Terra may perform only separately authorized validation/publication/lifecycle mutations.
+
+Every WP must name Luna/Terra/Sol, its exact paths, dependencies, mutation boundary, acceptance marker, validation commands, and lifecycle rule. After an exact acceptance marker, its issue may be closed and Project Status set to Done only when automation has not already done so. Milestone #63 remains open until final release completion.
+
+## Validation matrix
+
+| Gate | Required evidence |
+|---|---|
+| Repository/Git | clean scope, exact manifest, no unrelated work, no forbidden release mutation |
+| Build/tests | relevant .NET build/tests, Python tests, Streamlit 1.61.1 and dependency health |
+| Security | Gitleaks 8.30.1 policy, no credentials/API keys/secrets in Git, image, logs, or output |
+| Container | reproducible build, digest and provenance, Linux runtime and health |
+| Azure F1 | West Central US, F1/Free plan, HTTPS, required settings, complete inventory |
+| Persistence | `/home` SQLite integrity, DELETE journal, restart/recycle/redeploy recovery |
+| Provider | bounded Twelve Data success, missing/invalid/network failure isolation, recovery |
+| Presentation | canonical read-model chain, truthful System Health, no Streamlit bypass |
+| Cost/cleanup | no paid dependency, `$0.00` recurring infrastructure, teardown/read-back evidence |
+
+## Fixed constraints
+
+No Azure SQL, Azure Files, Container Apps, mandatory ACR, paid tier/networking/monitoring, live trading, ML/backtesting, schema migration, production SLA, or Release 2.0 scope. Azure remains deployment-only. The inherited strict cost marker is:
+
+`ACTUAL RECURRING INFRASTRUCTURE COST: $0.00`
+
+## Lifecycle and mutation audit
+
+Planning may create only the Release 1.12 artifacts and the approved milestone/Project/issue governance objects. It must not alter Initiative-1.11 issues #252–#257 or milestone #62. Implementation WPs may mutate only their separately authorized surfaces. Tags, GitHub Releases, and milestone closure require final release authority.
+
+## Handoff
+
+Next authority: GPT-5.6 Luna — WP01 Release Contract, Deployment Architecture & Reproducibility Boundary. No implementation or Azure execution is authorized by this plan.

--- a/docs/roadmap/release-1.12/RELEASE_1.12_FILE_MANIFEST.md
+++ b/docs/roadmap/release-1.12/RELEASE_1.12_FILE_MANIFEST.md
@@ -1,0 +1,34 @@
+# Release 1.12 File Manifest
+
+## Planning-authority paths
+
+The initial planning mutation is limited to these three new files:
+
+- `docs/roadmap/release-1.12/RELEASE_1.12_DEFINITION.md`
+- `docs/roadmap/release-1.12/RELEASE_1.12_EXECUTION_PLAN.md`
+- `docs/roadmap/release-1.12/RELEASE_1.12_FILE_MANIFEST.md`
+
+The existing `docs/roadmap/release-1.12/prompters/` authority/bootstrap prompts are control records and are not silently counted as implementation payload.
+
+## Future WP ownership
+
+No future implementation path is authorized by this manifest. Each WP authority must replace this section with a literal path allowlist before mutation. Expected ownership is:
+
+- WP01: planning/architecture contract paths only.
+- WP02: container/runtime paths only.
+- WP03: deployment automation and evidence paths only.
+- WP04: persistence paths only.
+- WP05: runtime configuration/secret-safe automation paths only.
+- WP06: public presentation/health paths only.
+- WP07: validation and no-bypass test paths only.
+- WP08: documentation/runbook/release acceptance paths only.
+
+Forbidden: unrelated source/tests, package or schema changes, Azure auth/profile material, credentials/API keys, private certificates, machine-local configuration, caches/build outputs, production deployment claims, tags, releases, and Release 2.0/ Product Release 1.11 reassignment.
+
+## Acceptance evidence
+
+Every future candidate must prove exact path count and set, no duplicates, no origin overlap, no forbidden paths, whitespace cleanliness, secret scan, relevant tests, no-bypass invariants, strict `$0.00`, and preserved `1.10 → 1.12 → 2.0 → 2.1 → 2.2 → 2.3` sequencing.
+
+## Mutation boundary
+
+This manifest is planning governance only. It does not authorize implementation, Azure/Docker/provider operations, staging, commits, pushes, tags, GitHub Releases, or merge.


### PR DESCRIPTION
## Release 1.12 planning artifacts

- Freezes Release 1.12 planning/governance; WP01 #260 is Closed/Done.
- Payload is exactly three governance Markdown artifacts.
- No implementation, Azure, Docker, provider, package, or schema mutation.
- WP02 #261 remains the next implementation boundary.
- Product Release 1.11 remains abandoned; Release 2.0 remains separate.