### PR TITLE
Publish Release 1.12 deployment controls and prompters

### DIFF
--- a/docs/roadmap/release-1.12/prompters/release-1.12-pr-268-merge-post-merge-verification-authority-terra.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-pr-268-merge-post-merge-verification-authority-terra.md
@@ -1,0 +1,227 @@
+# GPT-5.6 Terra — Release 1.12 PR #268 Merge + Post-Merge Verification Authority
+
+**Selected execution model: GPT-5.6 Terra**
+
+## Model authority map
+- **GPT-5.6 Luna** — contract, policy, architecture, definition, reconciliation, acceptance criteria, governance, planning.
+- **GPT-5.6 Terra** — PRIMARY for this authority: exact PR merge mutation, synchronization, post-merge verification, and mutation accounting.
+- **GPT-5.6 Sol** — supporting analysis only; never silently replaces Luna or Terra.
+
+## Mission
+Authorize exactly one narrow action: merge PR #268 and verify the merged publication boundary.
+
+Target:
+`#268 — Docs: publish Release 1.12 planning artifacts`
+
+Known expected pre-merge state:
+- head branch `docs/release-1.12-planning-artifacts`
+- head SHA `917207333f133b961f72b94525a17ed0d0aae954`
+- original parent `20a8fccd6e7a5b895e717f946f4501edd7ab8ffa`
+- PR Open, non-draft, base `main`
+- exact payload = 3 Markdown planning artifacts
+
+## Exact governed payload
+The merged payload MUST equal exactly:
+1. `docs/roadmap/release-1.12/RELEASE_1.12_DEFINITION.md`
+2. `docs/roadmap/release-1.12/RELEASE_1.12_EXECUTION_PLAN.md`
+3. `docs/roadmap/release-1.12/RELEASE_1.12_FILE_MANIFEST.md`
+
+Expected counts:
+- total 3
+- unique 3
+- Markdown 3
+- all other extensions 0
+
+## Pre-merge reconciliation
+Before mutation verify:
+- PR #268 exists
+- state Open
+- non-draft
+- base `main`
+- head branch exact
+- head SHA exact
+- payload exact 3/3
+- no unexpected commits added
+- checks/statuses are not failing in a way that makes merge unsafe
+- current `origin/main` reconciled
+- PR remains mergeable without scope drift
+
+If `origin/main` advanced, prove merge still yields the intended exact 3-path governance publication.
+
+If head SHA or payload differs materially: BLOCK.
+
+## Governance invariants
+Preserve:
+- Product Release 1.11 abandoned/nonexistent
+- sequence `1.10 → 1.12 → 2.0 → 2.1 → 2.2 → 2.3`
+- #260 Closed/Done
+- #261 Open/Todo
+- milestone #63 Open, expected 7 open / 1 closed
+- #262–#267 dependency-gated
+- Project #2 Release taxonomy unchanged
+- Initiative-1.11 milestone/issues unchanged
+- Release 1.10 tags/releases/history unchanged
+
+Do not close #261 or any WP issue.
+
+## Authorized mutations
+Authorized:
+- exactly one GitHub merge mutation for PR #268
+- Git fetch/remote-tracking updates required for verification
+- safe local `main` synchronization to verified `origin/main`
+
+Not authorized:
+- repository source edits
+- authored follow-up commit
+- amend/rebase/history rewrite
+- force push
+- new PR
+- issue/Project/milestone mutations
+- tag/release mutation
+- Azure
+- Docker/GHCR
+- provider calls
+- package/schema/production changes
+- WP02 implementation
+
+## Merge method
+Use the repository-approved/default merge method consistent with existing policy. State the exact method before execution.
+
+Record the resulting merge SHA as the new canonical Release 1.12 planning-publication `main` anchor.
+
+## Post-merge verification
+
+### PR state
+Verify:
+- #268 = MERGED
+- record merge SHA
+- record merged timestamp if available
+- merged head corresponds to `917207333f133b961f72b94525a17ed0d0aae954`
+
+### Main synchronization
+- fetch origin
+- verify `origin/main` contains the merge
+- update local `main` safely
+- verify local `main` = `origin/main`
+- verify ahead/behind = 0/0
+
+### Exact merged payload
+Use authoritative Git comparison.
+Prove:
+- merged diff total = 3
+- unique = 3
+- Markdown = 3
+- exact path set equals governed manifest
+- no extra path entered via merge/conflict drift
+
+If GitHub file enumeration disagrees with Git diff, Git comparison is authoritative and discrepancy must be reported.
+
+### Content presence
+Verify all three planning artifacts exist on `main`.
+
+### Governance preservation
+Verify:
+- #260 still Closed/Done
+- #261 still Open/Todo
+- milestone #63 still Open, expected 7/1
+- no Project Release/Status mutation
+- no Initiative-1.11 mutation
+- no Release 1.10 tag/release mutation
+- no new tag/GitHub Release
+- no Azure/Docker/provider mutation
+
+### Cleanliness
+Verify:
+- staged count 0
+- no accidental merge-local residue
+- pre-existing unrelated untracked files such as `prompters/` remain untracked/excluded
+
+## WP02 unblock condition
+Only after all gates pass emit:
+
+`RELEASE 1.12 WP02 — PUBLICATION PREREQUISITE: SATISFIED`
+
+`RELEASE 1.12 WP02 — EXECUTION AUTHORITY: READY TO RESUME`
+
+This authority does not execute WP02.
+
+## Mutation accounting
+Report exact counts for:
+- PR merges
+- fetch/remote-tracking updates
+- local branch updates
+- repository edits authored by this authority
+- authored commits
+- pushes
+- new PRs
+- issue mutations
+- Project mutations
+- milestone mutations
+- tag/release mutations
+- Azure
+- Docker/GHCR
+- provider requests
+- package/schema/production changes
+
+Expected protected-domain explicit mutations:
+- PR merge 1
+- issue 0
+- Project 0
+- milestone 0
+- tag/release 0
+- Azure 0
+- Docker/GHCR 0
+- provider 0
+- package/schema/production 0
+
+## Interactive execution protocol
+If GitHub-authenticated execution must occur in the user's Windows context, provide one bounded PowerShell batch at a time with:
+1. purpose
+2. exact copy/paste commands
+3. classification (`READ-ONLY`, `GITHUB MUTATION`, `LOCAL GIT MUTATION`)
+4. expected mutations
+5. required stdout/stderr/exit codes/evidence
+6. STOP and wait
+
+Never infer success or request token/auth-cache transfer.
+
+## Acceptance gates
+A. Pre-merge identity/state/head/base/payload proven.
+B. Exactly one authorized merge mutation completes.
+C. Local/origin main synchronization proven.
+D. Authoritative merged payload exact 3/3.
+E. Governance preserved.
+F. Repository clean/no accidental residue.
+G. Mutation audit exact.
+
+## Required markers
+`RELEASE 1.12 PR #268 — PRE-MERGE RECONCILIATION: PASS`
+
+`RELEASE 1.12 PR #268 — MERGE: PASS`
+
+`RELEASE 1.12 PR #268 — POST-MERGE MAIN SYNCHRONIZATION: PASS`
+
+`RELEASE 1.12 PR #268 — MERGED PAYLOAD 3/3: PASS`
+
+`RELEASE 1.12 PR #268 — GOVERNANCE PRESERVATION: PASS`
+
+`RELEASE 1.12 PR #268 — POST-MERGE CLEANLINESS: PASS`
+
+`RELEASE 1.12 PR #268 — MUTATION AUDIT: PASS`
+
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS PUBLICATION MERGE: PASS`
+
+`RELEASE 1.12 WP02 — PUBLICATION PREREQUISITE: SATISFIED`
+
+`RELEASE 1.12 WP02 — EXECUTION AUTHORITY: READY TO RESUME`
+
+Terminal:
+`RELEASE 1.12 PR #268 — MERGE + POST-MERGE VERIFICATION AUTHORITY COMPLETE`
+
+Blocked:
+`RELEASE 1.12 PR #268 — MERGE + POST-MERGE VERIFICATION AUTHORITY BLOCKED`
+
+## Completion boundary
+Complete only after PR #268 is merged, exact 3/3 payload proven on `main`, new merge/main anchor recorded, local/main and origin/main synchronized, governance unchanged, and mutation audit passes.
+
+Does not authorize WP02 implementation beyond declaring its publication prerequisite satisfied.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-pr-268-merge-post-merge-verification-bootstrap.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-pr-268-merge-post-merge-verification-bootstrap.md
@@ -1,0 +1,55 @@
+# GPT-5.6 Terra Bootstrap — PR #268 Merge + Post-Merge Verification
+
+Execute:
+`release-1.12-pr-268-merge-post-merge-verification-authority-terra.md`
+
+**Selected execution model: GPT-5.6 Terra**
+
+Repository:
+`C:\projects\github\AIQuantTradingResearch`
+
+Target:
+`#268 — Docs: publish Release 1.12 planning artifacts`
+
+Expected pre-merge identity:
+- Open
+- non-draft
+- base `main`
+- head `docs/release-1.12-planning-artifacts`
+- head SHA `917207333f133b961f72b94525a17ed0d0aae954`
+- original parent `20a8fccd6e7a5b895e717f946f4501edd7ab8ffa`
+- exact payload 3 Markdown planning artifacts
+
+Exact paths:
+- `docs/roadmap/release-1.12/RELEASE_1.12_DEFINITION.md`
+- `docs/roadmap/release-1.12/RELEASE_1.12_EXECUTION_PLAN.md`
+- `docs/roadmap/release-1.12/RELEASE_1.12_FILE_MANIFEST.md`
+
+Freshly reconcile before mutation. If head SHA or payload differs, BLOCK.
+
+This authority authorizes exactly one PR merge mutation plus the Git synchronization/verification required afterward. It does not authorize WP02 implementation or closing #261.
+
+After merge:
+- record merge SHA
+- fetch origin
+- synchronize local `main` with `origin/main`
+- prove 0/0 ahead-behind
+- prove authoritative Git payload exactly 3/3
+- verify all three files exist on main
+- verify #260 Closed/Done, #261 Open/Todo, milestone #63 Open expected 7/1
+- verify Project, Initiative-1.11, Release 1.10, tags/releases, Azure, Docker/GHCR, provider state unchanged
+- verify staged count 0 and unrelated `prompters/` remains excluded
+
+Required final:
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS PUBLICATION MERGE: PASS`
+
+`RELEASE 1.12 WP02 — PUBLICATION PREREQUISITE: SATISFIED`
+
+`RELEASE 1.12 WP02 — EXECUTION AUTHORITY: READY TO RESUME`
+
+`RELEASE 1.12 PR #268 — MERGE + POST-MERGE VERIFICATION AUTHORITY COMPLETE`
+
+Blocked:
+`RELEASE 1.12 PR #268 — MERGE + POST-MERGE VERIFICATION AUTHORITY BLOCKED`
+
+For authenticated execution, provide exact bounded PowerShell batches with purpose, classification, expected mutations, requested stdout/stderr/exit codes, then STOP.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-public-reference-deployment-implementation-stabilization-bootstrap.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-public-reference-deployment-implementation-stabilization-bootstrap.md
@@ -1,0 +1,29 @@
+# GPT-5.6 Luna Bootstrap — Phase 4 Release 1.12
+
+Execute:
+`release-1.12-public-reference-deployment-implementation-stabilization-definition-governance-execution-planning-authority-luna.md`
+
+**Selected execution model: GPT-5.6 Luna**
+
+Repository: `C:\projects\github\AIQuantTradingResearch`
+
+Define/govern:
+`Phase 4 - Release 1.12: Public Reference Deployment Implementation & Stabilization`
+
+Planning/governance only. Reconcile current `origin/main` and GitHub first. Verify PR #259 and merge `20a8fccd6e7a5b895e717f946f4501edd7ab8ffa`. Preserve Product Release 1.11 as abandoned/nonexistent. Reconcile intended sequence `1.10 → 1.12 → 2.0 → 2.1 → 2.2 → 2.3`. Consume, do not repeat, Initiative-1.11 Azure F1 feasibility.
+
+Preserve Azure App Service Linux F1 / West Central US / custom Docker / persistent `/home` / SQLite DELETE journal / public GHCR / bounded Twelve Data / reference-demo boundary and exact recurring infrastructure cost `$0.00`.
+
+No Azure SQL, Azure Files, Container Apps, mandatory ACR, paid tier/networking/monitoring, Release 2.0 ML attachment, or production SLA claim.
+
+Create/reconcile Release 1.12 planning artifacts, milestone, Project #2 Release taxonomy `1.12`, WP topology, exact acceptance gates, validation matrix, lifecycle and mutation audit only after fresh reconciliation. Do not mutate #252–#257 or milestone #62.
+
+Whenever a Release 1.12 WP passes exact acceptance, close its GitHub issue and set Project #2 Status Done unless automation already did so.
+
+If authenticated execution is required, provide exact PowerShell batches with purpose, classification, expected mutations/counts, evidence/exit codes, then STOP.
+
+Success terminal:
+`RELEASE 1.12 — DEFINITION, GOVERNANCE & EXECUTION-PLANNING AUTHORITY COMPLETE`
+
+Blocked terminal:
+`RELEASE 1.12 — DEFINITION, GOVERNANCE & EXECUTION-PLANNING AUTHORITY BLOCKED`

--- a/docs/roadmap/release-1.12/prompters/release-1.12-public-reference-deployment-implementation-stabilization-definition-governance-execution-planning-authority-luna.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-public-reference-deployment-implementation-stabilization-definition-governance-execution-planning-authority-luna.md
@@ -1,0 +1,176 @@
+# Phase 4 - Release 1.12: Public Reference Deployment Implementation & Stabilization
+## Definition, Governance & Execution-Planning Authority
+
+**Selected execution model: GPT-5.6 Luna**
+
+### Model authority
+- **GPT-5.6 Luna** — PRIMARY: contract, policy, architecture, definition, sequencing reconciliation, governance, planning, acceptance criteria.
+- **GPT-5.6 Terra** — downstream implementation, validation execution, approved Git/GitHub/Azure mutations, deployment and publication only under separate authority.
+- **GPT-5.6 Sol** — supporting analysis/synthesis only; never silently replaces Luna/Terra.
+
+## Mission
+Define and govern the formal product release:
+`Phase 4 - Release 1.12: Public Reference Deployment Implementation & Stabilization`
+
+This authority is planning/governance only. It does not authorize product implementation, Azure deployment, Docker/GHCR mutation, provider calls, release publication, or merge.
+
+## Predecessor reconciliation
+Before mutation, fetch/reconcile current `origin/main` and GitHub state. Verify rather than assume:
+- Initiative-1.11 decision: `AZURE APP SERVICE F1 REFERENCE DEPLOYMENT: FEASIBLE`.
+- strict cost: `ACTUAL RECURRING INFRASTRUCTURE COST: $0.00`.
+- milestone #62 Closed, 0 open / 6 closed; #252–#257 Closed/Done.
+- PR #258 merged.
+- PR #259 merged; publication head `c6c2e57be8c1c3c6b9823a4680d8e5cd0c416cc3`; merge `20a8fccd6e7a5b895e717f946f4501edd7ab8ffa`.
+- PR #259 authoritative Git payload: exactly 125 unique paths = 52 Markdown + 73 PowerShell.
+If fresh evidence conflicts, BLOCK.
+
+## Release identity and sequencing
+Product Release 1.11 remains `ABANDONED / NONEXISTENT`. Initiative-1.11 must not be reclassified as Product Release 1.11.
+
+Reconcile and, if current governance permits, freeze:
+`1.10 → 1.12 → 2.0 → 2.1 → 2.2 → 2.3`
+
+Exact requested milestone title:
+`Phase 4 - Release 1.12: Public Reference Deployment Implementation & Stabilization`
+
+Release 2.0 remains Lightweight Machine Learning Evaluation and must not absorb 1.12 deployment scope. Historical Phase 4 records are not rewritten merely to normalize numbering.
+
+## Inherited qualified architecture
+Consume Initiative-1.11 feasibility; do not repeat it:
+- Azure App Service Linux F1.
+- West Central US qualified target, absent a separately reconciled blocking fact.
+- custom Docker.
+- public/default HTTPS/DNS.
+- persistent `/home`.
+- writable SQLite; **DELETE journal mode selected**; WAL not selected.
+- public/free GHCR image distribution.
+- bounded authenticated Twelve Data connectivity.
+- secrets via runtime/deployment configuration, never Git/image.
+- public Streamlit reference/demo frontend.
+- existing .NET/Python boundaries preserved.
+- recurring infrastructure cost objective exactly `$0.00`.
+Azure remains a deployment target, not a new application-layer dependency.
+
+## Release objective
+Make the proven architecture reproducibly deployable and supportable as a public recruiter/reference/demo environment. Luna must define measurable contracts for:
+1. deterministic container/runtime composition;
+2. free registry publication;
+3. reproducible App Service F1 provisioning/configuration;
+4. persistent SQLite initialization/update/recovery under `/home`;
+5. Twelve Data secret/configuration and bounded automated refresh;
+6. public Streamlit/System Health reachability and truthful diagnostics;
+7. restart/recycle/redeploy/image-update recovery;
+8. F1-appropriate diagnostics without mandatory paid monitoring;
+9. bounded data currency automation;
+10. deployment/verification/rollback/recovery/secret-rotation/cost/teardown runbook;
+11. final strict-$0 acceptance;
+12. GitHub release lifecycle and closure.
+
+## Binding cost contract
+Final acceptance must prove:
+`ACTUAL RECURRING INFRASTRUCTURE COST: $0.00`
+
+No mandatory ACR, Azure Files, Azure SQL, paid App Service tier, paid monitoring, paid networking, or architecture capable of silently introducing recurring paid infrastructure.
+
+Carry forward F1 limitations: 60 CPU minutes/day, 1 GB storage, shared capacity, throttling/cold starts, no SLA, bounded low-volume reference/demo use only. No production-grade hosting claim.
+
+## Frozen exclusions
+No Product Release 1.11 resurrection; Release 2.0 ML; Azure SQL; Container Apps; Azure Files; mandatory ACR; paid tier/networking/monitoring; live trading; order execution; portfolio management; ML; backtesting; unrelated schema migration; parallel application pipelines; direct Streamlit SQLite/provider/Worker supervision bypass; unrelated architectural rewrite; HA/production claims.
+
+Azure SQL Database Free Offer investigation remains a later independent architecture initiative unless separately re-governed.
+
+## Application invariants
+Preserve .NET pipeline ownership; canonical visualization/read model; atomic JSON handoff; Python parser → frame → presentation → Streamlit; Streamlit no SQLite/provider/Worker supervision; deterministic/replay/simulated provenance; truthful observability/System Health; separate Release 1.8 JSON-over-stdio boundary; existing schema/version contracts absent explicit migration authority; local development support.
+
+## Required planning artifacts
+Prefer:
+- `docs/roadmap/release-1.12/RELEASE_1.12_DEFINITION.md`
+- `docs/roadmap/release-1.12/RELEASE_1.12_EXECUTION_PLAN.md`
+- `docs/roadmap/release-1.12/RELEASE_1.12_FILE_MANIFEST.md`
+
+No count-padding. Define predecessor boundary, scope/exclusions, architecture/cost invariants, mutation surfaces, WP dependencies, exact acceptance markers, validation matrix, deployment/recovery evidence, lifecycle and release closure.
+
+## Preferred WP topology
+Luna must validate/refine this topology from repository evidence:
+
+1. **WP01 — Release Contract, Deployment Architecture & Reproducibility Boundary** — GPT-5.6 Luna.
+2. **WP02 — Productionized Container & Runtime Composition** — GPT-5.6 Terra.
+3. **WP03 — GHCR Publication & Azure F1 Deployment Automation** — GPT-5.6 Terra.
+4. **WP04 — Persistent SQLite Initialization, Data Update & Recovery** — GPT-5.6 Terra.
+5. **WP05 — Twelve Data Runtime Configuration, Secrets & Bounded Automation** — GPT-5.6 Terra.
+6. **WP06 — Public Streamlit/System Health Deployment & Truthful Diagnostics** — GPT-5.6 Terra.
+7. **WP07 — Deployment Stability, Recovery, Cost & No-Bypass Validation** — GPT-5.6 Terra.
+8. **WP08 — Documentation, Operational Runbook & Release Acceptance** — GPT-5.6 Luna final acceptance; Terra only for separately authorized validation/publication/lifecycle mutations.
+
+Preferred dependency:
+`WP01 → WP02 → WP03 → WP04 → WP05 → WP06 → WP07 → WP08`
+
+Each WP must receive exact scope, file/mutation boundary, acceptance marker, validation commands, dependency gate and lifecycle rule.
+
+## GitHub governance
+Inspect current state first. If reconciliation passes, authorize only minimum governance needed to establish Release 1.12:
+- create/reconcile exactly one milestone with the exact requested title;
+- create/reconcile Project #2 Release taxonomy option `1.12`;
+- create approved WP issues;
+- attach them to Release 1.12 milestone and Project #2;
+- set Release `1.12` only for Release 1.12 work;
+- establish initial Status per repository convention.
+
+Do not mutate #252–#257, milestone #62, historical Initiative-1.11 evidence, Product Release 1.11, Release 2.0 scope, historical tags/releases, or unrelated Project items. Count every explicit mutation.
+
+## WP lifecycle
+After exact WP acceptance:
+1. close its GitHub WP issue;
+2. set Project #2 Status Done only if automation has not already done so;
+3. never count or perform redundant Status mutation;
+4. never close before acceptance;
+5. milestone stays Open until final release completion.
+
+## Final validation contract to define
+At minimum: Git cleanliness/payload; relevant .NET build/tests; Python tests; Streamlit/runtime version; dependency health; established Gitleaks policy; PowerShell parsing/static validation; container build/runtime; image digest/provenance; HTTPS; `/home` persistence; SQLite integrity + DELETE journal mode; bounded Twelve Data success/failure; secret absence from Git/image/log/public output; truthful System Health; restart/recycle/redeploy recovery; no architecture bypass; Azure resource inventory; recurring cost `$0.00`; cleanup/retention inventory.
+
+`invalid-wp04-probe-key` is deliberate historical synthetic invalid-auth test data, not a credential. Do not weaken scanning for any other value.
+
+## Mutation boundary
+Allowed: read-only Git/GitHub reconciliation; `git fetch` with remote-tracking mutation recorded; planning analysis; minimum Release 1.12 planning/GitHub governance mutations after reconciliation.
+
+Forbidden: product implementation; Azure resource deployment; Docker build/push; GHCR publication; provider requests; schema migration; tag; GitHub Release; implementation merge; unrelated lifecycle changes.
+
+If planning artifacts require publication by PR, stop at publication-ready state and hand publication to a separate GPT-5.6 Terra authority.
+
+## Interactive protocol
+When authenticated Windows context is required, provide each command batch with:
+1. purpose;
+2. exact copy/paste PowerShell;
+3. classification;
+4. expected mutations/path counts;
+5. exact stdout/stderr and exit codes to return;
+6. STOP and wait.
+Never infer success or weaken security controls.
+
+## Acceptance gates
+A. predecessor/current-main reconciliation.
+B. sequence preserves abandoned 1.11 and separates 1.12 from 2.0.
+C. definition/scope/architecture/cost frozen.
+D. every WP has model, scope, dependencies, mutation boundary, exact acceptance marker and lifecycle rule.
+E. exact GitHub milestone/taxonomy/tracking.
+F. planning artifacts mutually consistent.
+G. exact mutation audit and protected-object invariants.
+
+## Required success markers
+`RELEASE 1.12 — PREDECESSOR & SEQUENCING RECONCILIATION: PASS`
+`RELEASE 1.12 — DEFINITION & ARCHITECTURE CONTRACT: PASS`
+`RELEASE 1.12 — STRICT-ZERO-COST CONTRACT: PASS`
+`RELEASE 1.12 — WORK-PACKAGE PLAN: PASS`
+`RELEASE 1.12 — GITHUB GOVERNANCE: PASS`
+`RELEASE 1.12 — PLANNING ARTIFACTS: PASS`
+`RELEASE 1.12 — PLANNING MUTATION AUDIT: PASS`
+`RELEASE 1.12 — DEFINITION, GOVERNANCE & EXECUTION PLANNING: PASS`
+`RELEASE 1.12 — WP01 EXECUTION AUTHORITY: READY`
+`RELEASE 1.12 — DEFINITION, GOVERNANCE & EXECUTION-PLANNING AUTHORITY COMPLETE`
+
+On any unresolved gate:
+`RELEASE 1.12 — DEFINITION, GOVERNANCE & EXECUTION-PLANNING AUTHORITY BLOCKED`
+
+## Completion boundary
+Planning completion does not authorize implementation. Every implementation WP requires explicit downstream authority naming its selected execution model.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-remaining-33-files-publication-designation-authority-luna.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-remaining-33-files-publication-designation-authority-luna.md
@@ -1,0 +1,213 @@
+# GPT-5.6 Luna — Release 1.12 Remaining 33 Files Publication Designation Authority
+
+**Selected execution model: GPT-5.6 Luna**
+
+## Model authority map
+- **GPT-5.6 Luna** — authoritative read-only reconciliation, exact path designation, governance ownership, publication grouping, acceptance criteria.
+- **GPT-5.6 Terra** — later implementation/publication/merge mutations under an explicit exact-path authority.
+- **GPT-5.6 Sol** — supporting analysis only; never silently replaces Luna or Terra.
+
+## Mission
+
+Reconcile and freeze the exact literal set of the 33 local files intentionally preserved outside PR #270, and determine whether they may be published together as one dedicated PR.
+
+This authority is strictly read-only.
+
+## Canonical base
+
+Expected canonical `main` after PR #270:
+
+`e931e714258028b2a6aa942a2b5cda1fc3f6866f`
+
+Expected:
+- local `main` = `origin/main`
+- ahead/behind `0/0`
+- staging empty
+
+Fresh empirical evidence controls.
+
+## Expected candidate universe
+
+Exactly 33 local files are expected:
+
+1. root operator/helper:
+   - `a10.ps1`
+
+2. Release 1.12 deployment scripts:
+   - `eng/azure-cli/r1.12-deployment/wp02-deployment/a1.ps1`
+   - `eng/azure-cli/r1.12-deployment/wp02-deployment/a2.ps1`
+   - `eng/azure-cli/r1.12-deployment/wp02-deployment/a3.ps1`
+   - `eng/azure-cli/r1.12-deployment/wp02-deployment/a4.ps1`
+   - `eng/azure-cli/r1.12-deployment/wp02-deployment/a5.ps1`
+   - `eng/azure-cli/r1.12-deployment/wp02-deployment/a6.ps1`
+   - `eng/azure-cli/r1.12-deployment/wp02-deployment/a7.ps1`
+   - `eng/azure-cli/r1.12-deployment/wp02-deployment/a8.ps1`
+   - `eng/azure-cli/r1.12-deployment/wp02-deployment/a9.ps1`
+   - `eng/azure-cli/r1.12-deployment/wp02-deployment/a10.ps1`
+
+3. exactly 22 Markdown control artifacts under:
+   - `docs/roadmap/release-1.12/prompters/`
+
+The 22 Markdown files MUST be expanded to exact literal repository-relative paths.
+
+## Required read-only reconciliation
+
+Prove:
+- candidate count is exactly 33;
+- every candidate is currently untracked or otherwise unpublished;
+- none is already on canonical `main`;
+- none overlaps PR #270's 146-path relocation;
+- no additional local file is silently included.
+
+If the candidate count is not exactly 33, BLOCK and report the exact discrepancy.
+
+## Content inspection and publication suitability
+
+Inspect all 33 files.
+
+For each file determine:
+- purpose;
+- governance owner;
+- whether it is source-of-record, operator tooling, generated artifact, duplicate, temporary helper, or historical prompt/control artifact;
+- whether public publication is appropriate;
+- whether it contains secrets, credentials, tokens, auth caches, local-only user paths, transient logs, or sensitive runtime values;
+- whether publication would create misleading Release 1.12 architecture or operational claims.
+
+### Special rule for root `a10.ps1`
+
+Determine whether root `a10.ps1` is:
+- an exact duplicate of `eng/azure-cli/r1.12-deployment/wp02-deployment/a10.ps1`;
+- a materially different operator helper;
+- required as a repository root artifact.
+
+If it is a duplicate or local-only helper with no repository purpose, Luna MUST NOT include it merely to reach 33 files.
+
+If excluding it causes the publication set to be 32 or fewer, report that truthfully. Do not force a 33-path set.
+
+## Governance ownership
+
+Map each candidate to one primary owner:
+- Release 1.12 deployment/tooling;
+- Release 1.12 governance/prompter history;
+- local-only operator workflow;
+- duplicate/redundant;
+- blocked/sensitive.
+
+## Publication decision
+
+Luna must select exactly one:
+
+`REMAINING LOCAL FILES PUBLICATION: ONE PR APPROVED`
+
+`REMAINING LOCAL FILES PUBLICATION: SPLIT REQUIRED`
+
+`REMAINING LOCAL FILES PUBLICATION: PARTIAL ONLY`
+
+`REMAINING LOCAL FILES PUBLICATION: BLOCKED`
+
+Publishing all 33 together is allowed only if they form a coherent repository-purpose package and all are suitable for public source control.
+
+Do not group files solely to clear local `git status`.
+
+## Exact literal path contract
+
+If one PR is approved, output:
+
+`REMAINING_33_PUBLICATION_SET`
+
+containing every exact literal path, sorted.
+
+Required counts:
+
+`TOTAL_PATH_COUNT=<actual>`
+
+`POWERSHELL_PATH_COUNT=<actual>`
+
+`MARKDOWN_PATH_COUNT=<actual>`
+
+`OTHER_PATH_COUNT=<actual>`
+
+`UNTRACKED_CREATE_COUNT=<actual>`
+
+Expected only if all 33 are approved:
+
+`TOTAL_PATH_COUNT=33`
+`POWERSHELL_PATH_COUNT=11`
+`MARKDOWN_PATH_COUNT=22`
+`OTHER_PATH_COUNT=0`
+`UNTRACKED_CREATE_COUNT=33`
+
+No wildcards, globs, directory-only entries, ellipses, or inferred future paths.
+
+## Sensitive-content gate
+
+Run/read-only screening sufficient to establish that the approved publication set contains no unresolved secret or credential material.
+
+Synthetic/invalid test values may be allowed only if clearly non-secret.
+
+## WP03 relationship
+
+Decide:
+
+`REMAINING LOCAL FILES — WP03 PUBLICATION PREREQUISITE: REQUIRED`
+
+or
+
+`REMAINING LOCAL FILES — WP03 PUBLICATION PREREQUISITE: NOT REQUIRED`
+
+Explain why.
+
+## Mutation prohibition
+
+Not authorized:
+- staging;
+- commit;
+- branch creation;
+- push;
+- PR creation;
+- merge;
+- file edits;
+- file deletion;
+- GitHub lifecycle changes;
+- Azure/Docker/GHCR/provider execution;
+- package/schema changes.
+
+## Required markers
+
+`REMAINING LOCAL FILES — CANONICAL BASE RECONCILIATION: PASS`
+
+`REMAINING LOCAL FILES — CANDIDATE INVENTORY: PASS`
+
+`REMAINING LOCAL FILES — CONTENT & OWNERSHIP CLASSIFICATION: PASS`
+
+`REMAINING LOCAL FILES — SENSITIVE CONTENT SCREENING: PASS`
+
+`REMAINING LOCAL FILES — PUBLICATION COHERENCE: PASS`
+
+`REMAINING LOCAL FILES — LITERAL PATH SET CLOSURE: PASS`
+
+`REMAINING LOCAL FILES — WP03 DEPENDENCY DECISION: PASS`
+
+`REMAINING LOCAL FILES — READ-ONLY MUTATION AUDIT: PASS`
+
+If all 33 are approved:
+
+`REMAINING 33 FILES — PUBLICATION SET 33/33: PASS`
+
+Acceptance:
+
+`REMAINING LOCAL FILES — PUBLICATION DESIGNATION: PASS`
+
+Terra handoff:
+
+`GPT-5.6 TERRA REMAINING-FILES CONTRACT: ONLY REMAINING_33_PUBLICATION_SET MAY BE MUTATED`
+
+`REMAINING LOCAL FILES — TERRA PUBLICATION/MERGE AUTHORITY: READY`
+
+Terminal:
+
+`REMAINING LOCAL FILES — LUNA PUBLICATION DESIGNATION AUTHORITY COMPLETE`
+
+If unresolved:
+
+`REMAINING LOCAL FILES — LUNA PUBLICATION DESIGNATION AUTHORITY BLOCKED`

--- a/docs/roadmap/release-1.12/prompters/release-1.12-remaining-33-files-publication-merge-authority-terra.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-remaining-33-files-publication-merge-authority-terra.md
@@ -1,0 +1,216 @@
+# GPT-5.6 Terra — Release 1.12 Remaining Files Publication + Merge Authority
+
+**Selected execution model: GPT-5.6 Terra**
+
+## Prerequisite
+
+Do not mutate unless GPT-5.6 Luna has emitted:
+
+`REMAINING LOCAL FILES — PUBLICATION DESIGNATION: PASS`
+
+and:
+
+`GPT-5.6 TERRA REMAINING-FILES CONTRACT: ONLY REMAINING_33_PUBLICATION_SET MAY BE MUTATED`
+
+The exact Luna-approved literal set must be available in full.
+
+If Luna approved fewer than 33 paths, use the exact approved count and set; never add files merely to reach 33.
+
+## Mission
+
+Publish and merge the exact Luna-approved remaining local files as one dedicated PR, with no unrelated paths.
+
+## Canonical base
+
+Expected `main`:
+
+`e931e714258028b2a6aa942a2b5cda1fc3f6866f`
+
+Fresh reconciliation controls.
+
+## Exact mutation closure
+
+Authorized:
+- `CREATE` only for every path in Luna's exact publication set.
+
+Not authorized:
+- modification/deletion of any already-tracked path;
+- any path outside the Luna set;
+- application/source/config/package/schema changes unless literally included and approved by Luna.
+
+## Pre-staging gate
+
+Prove:
+- canonical base;
+- staging empty;
+- every approved path exists locally;
+- every approved path is untracked/unpublished;
+- no approved path is already present on `main`;
+- sensitive-content screening still passes;
+- no local file has drifted since Luna designation.
+
+Required:
+
+`REMAINING LOCAL FILES — TERRA PRE-STAGING: PASS`
+
+## Staging
+
+Use literal selective staging only.
+
+Never use:
+- `git add .`
+- `git add -A`
+
+Stage only the exact approved paths.
+
+Then prove:
+- staged path set equals Luna set exactly;
+- staged count equals Luna count;
+- all staged entries are creates;
+- zero unrelated paths;
+- `git diff --cached --check` passes.
+
+If Luna approved all 33:
+
+`REMAINING 33 FILES — STAGED PAYLOAD 33/33: PASS`
+
+## Validation
+
+Run:
+- `git diff --cached --check`;
+- Gitleaks/secret screening on candidate/staged content;
+- syntax/readability checks appropriate to PowerShell and Markdown;
+- duplicate/root-helper sanity check if root `a10.ps1` is included;
+- no Azure/Docker/GHCR/provider execution unless a separate authority explicitly requires it.
+
+Record exact validation evidence.
+
+## Commit and PR
+
+Create a dedicated branch from reconciled base.
+
+Preferred branch:
+
+`chore/release-1.12-publish-local-controls`
+
+Preferred commit:
+
+`Publish Release 1.12 deployment controls and prompters`
+
+Preferred PR title:
+
+`Publish Release 1.12 deployment controls and prompters`
+
+Push and create one non-draft PR to `main`.
+
+Verify PR payload using authoritative Git comparison, not a possibly truncated UI enumeration.
+
+Required:
+
+`REMAINING LOCAL FILES — PR PAYLOAD EXACT: PASS`
+
+If 33 approved:
+
+`REMAINING 33 FILES — PR PAYLOAD 33/33: PASS`
+
+## Merge authority
+
+This authority authorizes merge only after:
+- exact PR path-set verification;
+- no new commits/drift;
+- mergeability confirmed;
+- validation still passes.
+
+Merge once and record:
+- PR number;
+- head SHA;
+- merge SHA;
+- merge parents;
+- merged timestamp.
+
+Required:
+
+`REMAINING LOCAL FILES — PR MERGE: PASS`
+
+## Post-merge verification
+
+After merge:
+- fetch;
+- synchronize local `main`;
+- prove local `main` = `origin/main`, 0/0;
+- authoritative parent..merge path comparison;
+- exact merged path-set equality;
+- every approved path tracked/present;
+- zero unauthorized paths;
+- staging empty;
+- report any unrelated local files still preserved.
+
+If 33 approved:
+
+`REMAINING 33 FILES — MERGED PAYLOAD 33/33: PASS`
+
+## Governance/lifecycle boundary
+
+This publication PR is not itself WP03 implementation unless Luna explicitly classified it as such.
+
+Do not:
+- close #262;
+- set #262 Done;
+- close milestone #63;
+- alter Release assignments;
+- create tags/releases.
+
+WP03 lifecycle changes remain prohibited until WP03 exact acceptance.
+
+## Mutation accounting
+
+Report exact:
+- repository creates;
+- branches;
+- commits;
+- pushes;
+- PRs;
+- merges;
+- fetches;
+- local-main synchronization;
+- issue mutations;
+- Project mutations;
+- milestone mutations;
+- Azure/Docker/GHCR/provider mutations;
+- package/schema mutations.
+
+## Required markers
+
+`REMAINING LOCAL FILES — TERRA BASE RECONCILIATION: PASS`
+
+`REMAINING LOCAL FILES — TERRA PRE-STAGING: PASS`
+
+`REMAINING LOCAL FILES — STAGED PAYLOAD EXACT: PASS`
+
+`REMAINING LOCAL FILES — VALIDATION: PASS`
+
+`REMAINING LOCAL FILES — COMMIT: PASS`
+
+`REMAINING LOCAL FILES — PUSH: PASS`
+
+`REMAINING LOCAL FILES — PR PAYLOAD EXACT: PASS`
+
+`REMAINING LOCAL FILES — PR MERGE: PASS`
+
+`REMAINING LOCAL FILES — MERGED PAYLOAD EXACT: PASS`
+
+`REMAINING LOCAL FILES — POST-MERGE CLEANLINESS: PASS`
+
+`REMAINING LOCAL FILES — MUTATION AUDIT: PASS`
+
+If all 33 were approved:
+
+`REMAINING 33 FILES — PUBLICATION & MERGE: PASS`
+
+Terminal:
+
+`REMAINING LOCAL FILES — TERRA PUBLICATION + MERGE AUTHORITY COMPLETE`
+
+Blocked:
+
+`REMAINING LOCAL FILES — TERRA PUBLICATION + MERGE AUTHORITY BLOCKED`

--- a/docs/roadmap/release-1.12/prompters/release-1.12-three-planning-artifacts-git-pr-publication-authority-terra.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-three-planning-artifacts-git-pr-publication-authority-terra.md
@@ -1,0 +1,237 @@
+# GPT-5.6 Terra — Release 1.12 Three Planning Artifacts Git/PR Publication Authority
+
+**Selected execution model: GPT-5.6 Terra**
+
+## Model authority
+- **GPT-5.6 Luna** — contract, policy, architecture, definition, reconciliation, acceptance criteria, governance, planning.
+- **GPT-5.6 Terra** — PRIMARY for repository validation, selective staging, Git/GitHub publication, and PR verification.
+- **GPT-5.6 Sol** — supporting analysis only; never silently replaces Luna/Terra.
+
+## Mission
+Publish exactly these three frozen Release 1.12 planning artifacts through one clean Git/PR boundary:
+
+1. `docs/roadmap/release-1.12/RELEASE_1.12_DEFINITION.md`
+2. `docs/roadmap/release-1.12/RELEASE_1.12_EXECUTION_PLAN.md`
+3. `docs/roadmap/release-1.12/RELEASE_1.12_FILE_MANIFEST.md`
+
+This authority prevents WP02 implementation from silently absorbing unpublished governance artifacts.
+
+## Required predecessor state
+Freshly reconcile:
+- local `main` and `origin/main` (expected current baseline `20a8fccd6e7a5b895e717f946f4501edd7ab8ffa`);
+- WP01 #260 Closed/Done;
+- milestone #63 Open with 7 open / 1 closed;
+- #261 WP02 Open/Todo and dependency-ready;
+- the three exact artifacts exist locally and are absent from `origin/main`;
+- no unrelated Release 1.12 implementation is included.
+
+If any material premise differs, BLOCK rather than silently adapting.
+
+## Exact publication scope
+The PR must contain exactly 3 changed paths, all Markdown, exactly equal to the three-path manifest above.
+
+Expected:
+- total = 3
+- unique = 3
+- Markdown = 3
+- PowerShell = 0
+- production/source/config/package/schema = 0
+
+No count-padding, opportunistic cleanup, or WP02 implementation.
+
+## Governance invariants
+Preserve:
+- Product Release 1.11 abandoned/nonexistent;
+- sequence `1.10 → 1.12 → 2.0 → 2.1 → 2.2 → 2.3`;
+- milestone #63 Open;
+- #260 Closed/Done;
+- #261 Open/Todo;
+- #262–#267 dependency-gated;
+- Project #2 Release option `1.12`;
+- Initiative-1.11 milestone #62 and #252–#257 unchanged;
+- Release 1.10 history unchanged.
+
+No WP, Project, milestone, tag, or release lifecycle mutation is authorized.
+
+## Content validation
+Before staging:
+- verify exact file existence/path identity;
+- run `git diff --check`;
+- run established Gitleaks over relevant unpublished content/diff;
+- verify no credentials, `.env`, auth caches, private keys/certs, Azure/GitHub/Docker/provider auth material;
+- verify no Product Release 1.11 resurrection;
+- verify no Release 2.0 scope contamination;
+- verify no contradictory WP/milestone references;
+- verify mutual consistency across definition/plan/manifest.
+
+`invalid-wp04-probe-key` remains classified only as historical synthetic invalid-auth test data; this does not weaken scanning for any other secret-like value.
+
+## Fresh base reconciliation
+Repository:
+`C:\projects\github\AIQuantTradingResearch`
+
+Required preflight:
+- verify remote URL;
+- verify current branch;
+- `git fetch origin --prune`;
+- verify `main` vs `origin/main`;
+- verify HEAD;
+- verify staged area empty;
+- enumerate modified/untracked paths;
+- prove only intended governance paths are in scope.
+
+If `origin/main` advanced, reconcile against the new base before publication.
+
+## Deterministic manifest and selective staging
+Use an exact deterministic manifest containing only the three governed paths.
+
+Forbidden:
+- `git add .`
+- `git add -A`
+- broad directory staging.
+
+After selective staging prove:
+- staged total 3;
+- unique 3;
+- Markdown 3;
+- no non-Markdown paths;
+- exact manifest equality.
+
+On mismatch, safely unstage and BLOCK.
+
+## Branch
+Preferred:
+`docs/release-1.12-planning-artifacts`
+
+If it conflicts with existing work, choose one narrow equivalent and report it. Never overwrite unrelated history.
+
+## Cached diff gate
+Inspect:
+- `git diff --cached --name-only`
+- `git diff --cached --name-status`
+- `git diff --cached --stat`
+- `git diff --cached`
+- `git diff --cached --check`
+
+Confirm governance/docs-only scope.
+
+## Commit
+Preferred subject:
+`Docs: publish Release 1.12 planning artifacts`
+
+Expected commit count: 1.
+
+Verify commit parent equals reconciled base and changed set is exactly the 3-path manifest.
+
+## Push
+Push the fresh branch without force. Verify remote branch head equals local publication commit. Expected push mutation: 1.
+
+## PR creation
+Create exactly one non-draft PR to `main`.
+
+Preferred title:
+`Docs: publish Release 1.12 planning artifacts`
+
+PR body should state:
+- Release 1.12 planning/governance is frozen;
+- WP01 #260 is Closed/Done;
+- payload is exactly 3 governance artifacts;
+- no implementation/Azure/Docker/provider/package/schema mutation;
+- #261 WP02 remains next implementation boundary;
+- Product Release 1.11 remains abandoned and Release 2.0 separate.
+
+Expected PR creation mutation: 1.
+
+## Post-create verification
+Verify:
+- PR number;
+- OPEN;
+- non-draft;
+- base `main`;
+- correct head branch;
+- head SHA equals publication commit;
+- exactly 3 changed paths;
+- exact path-set equality;
+- Markdown = 3;
+- no extra files;
+- no lifecycle/Project/milestone/tag/release mutation.
+
+If GitHub file enumeration is incomplete, use authoritative Git base/head diff and report the discrepancy explicitly.
+
+## Merge boundary
+**Merge is NOT authorized by this authority.**
+
+Required:
+`RELEASE 1.12 — THREE-ARTIFACT PR MERGE: NOT AUTHORIZED BY THIS AUTHORITY`
+
+If manually merged outside this authority, record it later as an externally performed GitHub merge mutation and perform separate post-merge verification. Never rewrite history to imply Terra authorized the merge.
+
+## Mutation accounting
+Report exact counts for:
+- repository file mutations caused by this authority;
+- temp files;
+- branch creation;
+- staging/index mutation;
+- commits;
+- pushes;
+- PR creation;
+- issue/Project/milestone mutations;
+- tag/release mutations;
+- Azure;
+- Docker/GHCR;
+- provider calls;
+- package/schema/production mutations.
+
+Expected protected-domain mutations: all 0.
+
+## Interactive handoff
+For authenticated Windows execution, provide one bounded batch at a time with:
+1. purpose;
+2. exact copy/paste PowerShell;
+3. classification;
+4. expected mutations;
+5. exact stdout/stderr/exit codes to return;
+6. STOP and wait.
+
+Never infer success or weaken security controls.
+
+## Acceptance gates
+A. Fresh base reconciled.
+B. Exact three-path scope proven.
+C. Content/secret/governance validation passes.
+D. Staging exact 3/3.
+E. One commit exact 3/3.
+F. Push head verified.
+G. One non-draft PR exact 3/3.
+H. Protected governance/infrastructure unchanged.
+I. Mutation audit exact.
+
+## Required success markers
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS BASE RECONCILIATION: PASS`
+
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS CONTENT VALIDATION: PASS`
+
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS STAGING 3/3: PASS`
+
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS COMMIT 3/3: PASS`
+
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS PUSH: PASS`
+
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS PR 3/3 POST-CREATE VERIFICATION: PASS`
+
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS PUBLICATION MUTATION AUDIT: PASS`
+
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS GIT/PR PUBLICATION: PASS`
+
+`RELEASE 1.12 — THREE-ARTIFACT PR MERGE: NOT AUTHORIZED BY THIS AUTHORITY`
+
+Terminal:
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS GIT/PR PUBLICATION AUTHORITY COMPLETE`
+
+Blocked:
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS GIT/PR PUBLICATION AUTHORITY BLOCKED`
+
+## Completion boundary
+Completes only after one exact three-file publication PR exists and its payload is independently verified.
+
+Does not authorize PR merge or WP02 implementation. WP02 remains a separate GPT-5.6 Terra implementation authority.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-three-planning-artifacts-git-pr-publication-bootstrap.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-three-planning-artifacts-git-pr-publication-bootstrap.md
@@ -1,0 +1,41 @@
+# GPT-5.6 Terra Bootstrap — Release 1.12 Three Planning Artifacts Publication
+
+Execute:
+`release-1.12-three-planning-artifacts-git-pr-publication-authority-terra.md`
+
+**Selected execution model: GPT-5.6 Terra**
+
+Repository:
+`C:\projects\github\AIQuantTradingResearch`
+
+Exact payload:
+- `docs/roadmap/release-1.12/RELEASE_1.12_DEFINITION.md`
+- `docs/roadmap/release-1.12/RELEASE_1.12_EXECUTION_PLAN.md`
+- `docs/roadmap/release-1.12/RELEASE_1.12_FILE_MANIFEST.md`
+
+Freshly reconcile `main`/`origin/main` (expected current baseline `20a8fccd6e7a5b895e717f946f4501edd7ab8ffa`), WP01 #260 Closed/Done, milestone #63 Open 7/1, and #261 Open/Todo.
+
+Use deterministic exact three-path manifest, established Gitleaks, `git diff --check`, governance consistency checks, and selective staging only. Never use `git add .` or `git add -A`.
+
+Preferred branch:
+`docs/release-1.12-planning-artifacts`
+
+Preferred commit:
+`Docs: publish Release 1.12 planning artifacts`
+
+Preferred PR title:
+`Docs: publish Release 1.12 planning artifacts`
+
+Create one non-draft PR to `main`; verify exact 3/3 path set.
+
+Do not mutate #260–#267, Project #2, milestone #63, tags/releases, Azure, Docker/GHCR, Twelve Data/provider, packages, schema, or production code.
+
+**Merge is not authorized.**
+
+Required terminal:
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS GIT/PR PUBLICATION AUTHORITY COMPLETE`
+
+Blocked:
+`RELEASE 1.12 — THREE PLANNING ARTIFACTS GIT/PR PUBLICATION AUTHORITY BLOCKED`
+
+For authenticated execution, provide exact PowerShell batches with purpose, classification, expected mutations, requested evidence/exit codes, then STOP.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-unmerged-repository-artifacts-reconciliation-authority-luna.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-unmerged-repository-artifacts-reconciliation-authority-luna.md
@@ -1,0 +1,404 @@
+# GPT-5.6 Luna — Unmerged Repository Artifacts Reconciliation Authority
+
+**Selected execution model: GPT-5.6 Luna**
+
+## Model authority map
+- **GPT-5.6 Luna** — PRIMARY: read-only repository-state reconciliation, artifact classification, publication-set definition, governance boundary decisions, acceptance criteria.
+- **GPT-5.6 Terra** — implementation/publication/merge/lifecycle mutations only under a later explicit authority.
+- **GPT-5.6 Sol** — supporting analysis and synthesis only; never silently replaces Luna or Terra.
+
+## 1. Mission
+
+Reconcile the current local repository state after Release 1.12 WP02 completion and determine exactly which unmerged repository artifacts should be published, excluded, split, deleted, or left local.
+
+This authority is read-only.
+
+It MUST NOT stage, commit, restore, delete, create, move, rename, publish, merge, or otherwise mutate repository state.
+
+The output must freeze one or more literal publication path sets suitable for a later GPT-5.6 Terra Git/PR publication authority.
+
+## 2. Canonical starting point
+
+Expected canonical `main` anchor:
+
+`0ffca425f485fdea23e4a2f88ee2c5968b6046f0`
+
+Expected Git synchronization:
+- local `main` = `origin/main`
+- ahead/behind `0/0`
+
+Expected known local state from completed WP02 authority:
+- 73 pre-existing tracked deletions were preserved and unstaged;
+- unrelated untracked controls/deployment artifacts were preserved and unstaged;
+- `prompters/` remained untracked/preserved;
+- none of these local changes overlapped the exact WP02 3/3 payload;
+- #261 is Closed/Done;
+- #262 is Open/Todo;
+- milestone #63 is Open with 6 open / 2 closed.
+
+Fresh empirical evidence controls if counts or paths differ.
+
+## 3. Purpose of this reconciliation
+
+Do not assume:
+- every tracked deletion is intended;
+- every untracked file should be committed;
+- all artifacts belong in one PR;
+- filenames imply ownership;
+- historical feasibility evidence should automatically become Release 1.12 implementation content;
+- deployment/control artifacts should automatically attach to WP03.
+
+Instead, classify every local path by actual content, provenance, relationship to current governance, and publication necessity.
+
+## 4. Required read-only inventory
+
+Collect and reconcile, without mutation:
+
+### Git state
+- current branch;
+- `HEAD`;
+- `origin/main`;
+- ahead/behind;
+- `git status --short`;
+- staged paths;
+- unstaged tracked modifications/deletions;
+- untracked paths;
+- ignored paths where materially relevant.
+
+### Tracked deletions
+For every tracked deletion:
+- literal repository-relative path;
+- whether it exists on canonical `main`;
+- last commit introducing/modifying it;
+- high-level purpose;
+- whether deletion appears intentional, obsolete, generated, duplicated, superseded, or accidental;
+- whether any current tracked file references it;
+- whether deletion belongs to a coherent publication set.
+
+### Untracked files/directories
+For every untracked path:
+- expand directories to literal files where practical;
+- literal path;
+- file type;
+- high-level purpose;
+- whether it contains secrets, credentials, tokens, auth caches, machine-local state, generated output, binaries, logs, or other non-publishable content;
+- relationship to Initiative-1.11, Release 1.12, WP03+, tooling, controls, prompts, or unrelated local workflow;
+- whether it should be published, ignored, retained local, or separately governed.
+
+Do not use directory-only authorization in the final publishable path set.
+
+## 5. Required source inspection
+
+Read enough content from candidate artifacts to classify them correctly.
+
+For scripts/config/deployment artifacts, determine:
+- whether they are evidence-only;
+- whether they are reusable implementation tooling;
+- whether they encode Azure/App Service/GHCR assumptions;
+- whether they mutate resources;
+- whether they contain environment-specific identifiers;
+- whether they are safe for public repository publication;
+- whether they belong to Release 1.12 WP03 or later;
+- whether publishing them now creates hidden architecture coupling.
+
+For `prompters/`:
+- inspect representative/full content as needed;
+- determine whether it is project-governance source, generated working material, local-only operator content, or publishable documentation/tooling;
+- do not assume it belongs in the repository merely because it is useful.
+
+## 6. Secret and sensitive-content screening
+
+Perform read-only screening of all candidate untracked files and relevant deleted/replacement artifacts.
+
+At minimum look for:
+- Azure subscription/resource identifiers where publication is unnecessary;
+- tokens;
+- API keys;
+- auth headers;
+- cookies;
+- local account/user paths;
+- credentials;
+- Docker auth;
+- GitHub auth;
+- provider secrets;
+- private endpoints;
+- transient execution logs containing sensitive material.
+
+A candidate path with unresolved sensitive content MUST NOT enter a publishable path set.
+
+Do not modify or sanitize files under this authority.
+
+## 7. Classification taxonomy
+
+Every local path must receive exactly one primary classification:
+
+- `PUBLISH_NOW`
+- `PUBLISH_SEPARATELY`
+- `KEEP_LOCAL`
+- `RESTORE_TRACKED_PATH`
+- `DELETE_LOCAL_ONLY`
+- `BLOCKED_REVIEW`
+- `IGNORED_GENERATED`
+- `ALREADY_GOVERNED_HISTORICAL`
+
+For tracked deletions:
+- `PUBLISH_NOW` means the deletion itself is intended and should be staged as a deletion.
+- `RESTORE_TRACKED_PATH` means the local deletion should not be published and a later authorized cleanup authority may restore it.
+- `PUBLISH_SEPARATELY` means the deletion belongs to another coherent publication package.
+
+Do not perform the restore/delete/publication here.
+
+## 8. Governance ownership mapping
+
+For each candidate path, identify ownership where applicable:
+
+- Initiative-1.11 historical evidence/governance;
+- Release 1.12 cross-cutting governance;
+- Release 1.12 WP03 — GHCR Publication & Azure F1 Deployment Automation;
+- WP04 — Persistent SQLite Initialization, Data Update & Recovery;
+- WP05 — Twelve Data Runtime Configuration, Secrets & Bounded Automation;
+- WP06 — Public Streamlit/System Health Deployment & Truthful Diagnostics;
+- WP07 — Stability, Recovery, Cost & No-Bypass Validation;
+- WP08 — Documentation, Operational Runbook & Release Acceptance;
+- repository tooling/engineering hygiene;
+- local-only operator workflow;
+- unrelated/unknown.
+
+A path may have secondary relevance, but one primary ownership decision is required.
+
+## 9. Publication grouping
+
+If publishable artifacts are found, Luna must decide whether they form:
+
+- one coherent publication PR;
+- multiple coherent PRs;
+- no publication set yet.
+
+Do not group unrelated artifacts merely to clear `git status`.
+
+Each proposed publication group must have:
+- exact purpose;
+- governance owner;
+- exact literal path set;
+- exact tracked-deletion set;
+- exact create/add set;
+- rationale for grouping;
+- whether it must be merged before WP03 begins;
+- whether it may be published independently/later.
+
+## 10. Literal path-set closure
+
+For every publication group, output an exact sorted block:
+
+`PUBLICATION_SET_<N>`
+
+Every path must be repository-relative and literal.
+
+No:
+- wildcards;
+- globs;
+- directory-only entries;
+- `...`;
+- “related files”;
+- “all scripts under”;
+- future unspecified files.
+
+For each set report:
+- `TOTAL_PATH_COUNT`
+- `TRACKED_DELETION_COUNT`
+- `UNTRACKED_CREATE_COUNT`
+- `OTHER_MODIFICATION_COUNT`
+- `SCRIPT_COUNT`
+- `DOC_COUNT`
+- `CONFIG_COUNT`
+- `EVIDENCE_COUNT`
+- `GOVERNANCE_COUNT`
+
+## 11. Mandatory decision on the 73 tracked deletions
+
+The authority must explicitly reconcile the empirically observed tracked deletions.
+
+Output:
+
+`TRACKED_DELETION_RECONCILIATION`
+
+with:
+- observed count;
+- intended publishable deletions;
+- restore-later paths;
+- separately governed deletions;
+- blocked/unresolved deletions;
+- exact count equality check.
+
+The classifications must account for every observed tracked deletion exactly once.
+
+If observed count is not 73, state the fresh count and explain the discrepancy from prior WP02 evidence.
+
+## 12. Mandatory decision on untracked artifacts
+
+Output:
+
+`UNTRACKED_ARTIFACT_RECONCILIATION`
+
+with every literal untracked file classified.
+
+Directories may be summarized in prose only after the contained literal files have been accounted for.
+
+Explicitly identify:
+- controls artifacts;
+- deployment artifacts;
+- feasibility/probe evidence;
+- prompts/prompters;
+- temporary/generated files;
+- anything sensitive or machine-local.
+
+## 13. WP03 dependency decision
+
+Luna must decide exactly one:
+
+`WP03 PUBLICATION PREREQUISITE: REQUIRED`
+
+or
+
+`WP03 PUBLICATION PREREQUISITE: NOT REQUIRED`
+
+If REQUIRED:
+- identify the exact publication set(s) that must merge before WP03 implementation;
+- explain the dependency.
+
+If NOT REQUIRED:
+- explain why WP03 may proceed independently without relying on unpublished local artifacts.
+
+Do not leave this implicit.
+
+## 14. Historical-governance protection
+
+Preserve:
+- Release 1.10 immutable historical anchor;
+- Initiative-1.11 historical qualification;
+- Release 1.12 WP01/WP02 completed lifecycle;
+- Product Release 1.11 abandoned/nonexistent status;
+- Release 1.12 sequence and milestone;
+- frozen Release 1.12 planning artifacts unless a separate governance amendment is justified.
+
+Do not retroactively rewrite prior authority outputs.
+
+## 15. Read-only mutation prohibition
+
+Authorized:
+- file reads;
+- Git reads;
+- GitHub reads;
+- hashes/counts/diffs;
+- secret scanning in read-only mode;
+- repository-reference searches.
+
+Not authorized:
+- file creation inside repository;
+- file deletion;
+- file restore;
+- rename/move;
+- formatting;
+- staging;
+- commit;
+- branch;
+- push;
+- PR creation/merge;
+- issue/Project/milestone mutation;
+- Docker;
+- Azure;
+- GHCR;
+- provider calls;
+- package changes;
+- schema changes.
+
+If temporary analysis files are unavoidable, create them outside the repository, delete them before completion, and report them.
+
+## 16. Required output structure
+
+The final report must include:
+
+1. canonical base reconciliation;
+2. exact current Git state;
+3. `TRACKED_DELETION_RECONCILIATION`;
+4. `UNTRACKED_ARTIFACT_RECONCILIATION`;
+5. secret/sensitive screening result;
+6. ownership mapping;
+7. publication grouping decision;
+8. one or more exact `PUBLICATION_SET_<N>` blocks if applicable;
+9. exact excluded/keep-local/restore-later sets;
+10. `WP03 PUBLICATION PREREQUISITE` decision;
+11. mutation audit;
+12. next Terra authority recommendation.
+
+## 17. Acceptance gates
+
+### Gate A — base reconciliation
+Canonical `main` state is proven.
+
+### Gate B — total local-state closure
+Every tracked deletion and untracked file is accounted for.
+
+### Gate C — content/provenance classification
+Classification is based on actual inspection, not filenames alone.
+
+### Gate D — sensitive-content safety
+No publishable set contains unresolved secrets/machine-local sensitive content.
+
+### Gate E — publication-set coherence
+Each proposed PR group has one coherent purpose and literal path closure.
+
+### Gate F — deletion accounting
+All observed tracked deletions are classified exactly once.
+
+### Gate G — WP03 dependency
+Publication prerequisite is explicit.
+
+### Gate H — read-only audit
+No repository/Git/GitHub/runtime mutation occurred.
+
+## 18. Required markers
+
+`UNMERGED ARTIFACTS — CANONICAL BASE RECONCILIATION: PASS`
+
+`UNMERGED ARTIFACTS — GIT STATE INVENTORY: PASS`
+
+`UNMERGED ARTIFACTS — TRACKED DELETION RECONCILIATION: PASS`
+
+`UNMERGED ARTIFACTS — UNTRACKED ARTIFACT RECONCILIATION: PASS`
+
+`UNMERGED ARTIFACTS — SENSITIVE CONTENT SCREENING: PASS`
+
+`UNMERGED ARTIFACTS — GOVERNANCE OWNERSHIP MAPPING: PASS`
+
+`UNMERGED ARTIFACTS — PUBLICATION GROUPING: PASS`
+
+`UNMERGED ARTIFACTS — LITERAL PUBLICATION SET CLOSURE: PASS`
+
+`UNMERGED ARTIFACTS — WP03 DEPENDENCY DECISION: PASS`
+
+`UNMERGED ARTIFACTS — READ-ONLY MUTATION AUDIT: PASS`
+
+Acceptance:
+
+`UNMERGED ARTIFACTS — REPOSITORY RECONCILIATION: PASS`
+
+If a Terra publication authority may be created:
+
+`UNMERGED ARTIFACTS — RECONCILED TERRA PUBLICATION AUTHORITY: READY TO CREATE`
+
+Terminal:
+
+`UNMERGED ARTIFACTS — RECONCILIATION AUTHORITY COMPLETE`
+
+If unresolved:
+
+`UNMERGED ARTIFACTS — RECONCILIATION AUTHORITY BLOCKED`
+
+State exact unresolved paths/classifications and do not authorize publication.
+
+## 19. Completion boundary
+
+This authority completes only when the entire current local unmerged state is accounted for, publishable artifacts are frozen into literal coherent set(s), non-publishable artifacts are explicitly classified, and the WP03 dependency decision is explicit.
+
+It performs no mutation and does not itself create or merge any publication PR.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-unmerged-repository-artifacts-reconciliation-bootstrap.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-unmerged-repository-artifacts-reconciliation-bootstrap.md
@@ -1,0 +1,62 @@
+# GPT-5.6 Luna Bootstrap — Unmerged Repository Artifacts Reconciliation
+
+Execute:
+
+`release-1.12-unmerged-repository-artifacts-reconciliation-authority-luna.md`
+
+**Selected execution model: GPT-5.6 Luna**
+
+Repository:
+`C:\projects\github\AIQuantTradingResearch`
+
+Expected canonical `main`:
+`0ffca425f485fdea23e4a2f88ee2c5968b6046f0`
+
+Known prior state:
+- 73 pre-existing tracked deletions preserved and unstaged;
+- unrelated untracked controls/deployment artifacts preserved and unstaged;
+- `prompters/` preserved;
+- #261 Closed/Done;
+- #262 Open/Todo;
+- milestone #63 Open, 6 open / 2 closed.
+
+This is a strict read-only reconciliation.
+
+Do not stage, restore, delete, create, rename, commit, push, open PRs, merge, or mutate GitHub/Azure/Docker/GHCR/provider/package/schema state.
+
+Inventory every tracked deletion and every untracked file. Inspect content/provenance enough to classify each path exactly once as:
+
+- `PUBLISH_NOW`
+- `PUBLISH_SEPARATELY`
+- `KEEP_LOCAL`
+- `RESTORE_TRACKED_PATH`
+- `DELETE_LOCAL_ONLY`
+- `BLOCKED_REVIEW`
+- `IGNORED_GENERATED`
+- `ALREADY_GOVERNED_HISTORICAL`
+
+Freeze exact literal publication set(s) with counts. No globs or directory-only entries.
+
+Explicitly decide whether publication is a prerequisite for WP03:
+
+`WP03 PUBLICATION PREREQUISITE: REQUIRED`
+
+or
+
+`WP03 PUBLICATION PREREQUISITE: NOT REQUIRED`
+
+Required acceptance:
+
+`UNMERGED ARTIFACTS — REPOSITORY RECONCILIATION: PASS`
+
+If ready:
+
+`UNMERGED ARTIFACTS — RECONCILED TERRA PUBLICATION AUTHORITY: READY TO CREATE`
+
+Terminal:
+
+`UNMERGED ARTIFACTS — RECONCILIATION AUTHORITY COMPLETE`
+
+Blocked:
+
+`UNMERGED ARTIFACTS — RECONCILIATION AUTHORITY BLOCKED`

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp01-release-contract-deployment-architecture-reproducibility-boundary-authority-luna.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp01-release-contract-deployment-architecture-reproducibility-boundary-authority-luna.md
@@ -1,0 +1,160 @@
+# Release 1.12 WP01 — Release Contract, Deployment Architecture & Reproducibility Boundary
+## Execution Authority
+
+**Selected execution model: GPT-5.6 Luna**
+
+### Model authority map
+- **GPT-5.6 Luna** — PRIMARY: contract, policy, architecture, definition reconciliation, acceptance criteria, governance, read-only/planning execution.
+- **GPT-5.6 Terra** — downstream implementation, validation execution, approved Git/GitHub/Azure mutations, publication and merge only under separate explicit authority.
+- **GPT-5.6 Sol** — supporting analysis/synthesis only; never silently replaces Luna or Terra.
+
+## 1. Mission
+Execute Release 1.12 WP01: `Release Contract, Deployment Architecture & Reproducibility Boundary`.
+
+WP01 converts the accepted Release 1.12 planning package into the implementation-grade contract governing WP02–WP08. This authority MUST NOT implement deployment, provision Azure resources, build/push containers, call Twelve Data, migrate schema, publish a release, or merge implementation.
+
+## 2. Required starting state
+Freshly reconcile before mutation:
+- local `main` and `origin/main` expected at `20a8fccd6e7a5b895e717f946f4501edd7ab8ffa`;
+- PR #259 merged;
+- Initiative-1.11 remains non-release and Product Release 1.11 abandoned/nonexistent;
+- sequence `1.10 → 1.12 → 2.0 → 2.1 → 2.2 → 2.3`;
+- milestone #62 Closed 0/6;
+- Release 1.12 milestone #63 Open with eight open WPs;
+- #260 Open/Todo; #261–#267 dependency-gated;
+- Project #2 Release `1.12` exists and applies only to Release 1.12 work;
+- local planning artifacts exist: `RELEASE_1.12_DEFINITION.md`, `RELEASE_1.12_EXECUTION_PLAN.md`, `RELEASE_1.12_FILE_MANIFEST.md` under `docs/roadmap/release-1.12/`;
+- those planning artifacts are uncommitted/unpublished unless fresh evidence proves otherwise;
+- no Release 1.12 Azure/Docker/provider implementation has begun.
+
+Material conflict => BLOCK and reconcile; never silently adapt.
+
+## 3. Binding inherited architecture
+Consume, do not repeat, Initiative-1.11 feasibility:
+- Azure App Service Linux F1, West Central US;
+- custom Docker;
+- public/default HTTPS/DNS;
+- persistent `/home`;
+- writable SQLite on `/home`, **DELETE journal mode selected**, WAL not selected;
+- public/free GHCR;
+- bounded authenticated Twelve Data connectivity;
+- secret-safe runtime configuration;
+- Streamlit public reference/demo frontend;
+- exact recurring infrastructure-cost requirement: `ACTUAL RECURRING INFRASTRUCTURE COST: $0.00`.
+
+Carry F1 disclosure: 60 CPU minutes/day, 1 GB storage, shared capacity, throttling/cold starts, no production SLA, bounded recruiter/reference/demo usage only.
+
+## 4. Contract to freeze
+WP01 MUST freeze implementation-grade contracts for:
+
+### Deployment topology
+Source → deterministic container build → public GHCR image/digest → Azure F1 Linux custom-container web app → persistent `/home` → SQLite → existing application/runtime → public Streamlit/System Health, plus bounded Twelve Data outbound access, update automation, diagnostics, recovery and teardown. No unqualified paid component.
+
+### Container/runtime composition
+Define exact existing .NET/Python/Streamlit processes, startup/supervision ownership, lifecycle/failure behavior, filesystem paths, ports/listeners, environment variables, readiness behavior, graceful shutdown/restart, deterministic build inputs, image metadata and local-development compatibility. Streamlit MUST NOT acquire canonical database/provider/Worker ownership.
+
+### GHCR provenance
+Define image naming, immutable digest, human-readable tags, source-SHA relationship, release-tag relationship, public pull, rollback selection and evidence proving credentials/secrets are absent from layers/history/metadata. No mandatory ACR.
+
+### Azure F1 resource contract
+Freeze minimum region/F1 plan/web-app/settings/storage/runtime configuration, naming, inventory, restart/recycle/redeploy behavior, retention/cleanup, and fail-closed guards preventing paid SKU/dependency selection.
+
+### Persistent SQLite
+Freeze Azure path under `/home`, configurable local path, DELETE journal mode, initialization, schema compatibility, migration ownership, concurrency assumptions, integrity checks, transaction/rollback, restart/redeploy persistence, corruption recovery, reference-grade backup/export and storage-budget guardrails. No Azure SQL adoption.
+
+### Twelve Data and bounded automation
+Freeze secret source/name, request budget, entitlement/rate-limit assumptions, timeout/retry/backoff boundary, update cadence/trigger, workload ownership, missing/invalid-secret behavior, network/provider failure isolation and secret-leak evidence. WP01 performs no provider calls.
+
+### Public Streamlit/System Health
+Freeze public endpoint responsibility, truthful healthy/ready/degraded/empty/failure semantics, freshness/provenance disclosure, safe diagnostics, secret/internal-path suppression and no direct Streamlit SQLite/provider/Worker bypass.
+
+### Reproducibility
+Define clean-clone prerequisites and reproducible build, image publication, Azure deployment/configuration, DB initialization, secret injection, public verification, restart/redeploy verification, rollback/recovery, teardown and cost verification. Identify interactive authenticated steps versus automatable steps.
+
+### Strict-$0 enforcement
+Define fail-closed controls proving no mandatory paid App Service SKU, ACR, Azure Files, Azure SQL, paid monitoring/networking/scaling or other recurring Azure dependency. Final acceptance retains `$0.00`.
+
+### Security/secrets
+Freeze Gitleaks policy, runtime secret injection, image-history/layer inspection, log/public-output inspection, environment redaction, auth-cache/profile exclusion, certificate/private-key exclusion and cleanup. `invalid-wp04-probe-key` remains synthetic historical invalid-auth test data only; scanning is not weakened for other values.
+
+## 5. Application invariants
+Preserve .NET pipeline ownership; canonical visualization/read-model ownership; atomic JSON handoff; Python parser → frame → presentation → Streamlit; Streamlit no SQLite/provider/Worker supervision; separate Release 1.8 JSON-over-stdio; truthful deterministic/replay/simulated provenance; truthful Release 1.10 observability/System Health; existing schema/version boundaries absent separate authority; local development; Azure concerns at deployment/config boundaries where practical.
+
+Any required violation => BLOCK for Luna architecture reconciliation.
+
+## 6. Frozen exclusions
+No Product Release 1.11 resurrection; Release 2.0 ML; Azure SQL; Azure Files; Container Apps; mandatory ACR; paid tiers/networking/monitoring; production SLA/HA; live trading/order execution; portfolio management; ML/backtesting; unrelated schema migration; parallel pipelines; UI/provider/database bypass; unrelated refactors.
+
+## 7. File-manifest reconciliation
+Reconcile the three Release 1.12 planning artifacts and define exact downstream mutation surfaces across root/container files, .NET runtime composition, Python/Streamlit, configuration, `eng/`, tests, docs and GitHub workflows if selected.
+
+Distinguish: (1) WP01 changes; (2) each downstream WP's expected paths; (3) forbidden paths; (4) generated/local/runtime artifacts never committed. No implementation file changes merely to prepare them.
+
+## 8. Downstream WP contract freeze
+Freeze implementation-ready entry contracts for:
+- **WP02 — Productionized Container & Runtime Composition** — GPT-5.6 Terra.
+- **WP03 — GHCR Publication & Azure F1 Deployment Automation** — GPT-5.6 Terra.
+- **WP04 — Persistent SQLite Initialization, Data Update & Recovery** — GPT-5.6 Terra.
+- **WP05 — Twelve Data Runtime Configuration, Secrets & Bounded Automation** — GPT-5.6 Terra.
+- **WP06 — Public Streamlit/System Health Deployment & Truthful Diagnostics** — GPT-5.6 Terra.
+- **WP07 — Deployment Stability, Recovery, Cost & No-Bypass Validation** — GPT-5.6 Terra.
+- **WP08 — Documentation, Operational Runbook & Release Acceptance** — GPT-5.6 Luna final acceptance; Terra only for separately authorized validation/publication/lifecycle mutations.
+
+Each must have dependencies, exact mutation surfaces, forbidden mutations, validation/evidence, exact acceptance marker and lifecycle condition.
+
+## 9. WP01 mutation policy
+Allowed: read-only Git/GitHub reconciliation; `git fetch` with remote-tracking mutation recorded; necessary edits to the three Release 1.12 planning artifacts; one narrowly justified architecture/contract artifact only if existing files cannot coherently hold the contract; documentation-only manifest reconciliation.
+
+Forbidden: production/source implementation; packages; schema; Docker build/push; Azure mutation; GHCR mutation; provider requests; secret mutation; tag/release; commit/push/PR/merge under this authority. No count-padding artifacts.
+
+## 10. GitHub lifecycle
+WP01 is issue **#260**. Verify Open, milestone #63, Project Release `1.12`, Status `Todo` before closure.
+
+Only after exact acceptance: close #260; rely on Project automation for Done; if it does not fire, set Done explicitly; never perform/count redundant status mutation; verify milestone #63 remains Open with seven WPs; verify #261 is next dependency-ready. No other WP closes here.
+
+## 11. Publication boundary
+The planning artifacts are expected unpublished. Determine the coherent publication boundary after WP01 contract edits. Report exact unpublished path set and hand publication to a separate **GPT-5.6 Terra publication authority**. WP02 MUST NOT silently absorb unpublished governance artifacts into an unrelated implementation commit.
+
+## 12. Validation
+Before acceptance: `git diff --check`; established Gitleaks scan; Markdown/reference/path sanity; planning cross-consistency; exact sequence/milestone/issue references; no Product 1.11 resurrection; no Release 2.0 contamination; no unsupported Azure claims; no paid mandatory dependency; no implementation/source/package/schema changes; no secrets/auth caches/environment files; exact mutation audit.
+
+Current Azure capability claims not already proven by feasibility must use authoritative Microsoft evidence or be deferred to downstream empirical validation.
+
+## 13. Mutation accounting
+Report separately: repository files; remote-tracking refs; branches; index; commits; pushes; PRs; issues; Project item/fields; milestone; Azure; Docker/GHCR; provider requests; package/schema/production mutations.
+
+Expected implementation/infrastructure/provider mutations: **0**. Count #260 closure only after acceptance; count Project Status only if explicitly changed.
+
+## 14. Interactive handoff
+For authenticated/local execution provide one bounded batch at a time with purpose, exact PowerShell, classification, expected mutations, requested stdout/stderr/exit codes, then STOP. Never infer success or weaken security.
+
+## 15. Acceptance gates
+A — current-state reconciliation.
+B — deployment/runtime/GHCR/F1/SQLite/provider/public-health/security architecture frozen.
+C — clean-clone reproducibility contract frozen.
+D — strict-$0 fail-closed controls frozen.
+E — WP02–WP08 ownership/evidence/acceptance non-ambiguous.
+F — file manifest accurate without implementation mutation.
+G — whitespace/secrets/references/consistency/governance validation passes.
+H — exact mutation audit; implementation/Azure/Docker/provider/package/schema = zero.
+I — only after A–H, #260 Closed/Done; #63 remains Open.
+
+## 16. Exact markers
+`RELEASE 1.12 WP01 — CURRENT-STATE RECONCILIATION: PASS`
+`RELEASE 1.12 WP01 — DEPLOYMENT ARCHITECTURE CONTRACT: PASS`
+`RELEASE 1.12 WP01 — REPRODUCIBILITY BOUNDARY: PASS`
+`RELEASE 1.12 WP01 — STRICT-ZERO-COST ENFORCEMENT CONTRACT: PASS`
+`RELEASE 1.12 WP01 — DOWNSTREAM WP OWNERSHIP CONTRACT: PASS`
+`RELEASE 1.12 WP01 — FILE MANIFEST RECONCILIATION: PASS`
+`RELEASE 1.12 WP01 — VALIDATION: PASS`
+`RELEASE 1.12 WP01 — MUTATION AUDIT: PASS`
+`RELEASE 1.12 WP01 — RELEASE CONTRACT, DEPLOYMENT ARCHITECTURE & REPRODUCIBILITY BOUNDARY: PASS`
+`RELEASE 1.12 WP01 — GITHUB LIFECYCLE: CLOSED/DONE`
+`RELEASE 1.12 WP02 — EXECUTION AUTHORITY: READY`
+`RELEASE 1.12 WP01 — EXECUTION AUTHORITY COMPLETE`
+
+On unresolved gate:
+`RELEASE 1.12 WP01 — EXECUTION AUTHORITY BLOCKED`
+
+## 17. Completion boundary
+WP01 completes only after the implementation-grade contract and downstream boundaries are frozen, validation/mutation audit pass, and #260 is Closed/Done. WP02 still requires a separate explicit **GPT-5.6 Terra** execution authority.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp01-release-contract-deployment-architecture-reproducibility-boundary-bootstrap.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp01-release-contract-deployment-architecture-reproducibility-boundary-bootstrap.md
@@ -1,0 +1,35 @@
+# GPT-5.6 Luna Bootstrap — Release 1.12 WP01
+
+Execute:
+`release-1.12-wp01-release-contract-deployment-architecture-reproducibility-boundary-authority-luna.md`
+
+**Selected execution model: GPT-5.6 Luna**
+
+Repository: `C:\projects\github\AIQuantTradingResearch`
+
+WP: `#260 — Release Contract, Deployment Architecture & Reproducibility Boundary`
+
+Consume the completed Release 1.12 planning package and freeze the implementation-grade architecture/reproducibility contract for WP02–WP08.
+
+Freshly reconcile local/main, `origin/main`, PR #259 merge `20a8fccd6e7a5b895e717f946f4501edd7ab8ffa`, milestone #63, #260–#267, Project #2 Release `1.12`/Status, and the three local Release 1.12 planning artifacts.
+
+Preserve Product Release 1.11 abandoned/nonexistent; sequence `1.10 → 1.12 → 2.0 → 2.1 → 2.2 → 2.3`; Initiative-1.11 feasibility; Azure F1 West Central US/custom Docker/persistent `/home`/SQLite DELETE/public GHCR/bounded Twelve Data; exact `$0.00`; reference/demo-only claims; established .NET/Python/Streamlit ownership/no-bypass rules.
+
+No production implementation, packages/schema, Azure, Docker/GHCR, provider calls, tags/releases, commit/push/PR/merge under this Luna authority.
+
+Freeze deployment topology, runtime composition, image provenance, F1 resources, SQLite, Twelve Data automation, public System Health, secrets, reproducibility, strict-$0 guards, file ownership, and WP02–WP08 acceptance boundaries. Validate whitespace, Gitleaks, references, consistency, sequence/governance and mutation audit.
+
+Only after all acceptance gates pass: close #260; rely on Project automation for Done or explicitly set Done only if needed; verify #63 remains Open and #261 is next-ready.
+
+If governance artifacts require publication, report the exact unpublished set and hand it to a separate GPT-5.6 Terra publication authority.
+
+For authenticated execution: exact PowerShell batch + purpose + classification + expected mutations + evidence/exit codes, then STOP. Never infer success.
+
+Success:
+`RELEASE 1.12 WP01 — RELEASE CONTRACT, DEPLOYMENT ARCHITECTURE & REPRODUCIBILITY BOUNDARY: PASS`
+`RELEASE 1.12 WP01 — GITHUB LIFECYCLE: CLOSED/DONE`
+`RELEASE 1.12 WP02 — EXECUTION AUTHORITY: READY`
+`RELEASE 1.12 WP01 — EXECUTION AUTHORITY COMPLETE`
+
+Blocked:
+`RELEASE 1.12 WP01 — EXECUTION AUTHORITY BLOCKED`

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp02-literal-file-allowlist-reconciliation-authority-luna.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp02-literal-file-allowlist-reconciliation-authority-luna.md
@@ -1,0 +1,318 @@
+# GPT-5.6 Luna — Release 1.12 WP02 Literal File-Allowlist Reconciliation Authority
+
+**Selected execution model: GPT-5.6 Luna**
+
+## Model authority map
+- **GPT-5.6 Luna** — PRIMARY for this authority: contract interpretation, repository/path reconciliation, architecture ownership, literal allowlist/denylist definition, acceptance criteria, and governance.
+- **GPT-5.6 Terra** — implementation, validation execution, and separately authorized Git/GitHub/Docker mutations only after Luna freezes the literal path contract.
+- **GPT-5.6 Sol** — supporting analysis/synthesis only; never silently replaces Luna or Terra.
+
+## 1. Mission
+
+Resolve the exact blocker preventing Release 1.12 WP02 implementation:
+
+`#261 — Productionized Container & Runtime Composition`
+
+The merged frozen Release 1.12 manifest states that no future implementation path is authorized merely by planning and requires each implementation WP authority to replace that boundary with a **literal file allowlist before mutation**.
+
+This Luna authority must inspect the frozen Release 1.12 planning contract and the current repository tree, then freeze the exact literal repository paths that WP02 may create, modify, delete, or rename.
+
+This is a **read-only governance/reconciliation authority**.
+
+It performs no implementation.
+
+## 2. Canonical starting boundary
+
+Expected implementation/planning base:
+
+`d63f8748772f579f2c46cf79df3563627b31a958`
+
+Expected state:
+- local `main` = `origin/main` at that SHA, 0/0.
+- PR #268 merged with exact 3/3 planning artifacts.
+- #260 WP01 Closed/Done.
+- #261 WP02 Open/Todo.
+- #262 WP03 Open/Todo but dependency-gated.
+- milestone #63 Open, 7 open / 1 closed.
+- Product Release 1.11 abandoned/nonexistent.
+- sequence `1.10 → 1.12 → 2.0 → 2.1 → 2.2 → 2.3`.
+
+Fresh evidence controls if any expected read-only fact has changed.
+
+## 3. Binding source documents
+
+Read in full:
+
+1. `docs/roadmap/release-1.12/RELEASE_1.12_DEFINITION.md`
+2. `docs/roadmap/release-1.12/RELEASE_1.12_EXECUTION_PLAN.md`
+3. `docs/roadmap/release-1.12/RELEASE_1.12_FILE_MANIFEST.md`
+
+Also inspect, read-only, the repository paths necessary to understand existing:
+- container definitions;
+- build/runtime composition;
+- .NET Worker/application startup;
+- Python/Streamlit startup;
+- configuration;
+- JSON handoff;
+- SQLite path handling;
+- observability/System Health boundaries;
+- tests and architecture tests;
+- deployment/runtime scripts.
+
+Do not infer path ownership from filenames alone.
+
+## 4. Binding architecture constraints
+
+The literal allowlist must preserve:
+- Azure App Service Linux F1 target.
+- custom Docker.
+- public/default HTTPS/DNS.
+- persistent `/home`.
+- configuration-driven SQLite with DELETE journal selected.
+- public/free GHCR.
+- strict recurring infrastructure cost `$0.00`.
+- reference/demo-only scope.
+- .NET canonical pipeline ownership.
+- atomic JSON handoff.
+- Python parser → frame → presentation → Streamlit.
+- Streamlit has no SQLite/provider/Worker supervision ownership.
+- Release 1.8 JSON-over-stdio remains separate.
+- Release 1.10 observability/System Health truthfulness.
+- deterministic/replay/simulated provenance.
+- no Azure SQL, Azure Files, Container Apps, mandatory ACR, paid service, ML, backtesting, live trading, or architecture bypass.
+
+## 5. Required reconciliation method
+
+Luna must derive the allowlist from **both**:
+1. the frozen WP02 responsibilities/acceptance contract; and
+2. the empirical current repository structure at the canonical base.
+
+For every proposed path, state:
+- literal repository-relative path;
+- whether it currently exists;
+- permitted operation:
+  - `CREATE`
+  - `MODIFY`
+  - `DELETE`
+  - `RENAME`
+- exact WP02 responsibility requiring it;
+- why the change does not belong to WP03–WP08;
+- whether production/source code is touched;
+- whether tests are required.
+
+No wildcard, glob, directory-only, “such as”, “as needed”, “related files”, or category authorization is sufficient.
+
+## 6. Literal allowlist requirements
+
+The final contract must contain a table titled exactly:
+
+`WP02 LITERAL FILE ALLOWLIST`
+
+Every authorized path must appear as one literal repository-relative path.
+
+If a new file is authorized, name the exact future path.
+
+If an existing file is not necessary, do not authorize it prophylactically.
+
+If Luna cannot determine a necessary exact path without making an implementation-level architecture choice unsupported by the frozen contract, mark that path decision `UNRESOLVED` and BLOCK rather than guessing.
+
+## 7. Explicit denylist
+
+The final contract must also contain:
+
+`WP02 EXPLICIT FILE DENYLIST`
+
+At minimum, explicitly deny literal paths discovered during reconciliation that belong to:
+- WP03 GHCR/Azure deployment automation;
+- WP04 SQLite initialization/update/recovery;
+- WP05 Twelve Data runtime automation/secrets;
+- WP06 public Streamlit/System Health presentation;
+- WP07 stability/cost/no-bypass acceptance;
+- WP08 runbook/final release acceptance;
+- Release 2.0+;
+- Initiative-1.11 historical evidence;
+- unrelated trading/domain/ML/backtesting/schema surfaces.
+
+Directory/category statements may supplement the denylist, but may not replace literal path decisions for plausible nearby implementation candidates.
+
+## 8. Tests and validation-path ownership
+
+Luna must identify exact test paths Terra may modify or create for WP02.
+
+For each test path:
+- literal path;
+- operation;
+- behavior it validates;
+- production path(s) it covers.
+
+If existing test projects can validate WP02 without file mutation, state that explicitly and do not add unnecessary test paths to the allowlist.
+
+## 9. Docker/runtime path decision
+
+Luna must explicitly decide the exact repository paths, if any, for:
+- Dockerfile/container definition;
+- `.dockerignore`;
+- entrypoint/supervision script;
+- runtime configuration;
+- startup/configuration source changes;
+- container-specific test/support files.
+
+Do not authorize GHCR publication/deployment automation merely because Docker is involved.
+
+## 10. Path-set closure rule
+
+At the end of reconciliation, produce a sorted deterministic set:
+
+`WP02_AUTHORIZED_PATH_SET`
+
+The set must be closed: Terra may not mutate any repository path absent from it.
+
+Also report:
+- `AUTHORIZED_PATH_COUNT`
+- `EXISTING_PATH_COUNT`
+- `CREATE_PATH_COUNT`
+- `PRODUCTION_SOURCE_PATH_COUNT`
+- `TEST_PATH_COUNT`
+- `DOC_PATH_COUNT`
+
+A rename counts as both the explicitly named source and destination for authorization purposes.
+
+## 11. Terra handoff contract
+
+If reconciliation passes, Luna must state verbatim:
+
+`GPT-5.6 TERRA WP02 MUTATION CONTRACT: ONLY WP02_AUTHORIZED_PATH_SET MAY BE MUTATED`
+
+The next Terra authority must embed the complete literal set verbatim before implementation.
+
+Terra must block on:
+- any needed path outside the set;
+- any rename destination outside the set;
+- any generated tracked file outside the set;
+- any architecture decision that materially changes the frozen contract.
+
+A later Luna amendment is required to expand the set.
+
+## 12. Read-only mutation prohibition
+
+This authority authorizes:
+- repository reads;
+- Git reads;
+- GitHub reads;
+- local inspection commands that do not alter tracked/untracked repository state.
+
+It does NOT authorize:
+- editing/creating/deleting repository files;
+- staging;
+- commit;
+- push;
+- branch creation;
+- PR creation/merge;
+- issue closure;
+- Project mutation;
+- milestone mutation;
+- Docker build/run;
+- GHCR mutation;
+- Azure mutation;
+- provider request;
+- package installation/change;
+- schema change;
+- production execution.
+
+Temporary read-back files should be avoided. If unavoidable, they must be outside the repository or removed before completion and explicitly accounted for.
+
+## 13. Governance verification
+
+Before completion verify:
+- #261 remains Open/Todo.
+- #262 remains Open/Todo and dependency-gated.
+- milestone #63 remains Open.
+- no lifecycle mutation occurred.
+- canonical base remains unchanged unless an external mutation is discovered.
+- working tree state was not altered by this authority.
+
+Pre-existing unrelated untracked `prompters/` files are not WP02-authorized merely because they exist locally.
+
+## 14. Required output
+
+The final Luna report must include:
+1. canonical base SHA;
+2. planning-contract interpretation;
+3. empirical repository-path findings;
+4. `WP02 LITERAL FILE ALLOWLIST`;
+5. `WP02 EXPLICIT FILE DENYLIST`;
+6. sorted `WP02_AUTHORIZED_PATH_SET`;
+7. path counts;
+8. unresolved decisions, if any;
+9. read-only mutation audit;
+10. exact Terra handoff statement.
+
+## 15. Acceptance gates
+
+### Gate A — base reconciliation
+Canonical base and planning publication proven.
+
+### Gate B — frozen contract interpretation
+The manifest's no-future-path authorization rule is explicitly honored.
+
+### Gate C — repository inspection
+Current implementation structure is empirically inspected.
+
+### Gate D — literal allowlist
+Every authorized mutation path is literal, justified, and operation-scoped.
+
+### Gate E — literal denylist
+Plausible adjacent/out-of-scope paths are explicitly excluded.
+
+### Gate F — path-set closure
+Sorted deterministic authorized set and counts are produced.
+
+### Gate G — architecture preservation
+No path authorization silently moves responsibilities across WP boundaries.
+
+### Gate H — read-only audit
+No repository/Git/GitHub lifecycle/Docker/Azure/provider mutation occurred.
+
+## 16. Required markers
+
+`RELEASE 1.12 WP02 — LITERAL ALLOWLIST BASE RECONCILIATION: PASS`
+
+`RELEASE 1.12 WP02 — FROZEN MANIFEST PATH-AUTHORIZATION RULE: RECONCILED`
+
+`RELEASE 1.12 WP02 — REPOSITORY PATH INSPECTION: PASS`
+
+`RELEASE 1.12 WP02 — LITERAL FILE ALLOWLIST: PASS`
+
+`RELEASE 1.12 WP02 — EXPLICIT FILE DENYLIST: PASS`
+
+`RELEASE 1.12 WP02 — AUTHORIZED PATH SET CLOSURE: PASS`
+
+`RELEASE 1.12 WP02 — ARCHITECTURE & WP OWNERSHIP PRESERVATION: PASS`
+
+`RELEASE 1.12 WP02 — ALLOWLIST RECONCILIATION MUTATION AUDIT: PASS`
+
+Acceptance:
+
+`RELEASE 1.12 WP02 — LITERAL FILE-ALLOWLIST RECONCILIATION: PASS`
+
+Terra handoff:
+
+`GPT-5.6 TERRA WP02 MUTATION CONTRACT: ONLY WP02_AUTHORIZED_PATH_SET MAY BE MUTATED`
+
+`RELEASE 1.12 WP02 — RECONCILED TERRA IMPLEMENTATION AUTHORITY: READY TO CREATE`
+
+Terminal:
+
+`RELEASE 1.12 WP02 — LITERAL FILE-ALLOWLIST RECONCILIATION AUTHORITY COMPLETE`
+
+On any unresolved path/architecture decision:
+
+`RELEASE 1.12 WP02 — LITERAL FILE-ALLOWLIST RECONCILIATION AUTHORITY BLOCKED`
+
+Do not emit PASS or authorize Terra implementation if any necessary mutation path remains unresolved.
+
+## 17. Completion boundary
+
+This authority completes only when Luna has frozen a literal, closed, deterministic WP02 path set supported by both the frozen planning contract and empirical repository structure.
+
+It does not implement WP02 and does not alter #261 lifecycle state.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp02-literal-file-allowlist-reconciliation-bootstrap.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp02-literal-file-allowlist-reconciliation-bootstrap.md
@@ -1,0 +1,51 @@
+# GPT-5.6 Luna Bootstrap — Release 1.12 WP02 Literal File-Allowlist Reconciliation
+
+Execute:
+`release-1.12-wp02-literal-file-allowlist-reconciliation-authority-luna.md`
+
+**Selected execution model: GPT-5.6 Luna**
+
+Repository:
+`C:\projects\github\AIQuantTradingResearch`
+
+Expected canonical base:
+`d63f8748772f579f2c46cf79df3563627b31a958`
+
+WP:
+`#261 — Productionized Container & Runtime Composition`
+
+This is read-only governance reconciliation.
+
+The merged Release 1.12 manifest explicitly does not authorize future implementation paths. Therefore do not implement, edit, stage, commit, branch, push, create/merge a PR, build/run Docker, mutate GitHub lifecycle, Azure, GHCR, provider state, packages, or schema.
+
+Read the three frozen Release 1.12 planning documents in full and inspect the current repository structure empirically.
+
+Then freeze:
+- exact `WP02 LITERAL FILE ALLOWLIST`;
+- exact `WP02 EXPLICIT FILE DENYLIST`;
+- sorted `WP02_AUTHORIZED_PATH_SET`;
+- operation per path (`CREATE`/`MODIFY`/`DELETE`/`RENAME`);
+- justification and WP ownership per path;
+- deterministic path counts.
+
+No wildcard/glob/category authorization is valid.
+
+If an exact required path cannot be selected without an unsupported architecture decision, BLOCK instead of guessing.
+
+Required acceptance:
+
+`RELEASE 1.12 WP02 — LITERAL FILE-ALLOWLIST RECONCILIATION: PASS`
+
+Required Terra handoff:
+
+`GPT-5.6 TERRA WP02 MUTATION CONTRACT: ONLY WP02_AUTHORIZED_PATH_SET MAY BE MUTATED`
+
+`RELEASE 1.12 WP02 — RECONCILED TERRA IMPLEMENTATION AUTHORITY: READY TO CREATE`
+
+Terminal:
+
+`RELEASE 1.12 WP02 — LITERAL FILE-ALLOWLIST RECONCILIATION AUTHORITY COMPLETE`
+
+Blocked:
+
+`RELEASE 1.12 WP02 — LITERAL FILE-ALLOWLIST RECONCILIATION AUTHORITY BLOCKED`

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp02-pr-269-merge-post-merge-lifecycle-authority-terra.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp02-pr-269-merge-post-merge-lifecycle-authority-terra.md
@@ -1,0 +1,456 @@
+# GPT-5.6 Terra — Release 1.12 WP02 PR #269 Merge + Post-Merge Verification & Lifecycle Completion Authority
+
+**Selected execution model: GPT-5.6 Terra**
+
+## Model authority map
+- **GPT-5.6 Luna** — contract, policy, architecture, literal path designation, reconciliation, acceptance criteria, and governance.
+- **GPT-5.6 Terra** — PRIMARY for this authority: PR merge, post-merge validation execution, approved Git/GitHub lifecycle mutations, and WP02 lifecycle completion.
+- **GPT-5.6 Sol** — supporting analysis/synthesis only; never silently replaces Luna or Terra.
+
+## 1. Mission
+
+Complete Release 1.12 WP02 after the implementation authority stopped at the verified PR boundary.
+
+Target WP:
+
+`#261 — Productionized Container & Runtime Composition`
+
+Target PR:
+
+`#269 — Release 1.12 WP02: Productionized Container & Runtime Composition`
+
+This authority authorizes only:
+1. pre-merge reconciliation;
+2. merge of PR #269 if all gates pass;
+3. synchronization of local `main`;
+4. authoritative post-merge payload verification;
+5. required post-merge validation;
+6. exact mutation audit;
+7. closure of #261 only after merged acceptance;
+8. verification of Project #2 lifecycle state;
+9. verification that #262 is next-ready.
+
+It does not authorize implementation changes, path expansion, Azure/GHCR/provider work, or WP03 implementation.
+
+## 2. Canonical pre-merge evidence
+
+Expected:
+- PR #269 Open and non-draft.
+- implementation commit `32924c5bc3f805ef089cf5174aa518a0a9bd7744`.
+- exact PR payload:
+  - `.dockerignore`
+  - `Dockerfile`
+  - `container/entrypoint.sh`
+- payload count 3/3.
+- prior implementation validation:
+  - build 0 warnings / 0 errors;
+  - Architecture 27/27;
+  - Application 136/136;
+  - Python 25/25;
+  - Gitleaks clean;
+  - Docker normal/failure/stop/residue/security checks passed.
+- #261 Open/Todo.
+- #262 Open/Todo.
+- milestone #63 Open.
+- no Azure/GHCR/provider lifecycle mutation.
+- pre-existing unrelated untracked scripts and `prompters/` preserved and unstaged.
+
+Fresh evidence controls if external state changed.
+
+## 3. Binding Luna path contract
+
+The governing Luna amendment remains:
+
+`RELEASE 1.12 WP02 PATH DESIGNATION: LUNA GOVERNANCE AMENDMENT`
+
+`THE FROZEN RELEASE 1.12 MANIFEST REMAINS HISTORICAL; THIS AUTHORITY SUPPLIES THE SEPARATELY REQUIRED WP02 LITERAL PATH CONTRACT`
+
+Binding exact path set:
+
+```text
+.dockerignore
+Dockerfile
+container/entrypoint.sh
+```
+
+This authority MUST prove both PR payload and merged payload remain exactly these three paths.
+
+## 4. Pre-merge reconciliation
+
+Before merge, verify read-only:
+
+### Git
+- intended repository;
+- current `main` and `origin/main` relationship;
+- no local authored tracked modifications interfere;
+- unrelated untracked files identifiable and untouched.
+
+### PR #269
+Verify:
+- number 269;
+- state Open;
+- draft false;
+- base `main`;
+- head commit `32924c5bc3f805ef089cf5174aa518a0a9bd7744`;
+- mergeability acceptable;
+- exactly 3 paths;
+- exactly 3 unique paths;
+- path-set equality with Luna allowlist;
+- no unexpected commits.
+
+### Governance
+Verify:
+- #261 Open/Todo;
+- #262 Open/Todo;
+- milestone #63 Open;
+- Release assignment `1.12`;
+- Release 1.10 historical objects unchanged.
+
+If materially different, STOP and reconcile.
+
+Required marker:
+
+`RELEASE 1.12 WP02 PR #269 — PRE-MERGE RECONCILIATION: PASS`
+
+## 5. Exact pre-merge payload
+
+Required PR #269 path set:
+
+```text
+.dockerignore
+Dockerfile
+container/entrypoint.sh
+```
+
+Emit only if proven:
+
+`RELEASE 1.12 WP02 PR #269 — PRE-MERGE PAYLOAD 3/3: PASS`
+
+Any fourth path blocks merge.
+
+## 6. Merge authorization
+
+If all pre-merge gates pass, this authority authorizes exactly one GitHub merge mutation:
+
+**merge PR #269 into `main`.**
+
+Use normal repository merge policy.
+
+Do not:
+- modify PR content;
+- amend commits;
+- push new commits;
+- force push;
+- retarget base;
+- alter unrelated governance.
+
+Record:
+- merge action;
+- resulting PR state;
+- merged timestamp;
+- merge commit SHA;
+- merge parent SHAs if available.
+
+Required marker:
+
+`RELEASE 1.12 WP02 PR #269 — MERGE: PASS`
+
+## 7. Post-merge main synchronization
+
+After merge:
+- fetch origin;
+- safely update local `main`;
+- local `main` = `origin/main`;
+- ahead/behind `0/0`;
+- do not destructively reset over user work;
+- preserve unrelated untracked files.
+
+Record new canonical `main` SHA.
+
+Required marker:
+
+`RELEASE 1.12 WP02 PR #269 — POST-MERGE MAIN SYNCHRONIZATION: PASS`
+
+## 8. Authoritative merged-payload verification
+
+Do not rely only on `gh pr view --json files`.
+
+Use authoritative Git comparison:
+- identify pre-merge parent/base SHA;
+- identify merge SHA;
+- compare effective merged change;
+- count total paths;
+- count unique paths;
+- prove exact set equality with:
+
+```text
+.dockerignore
+Dockerfile
+container/entrypoint.sh
+```
+
+Required:
+- merged total = 3;
+- merged unique = 3;
+- no head/merge path delta;
+- no unrelated path.
+
+Required markers:
+
+`RELEASE 1.12 WP02 PR #269 — MERGED PAYLOAD 3/3: PASS`
+
+`RELEASE 1.12 WP02 PR #269 — HEAD/MERGE PATH SET EQUALITY: PASS`
+
+If Git proves otherwise, BLOCK lifecycle completion.
+
+## 9. Post-merge validation
+
+Run validation from merged `main`.
+
+### Core validation
+Re-run established canonical commands for:
+- .NET build;
+- Architecture tests;
+- Application tests;
+- Python tests;
+- Gitleaks.
+
+Expected prior baseline:
+- build 0 warnings / 0 errors;
+- Architecture 27/27;
+- Application 136/136;
+- Python 25/25;
+- Gitleaks clean.
+
+Fresh results control.
+
+### Docker validation
+Re-run WP02-relevant Docker checks proving:
+- clean image build;
+- normal container startup;
+- .NET process startup;
+- Streamlit process startup;
+- listener reachable;
+- truthful required-child failure behavior;
+- graceful stop;
+- child cleanup;
+- zero process/listener/container residue;
+- no secret leakage in image/history/logs.
+
+If Docker must run in the user's interactive Windows context, provide exact copy/paste PowerShell commands in bounded batches, classify each batch, state expected mutations and required stdout/stderr/exit-code evidence, then STOP and wait.
+
+Never infer Docker success.
+
+Required marker:
+
+`RELEASE 1.12 WP02 PR #269 — POST-MERGE VALIDATION: PASS`
+
+## 10. No-architecture-bypass verification
+
+Confirm merged `main` preserves:
+- .NET canonical pipeline ownership;
+- JSON handoff ownership;
+- Python/Streamlit presentation boundary;
+- no Streamlit SQLite/provider/Worker-supervision ownership;
+- no source/config/test mutation outside designated files;
+- no Azure deployment logic;
+- no GHCR publication logic;
+- no provider request logic;
+- no schema migration;
+- no package manifest mutation.
+
+Required marker:
+
+`RELEASE 1.12 WP02 PR #269 — ARCHITECTURE & NO-BYPASS: PASS`
+
+## 11. Repository cleanliness
+
+After validation:
+- tracked working-tree changes = zero;
+- staging area empty;
+- unrelated pre-existing untracked scripts and `prompters/` preserved and unstaged;
+- no authority-owned temporary residue in repository.
+
+Required marker:
+
+`RELEASE 1.12 WP02 PR #269 — POST-MERGE CLEANLINESS: PASS`
+
+## 12. WP02 acceptance
+
+Only after merge, synchronization, exact merged payload, head/merge equality, validation, architecture/no-bypass, and cleanliness all pass, emit:
+
+`RELEASE 1.12 WP02 — PRODUCTIONIZED CONTAINER & RUNTIME COMPOSITION: PASS`
+
+This is the lifecycle acceptance gate.
+
+Do not close #261 before this exact marker is justified.
+
+## 13. Lifecycle completion
+
+After exact acceptance:
+
+### Issue
+Close:
+
+`#261 — Productionized Container & Runtime Composition`
+
+### Project #2 Status
+Verify whether GitHub Project automation changes #261 Status to `Done`.
+
+If automation sets Done:
+- make no redundant Status mutation;
+- explicit Project Status mutations = 0.
+
+If automation does not set Done:
+- explicitly set #261 Status to `Done`;
+- count exactly 1 explicit Project Status mutation.
+
+### Milestone
+Verify:
+- milestone #63 remains Open;
+- expected counts transition from 7 open / 1 closed to 6 open / 2 closed.
+
+Do not close milestone #63.
+
+### Next WP
+Verify:
+- #262 remains Open;
+- Release remains `1.12`;
+- dependency gate is satisfied;
+- #262 is next-ready.
+
+Required markers:
+
+`RELEASE 1.12 WP02 — GITHUB LIFECYCLE: CLOSED/DONE`
+
+`RELEASE 1.12 WP03 — EXECUTION AUTHORITY: READY`
+
+## 14. Protected historical state
+
+Verify no mutation to:
+- Initiative-1.11 historical governance;
+- Product Release 1.11 abandoned/nonexistent status;
+- Release 1.10 historical objects;
+- `v1.10.0` target `eb9601596d9a9dd68f1f8a7c963906a76e5a2833`;
+- unrelated Release 2.x milestones.
+
+Required marker:
+
+`RELEASE 1.12 WP02 PR #269 — GOVERNANCE PRESERVATION: PASS`
+
+## 15. Mutation accounting
+
+Report exact counts for:
+- PR merges;
+- fetches;
+- local `main` fast-forwards/synchronizations;
+- authored repository edits;
+- authored commits;
+- pushes;
+- new PRs;
+- issue closures;
+- explicit Project Status mutations;
+- other Project mutations;
+- milestone mutations;
+- tag mutations;
+- release mutations;
+- Docker builds;
+- Docker container runs;
+- Azure mutations;
+- GHCR mutations;
+- provider requests;
+- package changes;
+- schema changes.
+
+Expected protected-domain counts:
+- authored repo edits = 0;
+- authored commits = 0;
+- pushes = 0;
+- new PRs = 0;
+- Azure = 0;
+- GHCR = 0;
+- provider = 0;
+- package = 0;
+- schema = 0;
+- milestone = 0;
+- tag/release = 0.
+
+Expected lifecycle:
+- PR merge = 1;
+- issue closure = 1 after acceptance;
+- explicit Project Status mutation = 0 if automation succeeds, otherwise 1.
+
+Required marker:
+
+`RELEASE 1.12 WP02 PR #269 — MUTATION AUDIT: PASS`
+
+## 16. Stop conditions
+
+STOP and emit BLOCKED if:
+- PR #269 is not the expected Open/non-draft PR;
+- head SHA differs unexpectedly;
+- payload differs from exact 3/3;
+- merge introduces a fourth path;
+- post-merge validation fails;
+- architecture/no-bypass fails;
+- repository is left dirty from authority-owned work;
+- #261 lifecycle cannot be reconciled;
+- Project/Milestone state is inconsistent;
+- any Azure/GHCR/provider/package/schema mutation would be required.
+
+Do not close #261 after failed acceptance.
+
+## 17. Required markers
+
+`RELEASE 1.12 WP02 PR #269 — PRE-MERGE RECONCILIATION: PASS`
+
+`RELEASE 1.12 WP02 PR #269 — PRE-MERGE PAYLOAD 3/3: PASS`
+
+`RELEASE 1.12 WP02 PR #269 — MERGE: PASS`
+
+`RELEASE 1.12 WP02 PR #269 — POST-MERGE MAIN SYNCHRONIZATION: PASS`
+
+`RELEASE 1.12 WP02 PR #269 — MERGED PAYLOAD 3/3: PASS`
+
+`RELEASE 1.12 WP02 PR #269 — HEAD/MERGE PATH SET EQUALITY: PASS`
+
+`RELEASE 1.12 WP02 PR #269 — POST-MERGE VALIDATION: PASS`
+
+`RELEASE 1.12 WP02 PR #269 — ARCHITECTURE & NO-BYPASS: PASS`
+
+`RELEASE 1.12 WP02 PR #269 — POST-MERGE CLEANLINESS: PASS`
+
+`RELEASE 1.12 WP02 PR #269 — GOVERNANCE PRESERVATION: PASS`
+
+`RELEASE 1.12 WP02 — PRODUCTIONIZED CONTAINER & RUNTIME COMPOSITION: PASS`
+
+`RELEASE 1.12 WP02 — GITHUB LIFECYCLE: CLOSED/DONE`
+
+`RELEASE 1.12 WP02 PR #269 — MUTATION AUDIT: PASS`
+
+`RELEASE 1.12 WP03 — EXECUTION AUTHORITY: READY`
+
+Terminal:
+
+`RELEASE 1.12 WP02 — PR #269 MERGE, POST-MERGE VERIFICATION & LIFECYCLE COMPLETION AUTHORITY COMPLETE`
+
+Blocked:
+
+`RELEASE 1.12 WP02 — PR #269 MERGE, POST-MERGE VERIFICATION & LIFECYCLE COMPLETION AUTHORITY BLOCKED`
+
+State the exact failed gate and preserve #261 Open unless acceptance had already been validly established.
+
+## 18. Completion boundary
+
+This authority completes only when:
+- PR #269 is merged;
+- local `main` synchronized;
+- merged payload proven exact 3/3;
+- required post-merge validation passes;
+- WP02 acceptance is justified;
+- #261 is Closed/Done;
+- milestone #63 remains Open;
+- #262 is verified next-ready;
+- exact mutation audit is complete.
+
+No WP03 implementation is authorized here.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp02-pr-269-merge-post-merge-lifecycle-bootstrap.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp02-pr-269-merge-post-merge-lifecycle-bootstrap.md
@@ -1,0 +1,75 @@
+# GPT-5.6 Terra Bootstrap — Release 1.12 WP02 PR #269 Merge + Post-Merge Verification & Lifecycle Completion
+
+Execute:
+
+`release-1.12-wp02-pr-269-merge-post-merge-lifecycle-authority-terra.md`
+
+**Selected execution model: GPT-5.6 Terra**
+
+Repository:
+`C:\projects\github\AIQuantTradingResearch`
+
+Target PR:
+`#269 — Release 1.12 WP02: Productionized Container & Runtime Composition`
+
+Expected head commit:
+`32924c5bc3f805ef089cf5174aa518a0a9bd7744`
+
+Binding exact payload:
+
+```text
+.dockerignore
+Dockerfile
+container/entrypoint.sh
+```
+
+Required pre-merge:
+- PR Open, non-draft, base `main`;
+- exact head SHA;
+- exact 3/3 payload;
+- #261 Open/Todo;
+- #262 Open/Todo;
+- milestone #63 Open;
+- no unexpected governance drift.
+
+If reconciled, merge PR #269.
+
+Then:
+1. fetch and safely synchronize local `main`;
+2. record merge SHA;
+3. use authoritative Git comparison to prove merged payload exactly 3/3;
+4. prove head/merge path-set equality;
+5. rerun required build/tests/Python/Gitleaks;
+6. rerun WP02-relevant Docker normal/failure/stop/residue/security checks;
+7. prove no architecture bypass;
+8. prove clean tracked/staged state and preserve unrelated untracked scripts/`prompters/`.
+
+Only after exact acceptance:
+
+`RELEASE 1.12 WP02 — PRODUCTIONIZED CONTAINER & RUNTIME COMPOSITION: PASS`
+
+close #261.
+
+Verify Project automation sets Done. Do not issue a redundant explicit Status mutation if automation already did so.
+
+Verify milestone #63 remains Open and should become 6 open / 2 closed.
+
+Verify #262 is Open and next-ready.
+
+Required lifecycle marker:
+
+`RELEASE 1.12 WP02 — GITHUB LIFECYCLE: CLOSED/DONE`
+
+Next:
+
+`RELEASE 1.12 WP03 — EXECUTION AUTHORITY: READY`
+
+No Azure/GHCR/provider/package/schema mutation is authorized.
+
+Terminal:
+
+`RELEASE 1.12 WP02 — PR #269 MERGE, POST-MERGE VERIFICATION & LIFECYCLE COMPLETION AUTHORITY COMPLETE`
+
+Blocked:
+
+`RELEASE 1.12 WP02 — PR #269 MERGE, POST-MERGE VERIFICATION & LIFECYCLE COMPLETION AUTHORITY BLOCKED`

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp02-productionized-container-runtime-composition-authority-terra.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp02-productionized-container-runtime-composition-authority-terra.md
@@ -1,0 +1,396 @@
+# GPT-5.6 Terra — Release 1.12 WP02: Productionized Container & Runtime Composition
+## Execution Authority
+
+**Selected execution model: GPT-5.6 Terra**
+
+### Model authority map
+- **GPT-5.6 Luna** — contract, policy, architecture, definition, reconciliation, acceptance criteria, governance, planning.
+- **GPT-5.6 Terra** — PRIMARY for implementation, validation execution, approved repository/Git/GitHub mutations, container build work, and lifecycle completion under this authority.
+- **GPT-5.6 Sol** — supporting analysis only; never silently replaces Luna or Terra.
+
+## Mission
+Execute Release 1.12 WP02: `Productionized Container & Runtime Composition`.
+
+WP02 turns the frozen Release 1.12 deployment/runtime contract into the productionized container/runtime composition required by downstream deployment work.
+
+## Required starting state
+Freshly reconcile:
+- WP01 #260 Closed/Done.
+- WP02 #261 Open/Todo.
+- milestone #63 Open, 7 open / 1 closed.
+- #262–#267 dependency-gated.
+- Product Release 1.11 abandoned/nonexistent.
+- release sequence `1.10 → 1.12 → 2.0 → 2.1 → 2.2 → 2.3`.
+- Initiative-1.11 and Release 1.10 historical governance unchanged.
+
+Expected planning publication:
+- PR #268: `Docs: publish Release 1.12 planning artifacts`
+- branch `docs/release-1.12-planning-artifacts`
+- commit `917207333f133b961f72b94525a17ed0d0aae954`
+- parent `20a8fccd6e7a5b895e717f946f4501edd7ab8ffa`
+- last reported Open, non-draft, exact 3/3 Markdown payload.
+
+## Binding publication gate
+WP02 MUST NOT implement from a stale `main` that lacks the frozen Release 1.12 planning contract.
+
+Before implementation, verify either:
+1. PR #268 has been merged and local/origin `main` contain the exact three planning artifacts; or
+2. a higher explicit authority has reconciled an equivalent publication boundary preserving the frozen contract.
+
+If PR #268 remains Open with no higher reconciliation, BLOCK before production/source mutation.
+
+This authority does not authorize merging PR #268.
+
+## Binding architecture
+Preserve:
+- Azure App Service Linux F1, West Central US.
+- custom Docker.
+- public/default HTTPS/DNS.
+- persistent `/home`.
+- configuration-driven writable SQLite; DELETE journal selected.
+- public/free GHCR.
+- bounded Twelve Data connectivity.
+- strict recurring infrastructure cost `$0.00`.
+- reference/demo-only claims; no production SLA/HA claims.
+- .NET pipeline ownership.
+- atomic JSON handoff to Python.
+- Python parser → frame → presentation → Streamlit.
+- Streamlit does not own SQLite/provider/Worker supervision.
+- Release 1.8 JSON-over-stdio remains separate.
+- Release 1.10 System Health/observability remains truthful.
+- deterministic/replay/simulated provenance remains truthful.
+
+If implementation requires violating any invariant, BLOCK for Luna reconciliation.
+
+## WP02 objective
+Implement a deterministic Linux container/runtime composition suitable for downstream WP03 deployment automation, without Azure resource mutation or provider-side execution.
+
+Prove:
+- exact runtime processes;
+- startup order/supervision;
+- public listener/port;
+- internal communication;
+- readiness/failure semantics;
+- graceful shutdown;
+- deterministic filesystem paths;
+- persistent vs ephemeral storage boundaries;
+- environment/configuration inputs;
+- reproducible build;
+- secret-safe image;
+- local compatibility;
+- bounded behavior suitable for F1;
+- no hidden Azure dependency in application code.
+
+## Runtime composition
+Explicitly account for:
+- .NET Worker/pipeline process;
+- canonical JSON handoff producer;
+- Python/Streamlit process;
+- startup/supervision wrapper if needed;
+- handoff paths;
+- stdout/stderr/log ownership;
+- signal handling;
+- child cleanup;
+- public port exposure.
+
+Supervision must:
+- have one clear container entrypoint;
+- fail closed on unrecoverable startup errors;
+- not conceal child-process failures;
+- avoid orphan/background residue;
+- terminate children on shutdown;
+- preserve useful diagnostics;
+- never make Streamlit owner/supervisor of .NET application responsibilities.
+
+## Container contract
+Implement/reconcile the production container definition:
+- Linux target.
+- deterministic build context.
+- explicit base image(s).
+- governed runtime/tooling versions.
+- no unnecessary build/runtime packages.
+- multi-stage build where appropriate.
+- no credentials/secrets/auth caches in layers.
+- exclude nonessential source/test artifacts from runtime image where practical.
+- deterministic working directories.
+- explicit runtime-user decision.
+- explicit listening port.
+- repository-owned entrypoint/start command.
+- `/home` treated as Azure persistent boundary, not assumed during local build.
+- SQLite path remains configuration-driven.
+
+Do not introduce mandatory ACR, Azure SQL, Azure Files, Container Apps, paid services, or Azure-specific application ownership.
+
+## Configuration/environment
+Implement only the required configuration surface, including as applicable:
+- runtime mode;
+- public port;
+- visualization/read-model handoff path;
+- SQLite path;
+- logging/diagnostics;
+- Twelve Data secret variable name only;
+- downstream data-update control inputs;
+- Streamlit/server binding.
+
+Rules:
+- no secret defaults;
+- no real `.env`;
+- no provider token in image;
+- no GitHub/Azure/Docker auth material;
+- missing secrets must fail safely;
+- defaults remain safe for local development.
+
+## Filesystem contract
+Distinguish:
+1. immutable image content;
+2. ephemeral container filesystem;
+3. persistent Azure `/home`;
+4. generated JSON/read-model handoff;
+5. SQLite DB;
+6. optional persisted diagnostics;
+7. temporary/runtime files.
+
+Do not assume `/home` persistence in ordinary local Docker execution without an explicit mount.
+
+## Health/readiness
+Implement only container/runtime health allocated to WP02.
+
+Distinguish:
+- process started;
+- required child failed;
+- listener unavailable;
+- startup timeout/failure;
+- required handoff path unavailable.
+
+Do not implement WP06 public System Health presentation or claim provider/data freshness from mere container liveness.
+
+## Reproducible local validation
+Provide exact commands for:
+- clean build;
+- image build;
+- local run;
+- optional volume mounts;
+- safe placeholder environment injection;
+- listener verification;
+- process verification;
+- graceful stop;
+- residue check.
+
+Docker Desktop Linux engine/WSL2 execution may require the user's interactive Windows PowerShell context. No Docker pipe ACL/security weakening is authorized.
+
+## Repository mutation surface
+First reconcile the frozen WP01 file manifest and state the exact WP02-owned path set before editing.
+
+Allowed only if assigned to WP02:
+- `Dockerfile`/container definitions;
+- `.dockerignore`;
+- narrow entrypoint/supervision scripts;
+- deployment/runtime configuration;
+- tests for container/runtime composition;
+- WP02 documentation/manifest updates;
+- minimal startup/configuration code strictly required by the contract.
+
+Forbidden without Luna reconciliation:
+- trading logic;
+- ML/backtesting;
+- unrelated domain/business code;
+- unrelated schema;
+- WP03 Azure provisioning;
+- WP04 persistence initialization/recovery;
+- WP05 provider automation;
+- WP06 public System Health UI;
+- WP08 final runbook/release work;
+- unrelated refactors;
+- Release 2.0+ scope;
+- Initiative-1.11 historical evidence.
+
+## Dependency policy
+No package/dependency addition for convenience.
+
+Any new dependency must be necessary, minimal, policy-compatible, justified, and validated. Material unplanned dependency expansion requires Luna reconciliation.
+
+## Validation matrix
+Run the repository's established relevant validation:
+- `git diff --check`;
+- relevant .NET build;
+- affected .NET tests;
+- affected Python tests;
+- architecture tests;
+- Gitleaks;
+- `pip check` if Python dependencies/environment touched;
+- version checks where relevant;
+- real container build;
+- container start;
+- local listener check;
+- process-topology verification;
+- child-failure behavior;
+- graceful stop;
+- zero residual process/listener;
+- image/history secret scan;
+- runtime log/secret disclosure scan;
+- exact changed-path ownership audit.
+
+Never infer Docker validation when it has not executed.
+
+## Container acceptance evidence
+Prove:
+- image builds from clean/reconciled state;
+- image starts with documented safe inputs;
+- required processes start;
+- listener is reachable;
+- startup failures surface truthfully;
+- no orphan residue after stop;
+- paths match contract;
+- SQLite path remains configurable;
+- `/home` is not hard-coded as local-only behavior;
+- provider call is not required just to start;
+- no secret embedded in image/history/layers;
+- no Azure credentials required;
+- no paid component required.
+
+Do not push to GHCR under WP02 unless the frozen manifest explicitly assigns image publication to WP02. Default GHCR publication ownership is WP03.
+
+## Git workflow
+After implementation/validation:
+- inspect the full working tree;
+- selectively stage only WP02-owned paths;
+- prove staged-set equality;
+- inspect cached diff;
+- run `git diff --cached --check`;
+- create a coherent WP02 implementation commit;
+- push a dedicated branch;
+- create a non-draft PR to `main`;
+- verify exact payload/base/head.
+
+Preferred branch:
+`feat/release-1.12-wp02-container-runtime`
+
+Preferred commit:
+`Release 1.12 WP02: productionize container runtime composition`
+
+Preferred PR title:
+`Release 1.12 WP02: Productionized Container & Runtime Composition`
+
+No force push.
+
+## Merge boundary
+Implementation PR merge is NOT automatically authorized by implementation success.
+
+If no separate explicit merge grant exists, stop at a verified open PR and emit:
+
+`RELEASE 1.12 WP02 — IMPLEMENTATION PR MERGE: NOT AUTHORIZED BY THIS AUTHORITY`
+
+If separately authorized, perform exact post-merge verification before lifecycle closure.
+
+## Lifecycle
+Issue #261 MUST NOT close before the exact WP02 acceptance marker and any required post-merge verification.
+
+After true WP02 completion:
+1. close #261;
+2. allow Project automation to set Done;
+3. if automation does not, explicitly set Done;
+4. count only explicit mutations;
+5. verify milestone #63 remains Open;
+6. verify #262 is next-ready.
+
+Do not close #262–#267.
+
+## Mutation accounting
+Report exact counts for:
+- repository files;
+- temporary files;
+- branches;
+- staging/index;
+- commits;
+- pushes;
+- PRs;
+- merges;
+- issue mutations;
+- Project mutations;
+- milestone mutations;
+- tags/releases;
+- Docker image builds;
+- local container runs;
+- GHCR mutations;
+- Azure mutations;
+- provider requests;
+- package changes;
+- schema changes;
+- production/source changes.
+
+Expected:
+- Azure 0
+- provider 0
+- milestone 0
+- tag/release 0
+- GHCR publication 0 unless explicitly assigned
+- issue closure exactly 1 only after acceptance
+- Project Status mutation 0 if automation sets Done
+
+## Interactive handoff
+For Docker/Windows-local work, provide one bounded batch at a time with:
+1. purpose;
+2. exact copy/paste PowerShell;
+3. classification (`READ-ONLY`, `LOCAL REPOSITORY MUTATION`, `LOCAL GIT MUTATION`, `DOCKER LOCAL MUTATION`, `GITHUB MUTATION`);
+4. expected mutations;
+5. exact stdout/stderr/exit codes required;
+6. STOP and wait.
+
+Never infer success or request credential/auth-cache transfer.
+
+## Acceptance gates
+A. Publication/base reconciliation.
+B. Exact WP02-owned manifest.
+C. Container implementation.
+D. Runtime supervision.
+E. Configuration/filesystem correctness.
+F. Secret/security isolation.
+G. Build/test/container validation.
+H. No-bypass/no-scope-drift.
+I. Exact Git/PR payload.
+J. Mutation audit.
+K. Lifecycle closure.
+
+## Required markers
+`RELEASE 1.12 WP02 — PUBLICATION & BASE RECONCILIATION: PASS`
+
+`RELEASE 1.12 WP02 — OWNED FILE MANIFEST: PASS`
+
+`RELEASE 1.12 WP02 — PRODUCTIONIZED CONTAINER DEFINITION: PASS`
+
+`RELEASE 1.12 WP02 — RUNTIME COMPOSITION & SUPERVISION: PASS`
+
+`RELEASE 1.12 WP02 — CONFIGURATION & FILESYSTEM CONTRACT: PASS`
+
+`RELEASE 1.12 WP02 — CONTAINER SECURITY & SECRET ISOLATION: PASS`
+
+`RELEASE 1.12 WP02 — LOCAL CONTAINER BUILD & RUNTIME VALIDATION: PASS`
+
+`RELEASE 1.12 WP02 — NO-BYPASS & SCOPE CONTROL: PASS`
+
+`RELEASE 1.12 WP02 — GIT/PR PAYLOAD VERIFICATION: PASS`
+
+`RELEASE 1.12 WP02 — MUTATION AUDIT: PASS`
+
+WP acceptance:
+`RELEASE 1.12 WP02 — PRODUCTIONIZED CONTAINER & RUNTIME COMPOSITION: PASS`
+
+If merge not authorized:
+`RELEASE 1.12 WP02 — IMPLEMENTATION PR MERGE: NOT AUTHORIZED BY THIS AUTHORITY`
+
+After actual completion:
+`RELEASE 1.12 WP02 — GITHUB LIFECYCLE: CLOSED/DONE`
+
+Next:
+`RELEASE 1.12 WP03 — EXECUTION AUTHORITY: READY`
+
+Terminal:
+`RELEASE 1.12 WP02 — EXECUTION AUTHORITY COMPLETE`
+
+Blocked:
+`RELEASE 1.12 WP02 — EXECUTION AUTHORITY BLOCKED`
+
+## Completion boundary
+WP02 completes only when the frozen planning package is reconciled into the implementation base, the productionized container/runtime composition is implemented and validated, the Git/PR payload is exact, any required merge boundary is satisfied, and #261 is Closed/Done.
+
+WP03 requires a separate explicit GPT-5.6 Terra authority.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp02-productionized-container-runtime-composition-bootstrap.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp02-productionized-container-runtime-composition-bootstrap.md
@@ -1,0 +1,61 @@
+# GPT-5.6 Terra Bootstrap — Release 1.12 WP02
+
+Execute:
+`release-1.12-wp02-productionized-container-runtime-composition-authority-terra.md`
+
+**Selected execution model: GPT-5.6 Terra**
+
+Repository:
+`C:\projects\github\AIQuantTradingResearch`
+
+WP:
+`#261 — Productionized Container & Runtime Composition`
+
+First reconcile the planning-publication gate.
+
+Expected:
+- PR #268 `Docs: publish Release 1.12 planning artifacts`
+- branch `docs/release-1.12-planning-artifacts`
+- commit `917207333f133b961f72b94525a17ed0d0aae954`
+- parent `20a8fccd6e7a5b895e717f946f4501edd7ab8ffa`
+- last reported Open/non-draft/exact 3/3.
+
+Do not begin production/source implementation unless the frozen three-file Release 1.12 planning package is present in the implementation base through a merged or explicitly reconciled publication boundary. This authority does not authorize merging PR #268.
+
+Once that gate passes:
+- read the frozen definition, execution plan, and file manifest;
+- prove exact WP02-owned paths before editing;
+- implement the Linux container/runtime composition;
+- preserve .NET ownership, atomic JSON handoff, Streamlit no-bypass boundaries, truthful observability/provenance, config-driven SQLite, and F1-compatible path semantics;
+- do not provision Azure, push GHCR, call Twelve Data, implement WP04/WP05/WP06 scope, add paid dependencies, or contaminate Release 2.0;
+- execute real local Docker build/run/failure/stop/residue/security validation;
+- selectively stage only WP02 paths;
+- create a dedicated branch/commit/non-draft PR and verify exact payload;
+- do not infer merge authority;
+- close #261 only after actual WP02 completion and verify #262 next-ready.
+
+Preferred branch:
+`feat/release-1.12-wp02-container-runtime`
+
+Preferred commit:
+`Release 1.12 WP02: productionize container runtime composition`
+
+Preferred PR:
+`Release 1.12 WP02: Productionized Container & Runtime Composition`
+
+Interactive Docker work must be exact copy/paste PowerShell batches with purpose, classification, expected mutations, evidence/exit codes, then STOP.
+
+Required acceptance:
+`RELEASE 1.12 WP02 — PRODUCTIONIZED CONTAINER & RUNTIME COMPOSITION: PASS`
+
+Lifecycle:
+`RELEASE 1.12 WP02 — GITHUB LIFECYCLE: CLOSED/DONE`
+
+Next:
+`RELEASE 1.12 WP03 — EXECUTION AUTHORITY: READY`
+
+Terminal:
+`RELEASE 1.12 WP02 — EXECUTION AUTHORITY COMPLETE`
+
+Blocked:
+`RELEASE 1.12 WP02 — EXECUTION AUTHORITY BLOCKED`

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp02-replacement-implementation-authority-terra.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp02-replacement-implementation-authority-terra.md
@@ -1,0 +1,624 @@
+# GPT-5.6 Terra — Release 1.12 WP02 Replacement Implementation Authority
+## Productionized Container & Runtime Composition
+
+**Selected execution model: GPT-5.6 Terra**
+
+## Model authority map
+- **GPT-5.6 Luna** — contract, policy, architecture, definition, reconciliation, acceptance criteria, governance, and literal repository-path designation.
+- **GPT-5.6 Terra** — PRIMARY for this authority: implementation and validation within the exact Luna-designated path contract, approved Git/PR mutations, Docker execution, and WP lifecycle completion when all gates are satisfied.
+- **GPT-5.6 Sol** — supporting analysis/synthesis only; never silently replaces Luna or Terra.
+
+---
+
+## 1. Authority replacement
+
+This authority **replaces the prior category-based GPT-5.6 Terra WP02 implementation authority**.
+
+The prior authority MUST NOT be used independently for mutation because it did not embed the literal path allowlist required by the frozen Release 1.12 manifest.
+
+This replacement authority incorporates the completed Luna governance amendment and is the controlling implementation authority for:
+
+`#261 — Release 1.12 WP02: Productionized Container & Runtime Composition`
+
+---
+
+## 2. Canonical starting state
+
+Expected canonical implementation base:
+
+`d63f8748772f579f2c46cf79df3563627b31a958`
+
+Expected state:
+- local `main` = `origin/main`, ahead/behind `0/0`;
+- Release 1.12 planning artifacts published on `main`;
+- #260 = Closed/Done;
+- #261 = Open/Todo;
+- #262 = Open/Todo and dependency-gated;
+- milestone #63 = Open, 7 open / 1 closed;
+- Initiative-1.11 unchanged;
+- `v1.10.0` remains anchored to `eb9601596d9a9dd68f1f8a7c963906a76e5a2833`.
+
+Fresh reconciliation controls if state has changed externally.
+
+---
+
+## 3. Binding Luna governance amendment
+
+The completed Luna designation established:
+
+`RELEASE 1.12 WP02 PATH DESIGNATION: LUNA GOVERNANCE AMENDMENT`
+
+`THE FROZEN RELEASE 1.12 MANIFEST REMAINS HISTORICAL; THIS AUTHORITY SUPPLIES THE SEPARATELY REQUIRED WP02 LITERAL PATH CONTRACT`
+
+Publication decision:
+
+`WP02 PATH DESIGNATION PUBLICATION REQUIREMENT: NOT REQUIRED`
+
+Binding mutation rule:
+
+`GPT-5.6 TERRA WP02 MUTATION CONTRACT: ONLY WP02_AUTHORIZED_PATH_SET MAY BE MUTATED`
+
+This replacement Terra authority embeds that path set verbatim below.
+
+---
+
+## 4. WP02_AUTHORIZED_PATH_SET — BINDING
+
+```text
+.dockerignore
+Dockerfile
+container/entrypoint.sh
+```
+
+`AUTHORIZED_PATH_COUNT=3`
+
+All three paths were designated by Luna as:
+- currently nonexistent at the designation base;
+- `CREATE` only;
+- mandatory for WP02.
+
+### Per-path authorization
+
+| Literal path | Authorized operation | Classification | WP02 responsibility |
+|---|---|---|---|
+| `.dockerignore` | `CREATE` | Container definition | Exclude secrets, caches, build outputs, and unrelated content from Docker build context |
+| `Dockerfile` | `CREATE` | Container definition | Define reproducible Linux multi-stage runtime composition |
+| `container/entrypoint.sh` | `CREATE` | Runtime supervision script | Start/supervise approved runtime processes; readiness/failure behavior; signal handling; child cleanup |
+
+### Absolute closure rule
+
+Terra MAY mutate only these three literal paths.
+
+Terra MUST BLOCK before mutation of any other tracked or untracked repository path.
+
+This includes:
+- generated tracked files;
+- formatter-generated files;
+- lockfiles;
+- test snapshots;
+- config files;
+- documentation;
+- project files;
+- package manifests;
+- temporary repository files.
+
+If implementation requires any fourth repository path, STOP and request a new GPT-5.6 Luna path-designation amendment.
+
+---
+
+## 5. Explicit denied paths
+
+The Luna designation explicitly denied WP02 mutation of:
+
+```text
+docker-compose.yml
+src/AIQuantTradingResearch.Worker/Program.cs
+src/AIQuantTradingResearch.Infrastructure/PythonIntegration/PythonCapabilityInvoker.cs
+src/AIQuantTradingResearch.Infrastructure/Persistence/Sqlite/SqliteStorageConfiguration.cs
+python/presentation/realtime_financial_visualization.py
+python/presentation/visualization_read_model.py
+requirements.txt
+eng/azure-cli/wp02-azure-cli-docker-app-service/check-docker-6.ps1
+eng/azure-cli/wp02-azure-cli-docker-app-service/check-docker-17.ps1
+eng/azure-cli/wp03-azure-cli-docker-sqlite/check-sqlite-01.ps1
+eng/azure-cli/wp04-azure-cli-docker-conn-12-data/check-conn-01.ps1
+docs/roadmap/release-1.12/RELEASE_1.12_DEFINITION.md
+docs/roadmap/release-1.12/RELEASE_1.12_EXECUTION_PLAN.md
+docs/roadmap/release-1.12/RELEASE_1.12_FILE_MANIFEST.md
+```
+
+The denylist is not exhaustive. Any repository path absent from `WP02_AUTHORIZED_PATH_SET` is forbidden.
+
+Pre-existing untracked `prompters/` content remains excluded.
+
+---
+
+## 6. Binding architecture
+
+Implementation MUST preserve:
+- Azure App Service Linux F1 reference target;
+- West Central US;
+- custom Linux Docker;
+- public/default HTTPS/DNS downstream;
+- persistent `/home` deployment boundary;
+- configuration-driven writable SQLite;
+- SQLite DELETE journal selection;
+- public/free GHCR downstream;
+- strict recurring infrastructure cost `$0.00`;
+- reference/demo-only claims;
+- no production SLA/HA claims;
+- .NET canonical pipeline ownership;
+- atomic JSON handoff;
+- Python parser → frame → presentation → Streamlit;
+- Streamlit no SQLite/provider/Worker-supervision ownership;
+- Release 1.8 JSON-over-stdio separation;
+- Release 1.10 observability/System Health truthfulness;
+- deterministic/replay/simulated provenance.
+
+WP02 MUST NOT introduce Azure SQL, Azure Files, Container Apps, mandatory ACR, paid services, ML, backtesting, live trading, schema migration, or architecture bypass.
+
+---
+
+## 7. Implementation objective
+
+Using only the three authorized new files, implement a productionized Linux container/runtime composition that:
+
+- builds the existing application/runtime without modifying application source;
+- starts the approved .NET Worker/pipeline and Python/Streamlit presentation processes;
+- preserves the existing configuration-driven JSON handoff;
+- preserves existing SQLite configuration ownership without implementing WP04 persistence behavior;
+- exposes the required Streamlit listener;
+- provides deterministic startup and process supervision;
+- surfaces unrecoverable child-process failure truthfully;
+- handles container termination signals;
+- cleans up child processes;
+- does not require provider connectivity merely to start;
+- contains no secrets/auth caches;
+- remains suitable for later Azure F1 deployment by WP03+.
+
+---
+
+## 8. Dockerfile requirements
+
+`Dockerfile` must, within the existing repository architecture:
+
+- target Linux;
+- use deterministic/governed runtime and build images compatible with the repository's current .NET/Python requirements;
+- use multi-stage construction where appropriate;
+- restore/build/publish the existing .NET application without editing project files;
+- prepare the existing Python runtime without modifying `requirements.txt`;
+- include only runtime content required by the approved composition;
+- copy `container/entrypoint.sh`;
+- establish deterministic working directories;
+- define the expected public listener/port behavior;
+- invoke the designated entrypoint;
+- avoid credentials, auth caches, tokens, local `.env`, and developer-only state;
+- not require Azure credentials;
+- not require GHCR/ACR logic;
+- not hard-code provider secrets;
+- not implement WP03 deployment automation.
+
+If a required package cannot be installed from existing governed repository inputs without modifying another path, BLOCK.
+
+---
+
+## 9. .dockerignore requirements
+
+`.dockerignore` must minimize build context and prevent accidental inclusion of inappropriate local content.
+
+It should exclude, where empirically applicable:
+- `.git`;
+- local IDE/editor state;
+- build outputs;
+- test/result caches;
+- Python caches/virtual environments;
+- local secrets/environment files;
+- Azure/GitHub/Docker credential material if present in the repository working context;
+- unrelated local/untracked `prompters/`;
+- other non-runtime local artifacts.
+
+Do not exclude files actually required by the Docker build.
+
+No other ignore/config file may be modified.
+
+---
+
+## 10. Entrypoint/supervision requirements
+
+`container/entrypoint.sh` must be a narrow deployment-composition script, not application business logic.
+
+It must:
+- be suitable for the Linux image;
+- start the existing required .NET and Streamlit processes using existing application/configuration seams;
+- avoid transferring application ownership to Streamlit;
+- preserve JSON handoff ownership;
+- use environment/configuration already supported by the application;
+- expose failures rather than silently restarting forever;
+- propagate/handle termination signals;
+- terminate child processes on shutdown;
+- return a failing exit code for unrecoverable required-child failure;
+- avoid orphan processes;
+- produce useful stdout/stderr diagnostics without exposing secrets;
+- avoid provider calls of its own;
+- avoid Azure CLI/SDK logic;
+- avoid persistence initialization/recovery logic owned by WP04.
+
+If existing applications cannot be composed correctly without source/config changes outside the three paths, BLOCK rather than widening scope.
+
+---
+
+## 11. No-test-file rule
+
+Luna designated:
+
+- no WP02 test path required;
+- existing test projects provide applicable seams;
+- external/container validation is sufficient for WP02-specific composition behavior.
+
+Therefore Terra MUST NOT create or modify repository test files.
+
+Validation may execute existing tests read-only.
+
+---
+
+## 12. No-documentation-file rule
+
+Luna designated no WP02 documentation mutation.
+
+Do not modify planning artifacts, README files, runbooks, or release documentation.
+
+WP08 retains documentation ownership.
+
+---
+
+## 13. No-config/source mutation rule
+
+Luna designated no WP02 path for:
+- Streamlit server configuration;
+- .NET runtime configuration;
+- JSON handoff configuration;
+- SQLite path configuration;
+- additional container health support.
+
+Therefore implementation must consume existing seams through Dockerfile/entrypoint runtime invocation only.
+
+If this proves impossible, BLOCK.
+
+---
+
+## 14. Docker execution handoff
+
+The user's authenticated/interactive Windows environment is the valid Docker Desktop Linux-engine execution context.
+
+When real Docker execution is required, Terra must provide exact copy/paste PowerShell commands in bounded batches.
+
+Each batch must state:
+1. purpose;
+2. exact commands;
+3. classification:
+   - `READ-ONLY`
+   - `DOCKER LOCAL MUTATION`
+   - `LOCAL GIT MUTATION`
+   - `GITHUB MUTATION`
+4. expected mutations;
+5. exact stdout/stderr/exit-code evidence required;
+6. STOP and wait.
+
+Never infer Docker results.
+
+No Docker pipe ACL/security weakening is authorized.
+
+---
+
+## 15. Required validation
+
+### Repository/path validation
+- prove starting working-tree state;
+- identify pre-existing unrelated untracked files;
+- after implementation prove the only repository mutations are the exact three authorized paths;
+- `git diff --check`;
+- no staged mutation before explicit staging phase.
+
+### Existing application validation
+Execute established relevant validation without modifying tests:
+- .NET build;
+- existing relevant .NET tests;
+- architecture tests;
+- Python tests;
+- `pip check` if applicable without environment mutation beyond the approved validation environment;
+- Gitleaks.
+
+Use the repository's current canonical commands discovered from existing governance/scripts/docs.
+
+### Docker build
+Prove a clean image build succeeds.
+
+Record:
+- exact build command;
+- image identifier/tag used locally;
+- exit code;
+- material warnings/errors.
+
+### Runtime
+Prove:
+- container starts;
+- required .NET process starts;
+- Streamlit process starts;
+- expected listener is reachable;
+- startup does not require an Azure credential;
+- startup does not require a provider request;
+- JSON handoff/runtime composition does not bypass existing ownership;
+- configuration remains externally supplied.
+
+### Failure behavior
+Using safe local conditions, prove required-child failure is surfaced truthfully and does not leave the container falsely healthy.
+
+Do not mutate application source/config to induce failure.
+
+### Shutdown/residue
+Prove:
+- graceful container stop;
+- entrypoint receives/handles termination;
+- child processes terminate;
+- no container/process/listener residue remains.
+
+### Secret/image safety
+Inspect:
+- image configuration;
+- image history;
+- relevant runtime logs;
+- build context implications.
+
+Prove no real secrets, auth caches, tokens, or credentials are embedded/disclosed.
+
+### Scope
+Prove:
+- Azure mutations = 0;
+- GHCR mutations = 0;
+- provider requests = 0;
+- package manifest changes = 0;
+- schema changes = 0;
+- repository mutations outside three paths = 0.
+
+---
+
+## 16. Provider and Azure prohibition
+
+WP02 does not authorize:
+- Twelve Data requests;
+- Azure login/resource operations;
+- Azure App Service creation/configuration;
+- GHCR push/publication;
+- ACR;
+- Azure Files;
+- Azure SQL;
+- deployment automation.
+
+Docker validation is local only.
+
+---
+
+## 17. Git workflow
+
+Only after implementation and all pre-PR validations pass:
+
+1. inspect `git status --short`;
+2. prove repository mutation set equals exactly the intended subset of the three authorized paths;
+3. selectively stage literal paths only;
+4. NEVER use `git add .` or `git add -A`;
+5. prove staged-set equality;
+6. inspect `git diff --cached`;
+7. run `git diff --cached --check`;
+8. commit;
+9. push dedicated branch;
+10. create one non-draft PR to `main`;
+11. verify PR payload exactly matches the staged authorized path set.
+
+Preferred branch:
+
+`feat/release-1.12-wp02-container-runtime`
+
+Preferred commit:
+
+`Release 1.12 WP02: productionize container runtime composition`
+
+Preferred PR title:
+
+`Release 1.12 WP02: Productionized Container & Runtime Composition`
+
+No force push.
+
+---
+
+## 18. PR merge authority
+
+This replacement authority authorizes implementation, validation, branch/commit/push, and creation of the WP02 implementation PR.
+
+**It does not authorize merging the WP02 implementation PR.**
+
+After verified PR creation emit:
+
+`RELEASE 1.12 WP02 — IMPLEMENTATION PR MERGE: NOT AUTHORIZED BY THIS AUTHORITY`
+
+A separate narrow GPT-5.6 Terra merge + post-merge verification authority is required.
+
+Accordingly, #261 MUST remain Open/Todo after this authority stops at the verified PR boundary.
+
+---
+
+## 19. Lifecycle boundary
+
+Do NOT close #261 under this authority unless a later explicit authority expands the boundary to include merge/post-merge/lifecycle completion.
+
+The governed sequence is:
+
+1. this replacement Terra authority implements/validates and creates exact WP02 PR;
+2. separate Terra authority merges and verifies it;
+3. only after exact WP02 acceptance on merged `main`, close #261;
+4. allow Project automation to set Done;
+5. explicitly set Done only if automation does not;
+6. verify milestone #63 remains Open;
+7. verify #262 becomes next-ready.
+
+Never close #261 before merged acceptance.
+
+---
+
+## 20. Mutation accounting
+
+Report exact counts for:
+- repository files created;
+- repository files modified;
+- repository files deleted;
+- temporary files created/removed;
+- Docker image builds;
+- local container runs;
+- branches;
+- staging mutations;
+- commits;
+- pushes;
+- PRs;
+- PR merges;
+- issue mutations;
+- Project mutations;
+- milestone mutations;
+- tag/release mutations;
+- Azure mutations;
+- GHCR mutations;
+- provider requests;
+- package changes;
+- schema changes.
+
+Expected repository path ceiling: 3.
+
+Expected protected domains:
+- PR merge = 0
+- issue = 0
+- Project = 0
+- milestone = 0
+- tag/release = 0
+- Azure = 0
+- GHCR = 0
+- provider = 0
+- package manifest = 0
+- schema = 0
+
+---
+
+## 21. Stop conditions
+
+Immediately BLOCK if:
+- canonical base/governance cannot be reconciled;
+- any authorized path unexpectedly already exists with unreconciled content;
+- a fourth repository path is required;
+- an authorized path requires an operation other than `CREATE`;
+- application source/config must change;
+- a package manifest must change;
+- a schema change is needed;
+- Docker composition would bypass .NET/Python/Streamlit ownership;
+- provider connectivity is required merely to start;
+- secrets would need to enter the image;
+- real Docker validation cannot be executed/proven;
+- exact PR payload cannot be proven.
+
+Do not improvise around a stop condition.
+
+---
+
+## 22. Acceptance gates
+
+### Gate A — base/governance reconciliation
+Canonical base, planning publication, Luna amendment, and #261 state proven.
+
+### Gate B — literal path contract
+Exact three-path `CREATE`-only allowlist acknowledged before mutation.
+
+### Gate C — implementation
+All required composition implemented using only those paths.
+
+### Gate D — architecture/no-bypass
+Existing ownership and cross-WP boundaries preserved.
+
+### Gate E — existing test suite
+Relevant build/tests/Gitleaks pass without test/source mutation.
+
+### Gate F — real Docker validation
+Build/start/listener/process/failure/shutdown/residue behavior proven.
+
+### Gate G — secret isolation
+Build context/image/history/logs are clean.
+
+### Gate H — mutation-set closure
+Repository mutations remain a subset of exactly the three authorized paths.
+
+### Gate I — Git/PR integrity
+Selective staging, commit, push, and non-draft PR payload proven exact.
+
+### Gate J — mutation audit
+All mutations accounted for and protected domains remain zero.
+
+---
+
+## 23. Required markers
+
+`RELEASE 1.12 WP02 — REPLACEMENT AUTHORITY BASE RECONCILIATION: PASS`
+
+`RELEASE 1.12 WP02 — LUNA LITERAL PATH CONTRACT: PASS`
+
+`RELEASE 1.12 WP02 — AUTHORIZED PATH MUTATION CLOSURE: PASS`
+
+`RELEASE 1.12 WP02 — PRODUCTIONIZED CONTAINER DEFINITION: PASS`
+
+`RELEASE 1.12 WP02 — RUNTIME COMPOSITION & SUPERVISION: PASS`
+
+`RELEASE 1.12 WP02 — ARCHITECTURE & NO-BYPASS: PASS`
+
+`RELEASE 1.12 WP02 — EXISTING BUILD & TEST VALIDATION: PASS`
+
+`RELEASE 1.12 WP02 — LOCAL DOCKER BUILD & RUNTIME VALIDATION: PASS`
+
+`RELEASE 1.12 WP02 — CONTAINER SECRET ISOLATION: PASS`
+
+`RELEASE 1.12 WP02 — GIT/PR PAYLOAD VERIFICATION: PASS`
+
+`RELEASE 1.12 WP02 — MUTATION AUDIT: PASS`
+
+Implementation acceptance:
+
+`RELEASE 1.12 WP02 — PRODUCTIONIZED CONTAINER & RUNTIME COMPOSITION: PASS`
+
+Required boundary:
+
+`RELEASE 1.12 WP02 — IMPLEMENTATION PR MERGE: NOT AUTHORIZED BY THIS AUTHORITY`
+
+Next governance action:
+
+`RELEASE 1.12 WP02 — MERGE + POST-MERGE VERIFICATION AUTHORITY: READY TO CREATE`
+
+Terminal:
+
+`RELEASE 1.12 WP02 — REPLACEMENT IMPLEMENTATION AUTHORITY COMPLETE`
+
+On failure:
+
+`RELEASE 1.12 WP02 — REPLACEMENT IMPLEMENTATION AUTHORITY BLOCKED`
+
+State the exact failed gate and perform no lifecycle closure.
+
+---
+
+## 24. Completion boundary
+
+This authority completes at a validated, pushed, exact-scope, non-draft WP02 implementation PR.
+
+It does not merge that PR and does not close #261.
+
+The implementation is constrained absolutely to:
+
+```text
+.dockerignore
+Dockerfile
+container/entrypoint.sh
+```
+
+Any expansion requires a new GPT-5.6 Luna governance amendment.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp02-replacement-implementation-bootstrap.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp02-replacement-implementation-bootstrap.md
@@ -1,0 +1,89 @@
+# GPT-5.6 Terra Bootstrap — Release 1.12 WP02 Replacement Implementation
+
+Execute:
+
+`release-1.12-wp02-replacement-implementation-authority-terra.md`
+
+**Selected execution model: GPT-5.6 Terra**
+
+Repository:
+`C:\projects\github\AIQuantTradingResearch`
+
+Expected base:
+`d63f8748772f579f2c46cf79df3563627b31a958`
+
+WP:
+`#261 — Productionized Container & Runtime Composition`
+
+This authority replaces the earlier category-based Terra WP02 authority.
+
+## Binding literal mutation contract
+
+`GPT-5.6 TERRA WP02 MUTATION CONTRACT: ONLY WP02_AUTHORIZED_PATH_SET MAY BE MUTATED`
+
+```text
+.dockerignore
+Dockerfile
+container/entrypoint.sh
+```
+
+All three are `CREATE` only.
+
+Any other repository path is forbidden. If a fourth path, source/config edit, package/schema change, generated tracked file, or different operation is required: STOP and emit BLOCKED. Do not improvise.
+
+The Luna designation explicitly requires no WP02 mutation to existing application source, tests, configuration, planning docs, SQLite implementation, provider logic, or Streamlit presentation code.
+
+Implement the productionized Linux Docker/runtime composition using only those three paths.
+
+Validate:
+- existing build/tests/architecture/Python/Gitleaks as applicable;
+- real local Docker build;
+- required .NET + Streamlit runtime processes;
+- listener;
+- truthful required-child failure;
+- graceful stop;
+- zero process/listener residue;
+- image/history/log secret isolation;
+- zero Azure/GHCR/provider mutation.
+
+For Docker execution in the interactive Windows user context, provide exact bounded PowerShell batches, classify mutations, request stdout/stderr/exit codes, then STOP and wait.
+
+After validation:
+- selectively stage only literal authorized paths;
+- never `git add .` or `git add -A`;
+- create dedicated branch/commit/push;
+- create one non-draft WP02 PR;
+- verify exact PR payload.
+
+Preferred branch:
+`feat/release-1.12-wp02-container-runtime`
+
+Preferred commit:
+`Release 1.12 WP02: productionize container runtime composition`
+
+Preferred PR:
+`Release 1.12 WP02: Productionized Container & Runtime Composition`
+
+Merge is NOT authorized.
+
+Do not close #261.
+
+Required acceptance:
+
+`RELEASE 1.12 WP02 — PRODUCTIONIZED CONTAINER & RUNTIME COMPOSITION: PASS`
+
+Boundary:
+
+`RELEASE 1.12 WP02 — IMPLEMENTATION PR MERGE: NOT AUTHORIZED BY THIS AUTHORITY`
+
+Next:
+
+`RELEASE 1.12 WP02 — MERGE + POST-MERGE VERIFICATION AUTHORITY: READY TO CREATE`
+
+Terminal:
+
+`RELEASE 1.12 WP02 — REPLACEMENT IMPLEMENTATION AUTHORITY COMPLETE`
+
+Blocked:
+
+`RELEASE 1.12 WP02 — REPLACEMENT IMPLEMENTATION AUTHORITY BLOCKED`

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp02-repository-path-designation-authority-luna.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp02-repository-path-designation-authority-luna.md
@@ -1,0 +1,403 @@
+# GPT-5.6 Luna — Release 1.12 WP02 Repository Path Designation Authority
+
+**Selected execution model: GPT-5.6 Luna**
+
+## Model authority map
+- **GPT-5.6 Luna** — PRIMARY: architecture/path ownership decision, repository-structure reconciliation, literal path designation, governance amendment definition, acceptance criteria.
+- **GPT-5.6 Terra** — implementation and separately authorized Git/GitHub/Docker mutations only after this designation is frozen and embedded in a Terra authority.
+- **GPT-5.6 Sol** — supporting analysis only; never silently replaces Luna or Terra.
+
+## 1. Mission
+
+Resolve the remaining architecture/governance blocker for:
+
+`Release 1.12 WP02 — #261 Productionized Container & Runtime Composition`
+
+The merged planning package is published, but its manifest intentionally authorizes no future implementation paths. The prior literal-allowlist reconciliation correctly BLOCKED because no literal WP02 paths existed from which an allowlist could be mechanically derived.
+
+This authority therefore makes the missing **Luna architecture/path-ownership decision**.
+
+Luna must inspect the frozen Release 1.12 contract and empirical repository structure, designate the exact repository paths WP02 is permitted to own, and produce a closed literal path contract suitable for direct embedding in a replacement GPT-5.6 Terra WP02 implementation authority.
+
+This authority is **read-only**. It designates paths; it does not implement or publish them.
+
+## 2. Canonical starting state
+
+Expected canonical base:
+
+`d63f8748772f579f2c46cf79df3563627b31a958`
+
+Expected governance:
+- Release 1.12 planning artifacts are present on `main`.
+- #260 = Closed/Done.
+- #261 = Open/Todo.
+- #262 = Open/Todo but dependency-gated.
+- milestone #63 = Open, 7 open / 1 closed.
+- Initiative-1.11 unchanged.
+- Product Release 1.11 remains abandoned/nonexistent.
+- release sequence remains `1.10 → 1.12 → 2.0 → 2.1 → 2.2 → 2.3`.
+
+Fresh read-only evidence controls if state differs.
+
+## 3. Binding planning sources
+
+Read in full:
+1. `docs/roadmap/release-1.12/RELEASE_1.12_DEFINITION.md`
+2. `docs/roadmap/release-1.12/RELEASE_1.12_EXECUTION_PLAN.md`
+3. `docs/roadmap/release-1.12/RELEASE_1.12_FILE_MANIFEST.md`
+
+Treat the manifest's no-future-path authorization clause as binding.
+
+This authority is the explicit separate architecture decision required to move from category-level WP responsibility to literal path ownership.
+
+## 4. Empirical repository inspection
+
+Inspect enough of the current repository, read-only, to understand the actual implementation topology, including:
+- root build/container/deployment files;
+- .NET solution/project layout;
+- Worker/pipeline startup and configuration;
+- JSON handoff implementation;
+- Python package/application layout;
+- Streamlit startup/presentation boundary;
+- SQLite configuration/path handling;
+- observability/System Health surfaces;
+- existing scripts;
+- existing tests/architecture tests;
+- existing ignore/configuration files.
+
+Use actual repository evidence, not conventional filenames or hypothetical structure.
+
+## 5. Architecture constraints
+
+Path designation MUST preserve:
+- Azure App Service Linux F1 reference target.
+- custom Linux Docker.
+- persistent `/home` deployment boundary.
+- configuration-driven writable SQLite.
+- SQLite DELETE journal selection.
+- public/free GHCR downstream publication.
+- strict recurring infrastructure cost `$0.00`.
+- reference/demo-only scope and no SLA/HA claim.
+- .NET canonical pipeline ownership.
+- atomic JSON handoff.
+- Python parser → frame → presentation → Streamlit.
+- Streamlit no SQLite/provider/Worker-supervision ownership.
+- Release 1.8 JSON-over-stdio separation.
+- Release 1.10 observability/System Health truthfulness.
+- deterministic/replay/simulated provenance.
+
+Do not designate paths that introduce Azure SQL, Azure Files, Container Apps, mandatory ACR, paid services, ML, backtesting, live trading, schema migration, or ownership bypass.
+
+## 6. Luna designation authority
+
+Unlike the prior mechanical allowlist reconciliation, this authority MAY make the missing architecture decision about where WP02-owned container/runtime composition belongs in the repository.
+
+For every designated path, Luna must decide:
+- exact repository-relative path;
+- current existence;
+- operation authorization:
+  - `CREATE`
+  - `MODIFY`
+  - `DELETE`
+  - `RENAME`
+- ownership rationale;
+- runtime responsibility;
+- why WP02 rather than WP03–WP08 owns it;
+- production/source/test/docs classification;
+- whether the path is mandatory or optional within the frozen design.
+
+Do not authorize broad directories, globs, or unspecified future paths.
+
+## 7. Minimal-path principle
+
+Designate the smallest coherent path set that can implement and validate WP02.
+
+Do not authorize paths merely because they might be convenient.
+
+Prefer:
+- deployment-composition boundaries over business-logic changes;
+- existing configuration extension points over architectural rewrites;
+- narrow entrypoint/supervision artifacts over new frameworks;
+- existing test projects over unnecessary new test infrastructure.
+
+If a production-source modification is avoidable through container/runtime composition, do not designate it.
+
+## 8. Required explicit decisions
+
+Luna must explicitly decide whether WP02 owns a literal path for each of these categories:
+
+- Dockerfile/container definition;
+- `.dockerignore`;
+- container entrypoint/supervision;
+- Streamlit container/server configuration;
+- .NET runtime configuration needed only for container execution;
+- JSON handoff path configuration;
+- SQLite path configuration;
+- health/readiness support at container/runtime level;
+- tests for entrypoint/process supervision;
+- tests for configuration/filesystem behavior;
+- documentation directly required to make WP02 reproducible.
+
+For every category, output either:
+- `DESIGNATED: <literal path(s)>`, or
+- `NO WP02 PATH REQUIRED`, with rationale.
+
+## 9. WP boundary protection
+
+Explicitly distinguish and exclude path ownership for:
+
+### WP03
+GHCR publication and Azure F1 deployment automation.
+
+### WP04
+Persistent SQLite initialization, data update, recovery, and persistence workflows.
+
+### WP05
+Twelve Data runtime secret/provider automation and bounded scheduling.
+
+### WP06
+Public Streamlit/System Health deployment/presentation and truthful public diagnostics.
+
+### WP07
+Deployment stability, recovery, cost, and no-bypass validation.
+
+### WP08
+Operational runbook, final documentation, release acceptance/publication.
+
+A path must not be assigned to WP02 if its primary purpose belongs to one of these WPs.
+
+## 10. Literal designation table
+
+Produce a table titled exactly:
+
+`WP02 REPOSITORY PATH DESIGNATION`
+
+Columns:
+- `Path`
+- `Exists`
+- `Authorized Operation`
+- `Classification`
+- `Mandatory/Optional`
+- `WP02 Responsibility`
+- `Boundary Rationale`
+
+Every row must contain one literal path.
+
+No wildcard/glob row is valid.
+
+## 11. Closed authorized path set
+
+Produce a sorted deterministic block titled:
+
+`WP02_AUTHORIZED_PATH_SET`
+
+Every path from the designation table that Terra may mutate must appear exactly once.
+
+Report:
+- `AUTHORIZED_PATH_COUNT`
+- `EXISTING_PATH_COUNT`
+- `CREATE_PATH_COUNT`
+- `MODIFY_PATH_COUNT`
+- `DELETE_PATH_COUNT`
+- `RENAME_PATH_COUNT`
+- `PRODUCTION_SOURCE_PATH_COUNT`
+- `TEST_PATH_COUNT`
+- `CONFIG_PATH_COUNT`
+- `SCRIPT_PATH_COUNT`
+- `DOC_PATH_COUNT`
+
+If a rename is authorized, both literal source and destination must be represented and the semantics explained.
+
+## 12. Explicit denylist
+
+Produce:
+
+`WP02_EXPLICIT_DENIED_PATH_SET`
+
+Include literal plausible-neighbor paths inspected during reconciliation that must not be mutated by WP02 because they belong to another WP or violate architecture.
+
+Supplementary directory/category denials are allowed, but cannot replace literal decisions for empirically plausible candidate paths.
+
+## 13. Governance amendment contract
+
+Because the frozen manifest itself contains no literal paths, this designation is a new Luna governance decision.
+
+The report must state:
+
+`RELEASE 1.12 WP02 PATH DESIGNATION: LUNA GOVERNANCE AMENDMENT`
+
+and:
+
+`THE FROZEN RELEASE 1.12 MANIFEST REMAINS HISTORICAL; THIS AUTHORITY SUPPLIES THE SEPARATELY REQUIRED WP02 LITERAL PATH CONTRACT`
+
+Do not silently rewrite history or claim the original manifest contained these paths.
+
+## 14. Publication decision
+
+Luna must decide whether this designation must itself be committed/published before Terra implementation.
+
+Output exactly one:
+
+`WP02 PATH DESIGNATION PUBLICATION REQUIREMENT: REQUIRED`
+
+or
+
+`WP02 PATH DESIGNATION PUBLICATION REQUIREMENT: NOT REQUIRED`
+
+with governance rationale.
+
+If publication is REQUIRED:
+- this authority still performs no mutation;
+- specify the exact future governance-artifact path to be published;
+- Terra implementation remains blocked until a separate publication authority completes.
+
+If publication is NOT REQUIRED:
+- explain why the authority output itself is sufficient as the separately required literal contract;
+- a replacement Terra authority may then embed it verbatim.
+
+Do not leave publication requirement ambiguous.
+
+## 15. Terra replacement-authority contract
+
+If path designation is complete and any required publication prerequisite is satisfied/not required, emit:
+
+`GPT-5.6 TERRA WP02 MUTATION CONTRACT: ONLY WP02_AUTHORIZED_PATH_SET MAY BE MUTATED`
+
+The replacement Terra authority must:
+- embed the entire path set verbatim;
+- preserve operation restrictions per path;
+- block on any required path outside the set;
+- block on generated tracked files outside the set;
+- block on architecture changes beyond this designation;
+- require a new Luna amendment to expand the set.
+
+The prior category-based Terra WP02 authority must not be treated as sufficient by itself.
+
+## 16. Read-only prohibition
+
+Authorized:
+- repository reads;
+- Git reads;
+- GitHub reads;
+- read-only filesystem inspection.
+
+Not authorized:
+- repository edits/creates/deletes;
+- staging;
+- commits;
+- branches;
+- pushes;
+- PR creation/merge;
+- issue/Project/milestone mutation;
+- Docker build/run;
+- GHCR;
+- Azure;
+- provider requests;
+- package changes/installations;
+- schema changes;
+- production execution.
+
+Avoid temporary files. If unavoidable, create them outside the repository, remove them, and report them.
+
+## 17. Governance verification
+
+Before completion verify:
+- #261 remains Open/Todo.
+- #262 remains dependency-gated.
+- milestone #63 remains Open.
+- no lifecycle mutation occurred.
+- canonical base did not change due to this authority.
+- working tree was not altered.
+- pre-existing unrelated untracked `prompters/` remains outside the designated set unless Luna explicitly and justifiably designates a literal path there; default expectation is exclusion.
+
+## 18. Required output
+
+Final report must contain:
+1. canonical base SHA;
+2. frozen-contract findings;
+3. empirical repository findings;
+4. category-by-category designation decisions;
+5. `WP02 REPOSITORY PATH DESIGNATION`;
+6. `WP02_AUTHORIZED_PATH_SET`;
+7. counts;
+8. `WP02_EXPLICIT_DENIED_PATH_SET`;
+9. governance-amendment statement;
+10. publication requirement decision;
+11. read-only mutation audit;
+12. Terra replacement-authority handoff or exact blocker.
+
+## 19. Acceptance gates
+
+### Gate A — base/planning reconciliation
+Published contract and canonical base proven.
+
+### Gate B — empirical topology
+Actual repository structure inspected sufficiently to make path decisions.
+
+### Gate C — architecture designation
+Missing path ownership is explicitly decided by Luna rather than inferred by Terra.
+
+### Gate D — literal closure
+Every authorized mutation path is literal and the set is deterministic/closed.
+
+### Gate E — WP boundary preservation
+WP03–WP08 ownership is not preempted.
+
+### Gate F — governance amendment truthfulness
+Original manifest is not retroactively misrepresented.
+
+### Gate G — publication requirement
+Required/not-required decision is explicit.
+
+### Gate H — read-only audit
+No mutation occurred.
+
+## 20. Required markers
+
+`RELEASE 1.12 WP02 — PATH DESIGNATION BASE RECONCILIATION: PASS`
+
+`RELEASE 1.12 WP02 — EMPIRICAL REPOSITORY TOPOLOGY: PASS`
+
+`RELEASE 1.12 WP02 — LUNA ARCHITECTURE PATH DESIGNATION: PASS`
+
+`RELEASE 1.12 WP02 — AUTHORIZED PATH SET CLOSURE: PASS`
+
+`RELEASE 1.12 WP02 — CROSS-WP PATH OWNERSHIP: PASS`
+
+`RELEASE 1.12 WP02 — PATH DESIGNATION GOVERNANCE AMENDMENT: PASS`
+
+`RELEASE 1.12 WP02 — PATH DESIGNATION PUBLICATION DECISION: PASS`
+
+`RELEASE 1.12 WP02 — PATH DESIGNATION MUTATION AUDIT: PASS`
+
+Acceptance:
+
+`RELEASE 1.12 WP02 — REPOSITORY PATH DESIGNATION: PASS`
+
+Governance amendment:
+
+`RELEASE 1.12 WP02 PATH DESIGNATION: LUNA GOVERNANCE AMENDMENT`
+
+`THE FROZEN RELEASE 1.12 MANIFEST REMAINS HISTORICAL; THIS AUTHORITY SUPPLIES THE SEPARATELY REQUIRED WP02 LITERAL PATH CONTRACT`
+
+If ready for Terra:
+
+`GPT-5.6 TERRA WP02 MUTATION CONTRACT: ONLY WP02_AUTHORIZED_PATH_SET MAY BE MUTATED`
+
+`RELEASE 1.12 WP02 — REPLACEMENT TERRA IMPLEMENTATION AUTHORITY: READY TO CREATE`
+
+Terminal:
+
+`RELEASE 1.12 WP02 — REPOSITORY PATH DESIGNATION AUTHORITY COMPLETE`
+
+If unresolved:
+
+`RELEASE 1.12 WP02 — REPOSITORY PATH DESIGNATION AUTHORITY BLOCKED`
+
+State the exact unresolved architecture/path/publication decision and do not authorize implementation.
+
+## 21. Completion boundary
+
+This authority completes only after Luna makes the missing architecture/path-ownership decision, freezes a closed literal WP02 path set, explicitly resolves whether that designation requires publication, and preserves all WP boundaries without mutation.
+
+It does not implement WP02 and does not close #261.

--- a/docs/roadmap/release-1.12/prompters/release-1.12-wp02-repository-path-designation-bootstrap.md
+++ b/docs/roadmap/release-1.12/prompters/release-1.12-wp02-repository-path-designation-bootstrap.md
@@ -1,0 +1,59 @@
+# GPT-5.6 Luna Bootstrap — Release 1.12 WP02 Repository Path Designation
+
+Execute:
+`release-1.12-wp02-repository-path-designation-authority-luna.md`
+
+**Selected execution model: GPT-5.6 Luna**
+
+Repository:
+`C:\projects\github\AIQuantTradingResearch`
+
+Expected base:
+`d63f8748772f579f2c46cf79df3563627b31a958`
+
+WP:
+`#261 — Productionized Container & Runtime Composition`
+
+This is the explicit architecture/path-ownership decision that the frozen manifest requires before WP02 mutation.
+
+Read the three Release 1.12 planning artifacts in full and inspect the empirical repository topology read-only.
+
+Unlike the prior mechanical reconciliation, this Luna authority MAY decide where WP02-owned Docker/runtime composition belongs. It must freeze exact literal paths, operations, rationale, cross-WP boundaries, a closed `WP02_AUTHORIZED_PATH_SET`, and a literal denylist.
+
+No globs, wildcard paths, category-only permissions, or Terra-selected paths are allowed.
+
+Explicitly decide paths for Dockerfile, `.dockerignore`, entrypoint/supervision, runtime configuration, JSON/SQLite path configuration, container health support, tests, and any directly required WP02 documentation—or state `NO WP02 PATH REQUIRED` per category.
+
+Also decide exactly whether this Luna designation itself must be published before implementation:
+
+`WP02 PATH DESIGNATION PUBLICATION REQUIREMENT: REQUIRED`
+
+or
+
+`WP02 PATH DESIGNATION PUBLICATION REQUIREMENT: NOT REQUIRED`
+
+No repository/Git/GitHub lifecycle/Docker/Azure/GHCR/provider/package/schema mutation is authorized.
+
+Required acceptance:
+
+`RELEASE 1.12 WP02 — REPOSITORY PATH DESIGNATION: PASS`
+
+Required amendment truth:
+
+`RELEASE 1.12 WP02 PATH DESIGNATION: LUNA GOVERNANCE AMENDMENT`
+
+`THE FROZEN RELEASE 1.12 MANIFEST REMAINS HISTORICAL; THIS AUTHORITY SUPPLIES THE SEPARATELY REQUIRED WP02 LITERAL PATH CONTRACT`
+
+If Terra can proceed after this decision:
+
+`GPT-5.6 TERRA WP02 MUTATION CONTRACT: ONLY WP02_AUTHORIZED_PATH_SET MAY BE MUTATED`
+
+`RELEASE 1.12 WP02 — REPLACEMENT TERRA IMPLEMENTATION AUTHORITY: READY TO CREATE`
+
+Terminal:
+
+`RELEASE 1.12 WP02 — REPOSITORY PATH DESIGNATION AUTHORITY COMPLETE`
+
+Blocked:
+
+`RELEASE 1.12 WP02 — REPOSITORY PATH DESIGNATION AUTHORITY BLOCKED`

--- a/eng/azure-cli/r1.12-deployment/wp02-deployment/a1.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp02-deployment/a1.ps1
@@ -1,0 +1,71 @@
+$ErrorActionPreference = 'Stop'
+
+$runId = [guid]::NewGuid().ToString('N')
+$imageTag = "aiq-release-112-wp02:$runId"
+$containerName = "aiq-release-112-wp02-$runId"
+$port = 18501
+
+Write-Host "WP02_IMAGE=$imageTag"
+Write-Host "WP02_CONTAINER=$containerName"
+Write-Host "WP02_PORT=$port"
+
+Write-Host '=== BUILD IMAGE ==='
+docker build --tag $imageTag .
+Write-Host "WP02_DOCKER_BUILD_EXIT_CODE=$LASTEXITCODE"
+if ($LASTEXITCODE -ne 0) { throw 'Docker build failed.' }
+
+Write-Host '=== START REPLAY/STREAMLIT COMPOSITION ==='
+docker run --detach --name $containerName --publish "127.0.0.1:${port}:8501" `
+  --env 'TwelveData__ApiKey=container-validation-placeholder' `
+  --env 'Dataset__Target=SIMULATED-USD' `
+  --env 'Dataset__From=2024-01-01T00:00:00.0000000+00:00' `
+  --env 'Dataset__To=2024-01-01T00:03:00.0000000+00:00' `
+  --env 'Worker__Mode=Replay' `
+  --env 'Worker__Replay__ReplayIdentity=simulated-live-replay-v1' `
+  --env 'Worker__Replay__Target=SIMULATED-USD' `
+  --env 'Worker__Replay__StartingTick=0' `
+  --env 'Worker__Replay__RequestedObservationCount=3' `
+  $imageTag
+Write-Host "WP02_DOCKER_RUN_EXIT_CODE=$LASTEXITCODE"
+if ($LASTEXITCODE -ne 0) { throw 'Container start failed.' }
+
+Write-Host '=== WAIT FOR STREAMLIT LISTENER ==='
+$listenerReady = $false
+for ($attempt = 1; $attempt -le 30; $attempt++) {
+  try {
+    $response = Invoke-WebRequest -UseBasicParsing -TimeoutSec 5 "http://127.0.0.1:$port/"
+    Write-Host "WP02_LISTENER_ATTEMPT=$attempt"
+    Write-Host "WP02_LISTENER_STATUS_CODE=$($response.StatusCode)"
+    $listenerReady = $response.StatusCode -eq 200
+    if ($listenerReady) { break }
+  }
+  catch {
+    Write-Host "WP02_LISTENER_ATTEMPT=$attempt"
+    Write-Host "WP02_LISTENER_ERROR=$($_.Exception.Message)"
+  }
+  Start-Sleep -Seconds 2
+}
+Write-Host "WP02_LISTENER_READY=$listenerReady"
+if (-not $listenerReady) { throw 'Streamlit listener did not become reachable.' }
+
+Write-Host '=== PROCESS TOPOLOGY ==='
+docker top $containerName -eo pid,ppid,comm,args
+Write-Host "WP02_DOCKER_TOP_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== SECRET-SAFE RUNTIME LOGS ==='
+docker logs $containerName
+Write-Host "WP02_DOCKER_LOGS_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== GRACEFUL STOP ==='
+docker stop --time 15 $containerName
+Write-Host "WP02_DOCKER_STOP_EXIT_CODE=$LASTEXITCODE"
+
+$exitCode = docker inspect --format '{{.State.ExitCode}}' $containerName
+Write-Host "WP02_CONTAINER_EXIT_CODE=$exitCode"
+docker rm $containerName
+Write-Host "WP02_DOCKER_REMOVE_EXIT_CODE=$LASTEXITCODE"
+
+$containerAfter = docker ps --all --quiet --filter "name=^/$containerName$"
+Write-Host "WP02_CONTAINER_PRESENT_AFTER_CLEANUP=$(-not [string]::IsNullOrWhiteSpace($containerAfter))"
+docker image inspect $imageTag *> $null
+Write-Host "WP02_IMAGE_RETAINED_FOR_FAILURE_BATCH=$($LASTEXITCODE -eq 0)"

--- a/eng/azure-cli/r1.12-deployment/wp02-deployment/a10.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp02-deployment/a10.ps1
@@ -1,0 +1,139 @@
+$ErrorActionPreference = 'Stop'
+
+$runId = [guid]::NewGuid().ToString('N')
+$imageTag = "aiq-release-112-wp02-postmerge:$runId"
+$normalContainer = "aiq-wp02-normal-$runId"
+$missingContainer = "aiq-wp02-missing-$runId"
+$childFailureContainer = "aiq-wp02-child-fail-$runId"
+$port = 18501
+$syntheticValue = 'container-validation-placeholder'
+
+function Show-Code([string]$name) {
+    Write-Host "$name=$LASTEXITCODE"
+}
+
+try {
+    Write-Host '=== CLEAN POST-MERGE IMAGE BUILD ==='
+    & docker build --pull --tag $imageTag .
+    Show-Code 'WP02_POSTMERGE_BUILD_EXIT_CODE'
+
+    Write-Host '=== NORMAL RUNTIME: WORKER + STREAMLIT + LISTENER ==='
+    & docker run --detach --name $normalContainer --publish "${port}:8501" `
+      -e "TwelveData__ApiKey=$syntheticValue" `
+      -e 'Dataset__Target=SIMULATED-USD' `
+      -e 'Dataset__From=2024-01-01T00:00:00.0000000+00:00' `
+      -e 'Dataset__To=2024-01-01T00:03:00.0000000+00:00' `
+      -e 'Worker__Replay__ReplayIdentity=simulated-live-replay-v1' `
+      -e 'Worker__Replay__Target=SIMULATED-USD' `
+      -e 'Worker__Replay__StartingTick=0' `
+      -e 'Worker__Replay__RequestedObservationCount=3' `
+      $imageTag
+    Show-Code 'WP02_POSTMERGE_NORMAL_RUN_EXIT_CODE'
+
+    $healthy = $false
+    for ($attempt = 1; $attempt -le 20; $attempt++) {
+        Write-Host "WP02_POSTMERGE_HEALTH_ATTEMPT=$attempt"
+        try {
+            $response = Invoke-WebRequest -UseBasicParsing -Uri "http://127.0.0.1:$port/" -TimeoutSec 5
+            Write-Host "WP02_POSTMERGE_LISTENER_STATUS_CODE=$($response.StatusCode)"
+            if ($response.StatusCode -eq 200) {
+                $healthy = $true
+                break
+            }
+        } catch {
+            Write-Host "WP02_POSTMERGE_LISTENER_ERROR=$($_.Exception.Message)"
+        }
+        Start-Sleep -Seconds 1
+    }
+    Write-Host "WP02_POSTMERGE_LISTENER_REACHABLE=$healthy"
+    if (-not $healthy) { throw 'Normal Streamlit listener did not become reachable.' }
+
+    & docker top $normalContainer
+    Show-Code 'WP02_POSTMERGE_NORMAL_PROCESS_TOPOLOGY_EXIT_CODE'
+
+    & docker logs $normalContainer
+    Show-Code 'WP02_POSTMERGE_NORMAL_LOGS_EXIT_CODE'
+
+    Write-Host '=== NORMAL GRACEFUL STOP ==='
+    & docker stop --time 10 $normalContainer
+    Show-Code 'WP02_POSTMERGE_NORMAL_STOP_EXIT_CODE'
+
+    $normalExit = & docker wait $normalContainer
+    Write-Host "WP02_POSTMERGE_NORMAL_CONTAINER_EXIT_CODE=$normalExit"
+    Show-Code 'WP02_POSTMERGE_NORMAL_WAIT_EXIT_CODE'
+
+    Write-Host '=== MISSING REQUIRED CONFIGURATION: FAIL CLOSED ==='
+    & docker run --detach --name $missingContainer `
+      -e 'Dataset__Target=SIMULATED-USD' `
+      -e 'Dataset__From=2024-01-01T00:00:00.0000000+00:00' `
+      -e 'Dataset__To=2024-01-01T00:03:00.0000000+00:00' `
+      -e 'Worker__Replay__ReplayIdentity=simulated-live-replay-v1' `
+      -e 'Worker__Replay__Target=SIMULATED-USD' `
+      -e 'Worker__Replay__StartingTick=0' `
+      -e 'Worker__Replay__RequestedObservationCount=3' `
+      $imageTag
+    Show-Code 'WP02_POSTMERGE_MISSING_RUN_EXIT_CODE'
+
+    $missingExit = & docker wait $missingContainer
+    Write-Host "WP02_POSTMERGE_MISSING_CONTAINER_EXIT_CODE=$missingExit"
+    Show-Code 'WP02_POSTMERGE_MISSING_WAIT_EXIT_CODE'
+
+    & docker logs $missingContainer
+    Show-Code 'WP02_POSTMERGE_MISSING_LOGS_EXIT_CODE'
+
+    Write-Host '=== REQUIRED STREAMLIT CHILD FAILURE ==='
+    & docker run --detach --name $childFailureContainer `
+      -e "TwelveData__ApiKey=$syntheticValue" `
+      -e 'Dataset__Target=SIMULATED-USD' `
+      -e 'Dataset__From=2024-01-01T00:00:00.0000000+00:00' `
+      -e 'Dataset__To=2024-01-01T00:03:00.0000000+00:00' `
+      -e 'Worker__Replay__ReplayIdentity=simulated-live-replay-v1' `
+      -e 'Worker__Replay__Target=SIMULATED-USD' `
+      -e 'Worker__Replay__StartingTick=0' `
+      -e 'Worker__Replay__RequestedObservationCount=3' `
+      -e 'STREAMLIT_SERVER_PORT=not-a-port' `
+      $imageTag
+    Show-Code 'WP02_POSTMERGE_CHILD_FAILURE_RUN_EXIT_CODE'
+
+    $childExit = & docker wait $childFailureContainer
+    Write-Host "WP02_POSTMERGE_CHILD_FAILURE_CONTAINER_EXIT_CODE=$childExit"
+    Show-Code 'WP02_POSTMERGE_CHILD_FAILURE_WAIT_EXIT_CODE'
+
+    & docker logs $childFailureContainer
+    Show-Code 'WP02_POSTMERGE_CHILD_FAILURE_LOGS_EXIT_CODE'
+
+    Write-Host '=== NON-PRINTING IMAGE SECRET ISOLATION ==='
+    $historyText = (& docker history --no-trunc $imageTag 2>&1 | Out-String)
+    Write-Host "WP02_POSTMERGE_HISTORY_EXIT_CODE=$LASTEXITCODE"
+    Write-Host "WP02_POSTMERGE_HISTORY_CONTAINS_SYNTHETIC_VALUE=$($historyText.Contains($syntheticValue))"
+    Write-Host "WP02_POSTMERGE_HISTORY_CONTAINS_API_KEY_NAME=$($historyText.Contains('TwelveData__ApiKey'))"
+
+    $inspectText = (& docker image inspect $imageTag 2>&1 | Out-String)
+    Write-Host "WP02_POSTMERGE_IMAGE_INSPECT_EXIT_CODE=$LASTEXITCODE"
+    Write-Host "WP02_POSTMERGE_CONFIG_CONTAINS_SYNTHETIC_VALUE=$($inspectText.Contains($syntheticValue))"
+    Write-Host "WP02_POSTMERGE_CONFIG_CONTAINS_API_KEY_NAME=$($inspectText.Contains('TwelveData__ApiKey'))"
+}
+finally {
+    Write-Host '=== EXPLICIT WP02 TEMPORARY DOCKER CLEANUP ==='
+    foreach ($container in @($normalContainer, $missingContainer, $childFailureContainer)) {
+        & docker rm --force $container *> $null
+        Write-Host "WP02_POSTMERGE_CONTAINER_REMOVE_EXIT_CODE=$LASTEXITCODE"
+    }
+
+    & docker image rm $imageTag *> $null
+    Write-Host "WP02_POSTMERGE_IMAGE_REMOVE_EXIT_CODE=$LASTEXITCODE"
+
+    $ownedContainers = @(
+        & docker ps --all --filter 'name=aiq-wp02-' --format '{{.Names}}' |
+        Where-Object { $_ -and $_.Trim() }
+    ).Count
+    $ownedImages = @(
+        & docker image ls --format '{{.Repository}}:{{.Tag}}' |
+        Where-Object { $_ -like 'aiq-release-112-wp02-postmerge:*' }
+    ).Count
+    $listener = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
+
+    Write-Host "WP02_POSTMERGE_OWNED_CONTAINERS_REMAINING=$ownedContainers"
+    Write-Host "WP02_POSTMERGE_OWNED_IMAGES_REMAINING=$ownedImages"
+    Write-Host "WP02_POSTMERGE_PORT_18501_LISTENER_PRESENT=$([bool]$listener)"
+}

--- a/eng/azure-cli/r1.12-deployment/wp02-deployment/a2.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp02-deployment/a2.ps1
@@ -1,0 +1,21 @@
+$containerName = 'aiq-release-112-wp02-d6199dd0478343b7ad81a414143704d5'
+
+Write-Host '=== CONTAINER STATE ==='
+docker inspect --format '{{json .State}}' $containerName
+Write-Host "WP02_DIAG_INSPECT_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== PROCESS TOPOLOGY ==='
+docker top $containerName -eo pid,ppid,stat,comm,args
+Write-Host "WP02_DIAG_TOP_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== COMPLETE CONTAINER LOGS ==='
+docker logs $containerName
+Write-Host "WP02_DIAG_LOGS_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== IMAGE ENTRYPOINT / ENVIRONMENT ==='
+docker image inspect --format '{{json .Config}}' 'aiq-release-112-wp02:d6199dd0478343b7ad81a414143704d5'
+Write-Host "WP02_DIAG_IMAGE_INSPECT_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== PORT PUBLISHING ==='
+docker port $containerName
+Write-Host "WP02_DIAG_PORT_EXIT_CODE=$LASTEXITCODE"

--- a/eng/azure-cli/r1.12-deployment/wp02-deployment/a3.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp02-deployment/a3.ps1
@@ -1,0 +1,68 @@
+$ErrorActionPreference = 'Stop'
+
+$runId = [guid]::NewGuid().ToString('N')
+$imageTag = "aiq-release-112-wp02:$runId"
+$containerName = "aiq-release-112-wp02-$runId"
+$port = 18501
+
+Write-Host "WP02_IMAGE=$imageTag"
+Write-Host "WP02_CONTAINER=$containerName"
+Write-Host "WP02_PORT=$port"
+
+Write-Host '=== BUILD ICU-COMPATIBLE IMAGE ==='
+docker build --tag $imageTag .
+Write-Host "WP02_DOCKER_BUILD_EXIT_CODE=$LASTEXITCODE"
+if ($LASTEXITCODE -ne 0) { throw 'Docker build failed.' }
+
+Write-Host '=== START REPLAY/STREAMLIT COMPOSITION ==='
+docker run --detach --name $containerName --publish "127.0.0.1:${port}:8501" `
+  --env 'TwelveData__ApiKey=container-validation-placeholder' `
+  --env 'Dataset__Target=SIMULATED-USD' `
+  --env 'Dataset__From=2024-01-01T00:00:00.0000000+00:00' `
+  --env 'Dataset__To=2024-01-01T00:03:00.0000000+00:00' `
+  --env 'Worker__Mode=Replay' `
+  --env 'Worker__Replay__ReplayIdentity=simulated-live-replay-v1' `
+  --env 'Worker__Replay__Target=SIMULATED-USD' `
+  --env 'Worker__Replay__StartingTick=0' `
+  --env 'Worker__Replay__RequestedObservationCount=3' `
+  $imageTag
+Write-Host "WP02_DOCKER_RUN_EXIT_CODE=$LASTEXITCODE"
+if ($LASTEXITCODE -ne 0) { throw 'Container start failed.' }
+
+$listenerReady = $false
+for ($attempt = 1; $attempt -le 30; $attempt++) {
+  try {
+    $response = Invoke-WebRequest -UseBasicParsing -TimeoutSec 5 "http://127.0.0.1:$port/"
+    Write-Host "WP02_LISTENER_ATTEMPT=$attempt"
+    Write-Host "WP02_LISTENER_STATUS_CODE=$($response.StatusCode)"
+    $listenerReady = $response.StatusCode -eq 200
+    if ($listenerReady) { break }
+  } catch {
+    Write-Host "WP02_LISTENER_ATTEMPT=$attempt"
+    Write-Host "WP02_LISTENER_ERROR=$($_.Exception.Message)"
+  }
+  Start-Sleep -Seconds 2
+}
+Write-Host "WP02_LISTENER_READY=$listenerReady"
+if (-not $listenerReady) { throw 'Streamlit listener did not become reachable.' }
+
+Write-Host '=== PROCESS TOPOLOGY ==='
+docker top $containerName -eo pid,ppid,stat,comm,args
+Write-Host "WP02_DOCKER_TOP_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== SECRET-SAFE RUNTIME LOGS ==='
+docker logs $containerName
+Write-Host "WP02_DOCKER_LOGS_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== GRACEFUL STOP AND CLEANUP ==='
+docker stop --time 15 $containerName
+Write-Host "WP02_DOCKER_STOP_EXIT_CODE=$LASTEXITCODE"
+$exitCode = docker inspect --format '{{.State.ExitCode}}' $containerName
+Write-Host "WP02_CONTAINER_EXIT_CODE=$exitCode"
+docker rm $containerName
+Write-Host "WP02_DOCKER_REMOVE_EXIT_CODE=$LASTEXITCODE"
+
+$containerAfter = docker ps --all --quiet --filter "name=^/$containerName$"
+Write-Host "WP02_CONTAINER_PRESENT_AFTER_CLEANUP=$(-not [string]::IsNullOrWhiteSpace($containerAfter))"
+docker image inspect $imageTag *> $null
+Write-Host "WP02_IMAGE_RETAINED_FOR_NEXT_BATCH=$($LASTEXITCODE -eq 0)"

--- a/eng/azure-cli/r1.12-deployment/wp02-deployment/a4.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp02-deployment/a4.ps1
@@ -1,0 +1,68 @@
+$ErrorActionPreference = 'Stop'
+
+$runId = [guid]::NewGuid().ToString('N')
+$imageTag = "aiq-release-112-wp02:$runId"
+$containerName = "aiq-release-112-wp02-$runId"
+$port = 18501
+
+Write-Host "WP02_IMAGE=$imageTag"
+Write-Host "WP02_CONTAINER=$containerName"
+Write-Host "WP02_PORT=$port"
+
+Write-Host '=== BUILD ICU-COMPATIBLE IMAGE ==='
+docker build --tag $imageTag .
+Write-Host "WP02_DOCKER_BUILD_EXIT_CODE=$LASTEXITCODE"
+if ($LASTEXITCODE -ne 0) { throw 'Docker build failed.' }
+
+Write-Host '=== START REPLAY/STREAMLIT COMPOSITION ==='
+docker run --detach --name $containerName --publish "127.0.0.1:${port}:8501" `
+  --env 'TwelveData__ApiKey=container-validation-placeholder' `
+  --env 'Dataset__Target=SIMULATED-USD' `
+  --env 'Dataset__From=2024-01-01T00:00:00.0000000+00:00' `
+  --env 'Dataset__To=2024-01-01T00:03:00.0000000+00:00' `
+  --env 'Worker__Mode=Replay' `
+  --env 'Worker__Replay__ReplayIdentity=simulated-live-replay-v1' `
+  --env 'Worker__Replay__Target=SIMULATED-USD' `
+  --env 'Worker__Replay__StartingTick=0' `
+  --env 'Worker__Replay__RequestedObservationCount=3' `
+  $imageTag
+Write-Host "WP02_DOCKER_RUN_EXIT_CODE=$LASTEXITCODE"
+if ($LASTEXITCODE -ne 0) { throw 'Container start failed.' }
+
+$listenerReady = $false
+for ($attempt = 1; $attempt -le 30; $attempt++) {
+  try {
+    $response = Invoke-WebRequest -UseBasicParsing -TimeoutSec 5 "http://127.0.0.1:$port/"
+    Write-Host "WP02_LISTENER_ATTEMPT=$attempt"
+    Write-Host "WP02_LISTENER_STATUS_CODE=$($response.StatusCode)"
+    $listenerReady = $response.StatusCode -eq 200
+    if ($listenerReady) { break }
+  } catch {
+    Write-Host "WP02_LISTENER_ATTEMPT=$attempt"
+    Write-Host "WP02_LISTENER_ERROR=$($_.Exception.Message)"
+  }
+  Start-Sleep -Seconds 2
+}
+Write-Host "WP02_LISTENER_READY=$listenerReady"
+if (-not $listenerReady) { throw 'Streamlit listener did not become reachable.' }
+
+Write-Host '=== PROCESS TOPOLOGY ==='
+docker top $containerName -eo pid,ppid,stat,comm,args
+Write-Host "WP02_DOCKER_TOP_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== SECRET-SAFE RUNTIME LOGS ==='
+docker logs $containerName
+Write-Host "WP02_DOCKER_LOGS_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== GRACEFUL STOP AND CLEANUP ==='
+docker stop --time 15 $containerName
+Write-Host "WP02_DOCKER_STOP_EXIT_CODE=$LASTEXITCODE"
+$exitCode = docker inspect --format '{{.State.ExitCode}}' $containerName
+Write-Host "WP02_CONTAINER_EXIT_CODE=$exitCode"
+docker rm $containerName
+Write-Host "WP02_DOCKER_REMOVE_EXIT_CODE=$LASTEXITCODE"
+
+$containerAfter = docker ps --all --quiet --filter "name=^/$containerName$"
+Write-Host "WP02_CONTAINER_PRESENT_AFTER_CLEANUP=$(-not [string]::IsNullOrWhiteSpace($containerAfter))"
+docker image inspect $imageTag *> $null
+Write-Host "WP02_IMAGE_RETAINED_FOR_NEXT_BATCH=$($LASTEXITCODE -eq 0)"

--- a/eng/azure-cli/r1.12-deployment/wp02-deployment/a5.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp02-deployment/a5.ps1
@@ -1,0 +1,66 @@
+$ErrorActionPreference = 'Stop'
+
+$imageTag = 'aiq-release-112-wp02:0d334987effa480f8176abff08f8d7a5'
+$runId = [guid]::NewGuid().ToString('N')
+$missingSecretContainer = "aiq-release-112-wp02-missing-$runId"
+$streamlitFailureContainer = "aiq-release-112-wp02-streamlit-fail-$runId"
+
+function Show-ExitCode([string]$name) {
+    Write-Host "$name=$LASTEXITCODE"
+}
+
+& docker image inspect $imageTag *> $null
+Show-ExitCode 'WP02_FAILURE_IMAGE_PRECHECK_EXIT_CODE'
+
+Write-Host '=== MISSING REQUIRED SECRET: MUST FAIL CLOSED ==='
+& docker run --detach --name $missingSecretContainer `
+  -e 'Dataset__Target=SIMULATED-USD' `
+  -e 'Dataset__From=2024-01-01T00:00:00.0000000+00:00' `
+  -e 'Dataset__To=2024-01-01T00:03:00.0000000+00:00' `
+  -e 'Worker__Replay__ReplayIdentity=simulated-live-replay-v1' `
+  -e 'Worker__Replay__Target=SIMULATED-USD' `
+  -e 'Worker__Replay__StartingTick=0' `
+  -e 'Worker__Replay__RequestedObservationCount=3' `
+  $imageTag
+Show-ExitCode 'WP02_MISSING_SECRET_RUN_EXIT_CODE'
+
+$missingExit = & docker wait $missingSecretContainer
+$missingWaitInvocationExit = $LASTEXITCODE
+Write-Host "WP02_MISSING_SECRET_CONTAINER_EXIT_CODE=$missingExit"
+Write-Host "WP02_MISSING_SECRET_WAIT_EXIT_CODE=$missingWaitInvocationExit"
+
+& docker logs $missingSecretContainer
+Show-ExitCode 'WP02_MISSING_SECRET_LOGS_EXIT_CODE'
+
+& docker rm $missingSecretContainer
+Show-ExitCode 'WP02_MISSING_SECRET_REMOVE_EXIT_CODE'
+
+Write-Host '=== REQUIRED STREAMLIT CHILD FAILURE: MUST TERMINATE CONTAINER ==='
+& docker run --detach --name $streamlitFailureContainer `
+  -e 'TwelveData__ApiKey=container-validation-placeholder' `
+  -e 'Dataset__Target=SIMULATED-USD' `
+  -e 'Dataset__From=2024-01-01T00:00:00.0000000+00:00' `
+  -e 'Dataset__To=2024-01-01T00:03:00.0000000+00:00' `
+  -e 'Worker__Replay__ReplayIdentity=simulated-live-replay-v1' `
+  -e 'Worker__Replay__Target=SIMULATED-USD' `
+  -e 'Worker__Replay__StartingTick=0' `
+  -e 'Worker__Replay__RequestedObservationCount=3' `
+  -e 'STREAMLIT_SERVER_PORT=not-a-port' `
+  $imageTag
+Show-ExitCode 'WP02_STREAMLIT_FAILURE_RUN_EXIT_CODE'
+
+$streamlitExit = & docker wait $streamlitFailureContainer
+$streamlitWaitInvocationExit = $LASTEXITCODE
+Write-Host "WP02_STREAMLIT_FAILURE_CONTAINER_EXIT_CODE=$streamlitExit"
+Write-Host "WP02_STREAMLIT_FAILURE_WAIT_EXIT_CODE=$streamlitWaitInvocationExit"
+
+& docker logs $streamlitFailureContainer
+Show-ExitCode 'WP02_STREAMLIT_FAILURE_LOGS_EXIT_CODE'
+
+& docker rm $streamlitFailureContainer
+Show-ExitCode 'WP02_STREAMLIT_FAILURE_REMOVE_EXIT_CODE'
+
+$missingPresent = (& docker ps --all --filter "name=$missingSecretContainer" --format '{{.ID}}').Length -gt 0
+$streamlitPresent = (& docker ps --all --filter "name=$streamlitFailureContainer" --format '{{.ID}}').Length -gt 0
+Write-Host "WP02_MISSING_SECRET_CONTAINER_PRESENT_AFTER_CLEANUP=$missingPresent"
+Write-Host "WP02_STREAMLIT_FAILURE_CONTAINER_PRESENT_AFTER_CLEANUP=$streamlitPresent"

--- a/eng/azure-cli/r1.12-deployment/wp02-deployment/a6.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp02-deployment/a6.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = 'Stop'
+$imageTag = 'aiq-release-112-wp02:0d334987effa480f8176abff08f8d7a5'
+$syntheticValue = 'container-validation-placeholder'
+
+& docker image inspect $imageTag *> $null
+Write-Host "WP02_SECURITY_IMAGE_PRECHECK_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== IMAGE HISTORY: NON-PRINTING SYNTHETIC-SECRET SCAN ==='
+$history = & docker history --no-trunc $imageTag 2>&1
+$historyExit = $LASTEXITCODE
+$historyText = $history | Out-String
+Write-Host "WP02_SECURITY_HISTORY_EXIT_CODE=$historyExit"
+Write-Host "WP02_SECURITY_HISTORY_CONTAINS_SYNTHETIC_VALUE=$($historyText.Contains($syntheticValue))"
+Write-Host "WP02_SECURITY_HISTORY_CONTAINS_API_KEY_NAME=$($historyText.Contains('TwelveData__ApiKey'))"
+
+Write-Host '=== IMAGE CONFIGURATION: NON-PRINTING SYNTHETIC-SECRET SCAN ==='
+$imageInspect = & docker image inspect $imageTag 2>&1
+$imageInspectExit = $LASTEXITCODE
+$imageInspectText = $imageInspect | Out-String
+Write-Host "WP02_SECURITY_IMAGE_INSPECT_EXIT_CODE=$imageInspectExit"
+Write-Host "WP02_SECURITY_IMAGE_CONFIG_CONTAINS_SYNTHETIC_VALUE=$($imageInspectText.Contains($syntheticValue))"
+Write-Host "WP02_SECURITY_IMAGE_CONFIG_CONTAINS_API_KEY_NAME=$($imageInspectText.Contains('TwelveData__ApiKey'))"
+
+Write-Host '=== OWNED CONTAINER / LISTENER RESIDUE ==='
+$ownedContainers = & docker ps --all --filter 'name=aiq-release-112-wp02-' --format '{{.Names}}'
+$ownedContainersExit = $LASTEXITCODE
+$ownedContainerCount = @($ownedContainers | Where-Object { $_ -and $_.Trim() }).Count
+Write-Host "WP02_SECURITY_OWNED_CONTAINER_LIST_EXIT_CODE=$ownedContainersExit"
+Write-Host "WP02_SECURITY_OWNED_CONTAINER_COUNT=$ownedContainerCount"
+
+$listener = Get-NetTCPConnection -LocalPort 18501 -State Listen -ErrorAction SilentlyContinue
+Write-Host "WP02_SECURITY_PORT_18501_LISTENER_PRESENT=$([bool]$listener)"
+
+Write-Host '=== REMOVE ONLY THE WP02 LOCAL IMAGE ==='
+& docker image rm $imageTag
+Write-Host "WP02_SECURITY_IMAGE_REMOVE_EXIT_CODE=$LASTEXITCODE"
+
+& docker image inspect $imageTag *> $null
+$imagePresent = $LASTEXITCODE -eq 0
+Write-Host "WP02_SECURITY_IMAGE_PRESENT_AFTER_CLEANUP=$imagePresent"

--- a/eng/azure-cli/r1.12-deployment/wp02-deployment/a7.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp02-deployment/a7.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Continue'
+
+Write-Host '=== WP02 LOCAL IMAGE INVENTORY ==='
+& docker image ls --format '{{.Repository}}:{{.Tag}} {{.ID}}' | Select-String 'aiq-release-112-wp02'
+Write-Host "WP02_IMAGE_LIST_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== WP02 CONTAINER INVENTORY ==='
+& docker ps --all --format '{{.Names}} {{.Image}} {{.Status}}' | Select-String 'aiq-release-112-wp02'
+Write-Host "WP02_CONTAINER_LIST_EXIT_CODE=$LASTEXITCODE"
+
+Write-Host '=== PORT 18501 LISTENER ==='
+$listener = Get-NetTCPConnection -LocalPort 18501 -State Listen -ErrorAction SilentlyContinue
+Write-Host "WP02_PORT_18501_LISTENER_PRESENT=$([bool]$listener)"

--- a/eng/azure-cli/r1.12-deployment/wp02-deployment/a8.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp02-deployment/a8.ps1
@@ -1,0 +1,25 @@
+$ErrorActionPreference = 'Stop'
+
+$imageTags = @(
+  'aiq-release-112-wp02:3bb3532ad1b94a74a08db8cc3593332d',
+  'aiq-release-112-wp02:6fe0ffdfd7a1412ca6bc94ec9f9f9a6b',
+  'aiq-release-112-wp02:d6199dd0478343b7ad81a414143704d5'
+)
+
+$syntheticValue = 'container-validation-placeholder'
+
+foreach ($imageTag in $imageTags) {
+    Write-Host "=== $imageTag ==="
+
+    $historyText = (& docker history --no-trunc $imageTag 2>&1 | Out-String)
+    $historyExit = $LASTEXITCODE
+    Write-Host "WP02_SECURITY_HISTORY_EXIT_CODE=$historyExit"
+    Write-Host "WP02_SECURITY_HISTORY_CONTAINS_SYNTHETIC_VALUE=$($historyText.Contains($syntheticValue))"
+    Write-Host "WP02_SECURITY_HISTORY_CONTAINS_API_KEY_NAME=$($historyText.Contains('TwelveData__ApiKey'))"
+
+    $inspectText = (& docker image inspect $imageTag 2>&1 | Out-String)
+    $inspectExit = $LASTEXITCODE
+    Write-Host "WP02_SECURITY_IMAGE_INSPECT_EXIT_CODE=$inspectExit"
+    Write-Host "WP02_SECURITY_CONFIG_CONTAINS_SYNTHETIC_VALUE=$($inspectText.Contains($syntheticValue))"
+    Write-Host "WP02_SECURITY_CONFIG_CONTAINS_API_KEY_NAME=$($inspectText.Contains('TwelveData__ApiKey'))"
+}

--- a/eng/azure-cli/r1.12-deployment/wp02-deployment/a9.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp02-deployment/a9.ps1
@@ -1,0 +1,28 @@
+$ErrorActionPreference = 'Stop'
+
+$imageTags = @(
+  'aiq-release-112-wp02:3bb3532ad1b94a74a08db8cc3593332d',
+  'aiq-release-112-wp02:6fe0ffdfd7a1412ca6bc94ec9f9f9a6b',
+  'aiq-release-112-wp02:d6199dd0478343b7ad81a414143704d5'
+)
+
+foreach ($imageTag in $imageTags) {
+    & docker image rm $imageTag
+    Write-Host "WP02_LOCAL_IMAGE_REMOVE_EXIT_CODE=$LASTEXITCODE"
+}
+
+$remaining = @(
+    & docker image ls --format '{{.Repository}}:{{.Tag}}' |
+    Where-Object { $_ -like 'aiq-release-112-wp02:*' }
+).Count
+
+$ownedContainers = @(
+    & docker ps --all --filter 'name=aiq-release-112-wp02-' --format '{{.Names}}' |
+    Where-Object { $_ -and $_.Trim() }
+).Count
+
+$listener = Get-NetTCPConnection -LocalPort 18501 -State Listen -ErrorAction SilentlyContinue
+
+Write-Host "WP02_LOCAL_IMAGES_REMAINING=$remaining"
+Write-Host "WP02_OWNED_CONTAINERS_REMAINING=$ownedContainers"
+Write-Host "WP02_PORT_18501_LISTENER_PRESENT=$([bool]$listener)"


### PR DESCRIPTION
Publishes the reconciled 32-path Release 1.12 local-controls package: 10 PowerShell deployment controls and 22 Markdown prompter/control artifacts. The duplicate root helper is intentionally excluded, along with the two requester-only authority prompts. No Azure, Docker, GHCR, provider, lifecycle, package, or schema changes.