### PR TITLE
Release 1.12 WP03: GHCR publication and Azure F1 deployment automation

### DIFF
--- a/eng/azure-cli/r1.12-deployment/wp03-ghcr-azure-f1/cleanup-f1-reference.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp03-ghcr-azure-f1/cleanup-f1-reference.ps1
@@ -1,0 +1,20 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)] [string] $ResourceGroup
+)
+
+$ErrorActionPreference = 'Stop'
+Write-Host '=== VERIFY OWNED WP03 RESOURCE GROUP ==='
+$group = & az group show --name $ResourceGroup --query '{name:name,location:location,tags:tags}' --output json | ConvertFrom-Json
+Write-Host "WP03_CLEANUP_PREDELETE_READ_EXIT_CODE=$LASTEXITCODE"
+if ($LASTEXITCODE -ne 0) { throw 'Resource group does not exist or cannot be read.' }
+if ($group.tags.wp -ne 'WP03' -or $group.tags.initiative -ne 'Release-1.12' -or $group.tags.recurringCost -ne '0') { throw 'Refusing to delete a resource group without the exact WP03 ownership tags.' }
+
+if ($PSCmdlet.ShouldProcess($ResourceGroup, 'Delete verified WP03 resource group')) {
+    & az group delete --name $ResourceGroup --yes --no-wait
+    Write-Host "WP03_CLEANUP_DELETE_REQUEST_EXIT_CODE=$LASTEXITCODE"
+    if ($LASTEXITCODE -ne 0) { throw 'Resource-group deletion request failed.' }
+}
+else {
+    Write-Host 'WP03_CLEANUP_DELETE_REQUEST=WHATIF'
+}

--- a/eng/azure-cli/r1.12-deployment/wp03-ghcr-azure-f1/deploy-f1-reference.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp03-ghcr-azure-f1/deploy-f1-reference.ps1
@@ -1,0 +1,45 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9-]{0,89}$')] [string] $ResourceGroup,
+    [Parameter(Mandatory)] [ValidatePattern('^[A-Za-z0-9-]{1,60}$')] [string] $PlanName,
+    [Parameter(Mandatory)] [ValidatePattern('^[a-z0-9][a-z0-9-]{1,58}[a-z0-9]$')] [string] $WebAppName,
+    [Parameter(Mandatory)] [ValidatePattern('^ghcr\.io/.+@sha256:[a-f0-9]{64}$')] [string] $Image,
+    [string] $Location = 'westcentralus'
+)
+
+$ErrorActionPreference = 'Stop'
+if ($Location -ne 'westcentralus') { throw 'WP03 is limited to West Central US.' }
+function Write-ExitCode([string] $Name) { Write-Host "$Name=$LASTEXITCODE" }
+
+Write-Host '=== ACCOUNT / TARGET PRECHECK ==='
+& az account show --query '{name:name,state:state,isDefault:isDefault}' --output json
+Write-ExitCode 'WP03_AZ_ACCOUNT_READ_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'Azure authentication is required in the interactive operator session.' }
+
+Write-Host '=== CREATE OR RECONCILE OWNED RESOURCE GROUP ==='
+& az group create --name $ResourceGroup --location $Location --tags initiative='Release-1.12' wp='WP03' owner='Terra' recurringCost='0' --output none
+Write-ExitCode 'WP03_RESOURCE_GROUP_CREATE_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'Resource group operation failed.' }
+
+Write-Host '=== CREATE OR RECONCILE LINUX F1 PLAN ==='
+& az appservice plan create --name $PlanName --resource-group $ResourceGroup --location $Location --sku F1 --is-linux --output none
+Write-ExitCode 'WP03_F1_PLAN_CREATE_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'F1 Linux App Service plan operation failed.' }
+
+Write-Host '=== CREATE OR RECONCILE PUBLIC GHCR WEB APP ==='
+& az webapp create --name $WebAppName --resource-group $ResourceGroup --plan $PlanName --container-image-name $Image --https-only true --output none
+Write-ExitCode 'WP03_WEBAPP_CREATE_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'Web App create operation failed.' }
+
+Write-Host '=== APPLY WP03 DEPLOYMENT SETTINGS ONLY ==='
+& az webapp config appsettings set --name $WebAppName --resource-group $ResourceGroup --settings WEBSITES_ENABLE_APP_SERVICE_STORAGE=true WEBSITES_PORT=8501 --output none
+Write-ExitCode 'WP03_DEPLOYMENT_SETTINGS_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'WP03 deployment settings operation failed.' }
+
+& az webapp config container set --name $WebAppName --resource-group $ResourceGroup --container-image-name $Image --container-registry-url https://ghcr.io --output none
+Write-ExitCode 'WP03_CONTAINER_CONFIGURATION_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'Container configuration operation failed.' }
+
+Write-Host 'WP03_DEPLOYMENT_SCOPE=F1_Free_WestCentralUS_PublicGHCR_PersistentHome'
+Write-Host 'WP03_SECRET_CONFIGURATION=NOT_IMPLEMENTED_WP05_OWNED'
+Write-Host 'WP03_SQLITE_INITIALIZATION=NOT_IMPLEMENTED_WP04_OWNED'

--- a/eng/azure-cli/r1.12-deployment/wp03-ghcr-azure-f1/publish-ghcr-image.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp03-ghcr-azure-f1/publish-ghcr-image.ps1
@@ -1,0 +1,54 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [ValidatePattern('^[a-z0-9][a-z0-9._-]*$')] [string] $GitHubOwner,
+    [Parameter(Mandatory)] [ValidatePattern('^[a-z0-9][a-z0-9._-]*$')] [string] $ImageName,
+    [Parameter(Mandatory)] [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9._-]*$')] [string] $Tag,
+    [switch] $InteractiveLogin
+)
+
+$ErrorActionPreference = 'Stop'
+$image = "ghcr.io/$GitHubOwner/$ImageName`:$Tag"
+
+function Write-ExitCode([string] $Name) { Write-Host "$Name=$LASTEXITCODE" }
+
+if ($InteractiveLogin) {
+    Write-Host '=== INTERACTIVE GHCR LOGIN ==='
+    Write-Host 'Docker will prompt locally. Do not provide credentials to this script or chat.'
+    & docker login ghcr.io
+    Write-ExitCode 'WP03_GHCR_LOGIN_EXIT_CODE'
+    if ($LASTEXITCODE -ne 0) { throw 'GHCR login failed.' }
+}
+
+Write-Host '=== BUILD RELEASE IMAGE ==='
+& docker build --pull --tag $image .
+Write-ExitCode 'WP03_GHCR_BUILD_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'Docker build failed.' }
+
+Write-Host '=== PUSH GHCR IMAGE ==='
+& docker push $image
+Write-ExitCode 'WP03_GHCR_PUSH_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'GHCR push failed.' }
+
+Write-Host '=== READ IMMUTABLE DIGEST ==='
+$digest = (& docker buildx imagetools inspect $image --format '{{json .Manifest.Digest}}').Trim('"')
+Write-ExitCode 'WP03_GHCR_DIGEST_READ_EXIT_CODE'
+if ([string]::IsNullOrWhiteSpace($digest) -or -not $digest.StartsWith('sha256:')) { throw 'Published image digest was not available.' }
+$immutableImage = "ghcr.io/$GitHubOwner/$ImageName@$digest"
+Write-Host "WP03_GHCR_IMAGE=$image"
+Write-Host "WP03_GHCR_IMMUTABLE_IMAGE=$immutableImage"
+
+Write-Host '=== VERIFY ANONYMOUS MANIFEST ==='
+$configRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('aiq-wp03-ghcr-' + [guid]::NewGuid().ToString('N'))
+try {
+    New-Item -ItemType Directory -Path $configRoot | Out-Null
+    $previousDockerConfig = $env:DOCKER_CONFIG
+    $env:DOCKER_CONFIG = $configRoot
+    & docker manifest inspect $immutableImage | Out-Null
+    Write-ExitCode 'WP03_GHCR_ANONYMOUS_MANIFEST_EXIT_CODE'
+    if ($LASTEXITCODE -ne 0) { throw 'Image is not anonymously available; make the GHCR package public before Azure deployment.' }
+}
+finally {
+    $env:DOCKER_CONFIG = $previousDockerConfig
+    if (Test-Path -LiteralPath $configRoot) { Remove-Item -LiteralPath $configRoot -Recurse -Force }
+    Write-Host "WP03_GHCR_TEMP_CONFIG_PRESENT_AFTER_CLEANUP=$(Test-Path -LiteralPath $configRoot)"
+}

--- a/eng/azure-cli/r1.12-deployment/wp03-ghcr-azure-f1/verify-f1-reference.ps1
+++ b/eng/azure-cli/r1.12-deployment/wp03-ghcr-azure-f1/verify-f1-reference.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $ResourceGroup,
+    [Parameter(Mandatory)] [string] $PlanName,
+    [Parameter(Mandatory)] [string] $WebAppName
+)
+
+$ErrorActionPreference = 'Stop'
+function Write-ExitCode([string] $Name) { Write-Host "$Name=$LASTEXITCODE" }
+
+Write-Host '=== F1 PLAN ==='
+& az appservice plan show --name $PlanName --resource-group $ResourceGroup --query '{name:name,location:location,sku:sku.name,tier:sku.tier,kind:kind}' --output json
+Write-ExitCode 'WP03_VERIFY_PLAN_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'Plan read-back failed.' }
+
+Write-Host '=== WEB APP RUNTIME ==='
+& az webapp show --name $WebAppName --resource-group $ResourceGroup --query '{name:name,location:location,httpsOnly:httpsOnly,state:state,kind:kind,publicNetworkAccess:publicNetworkAccess}' --output json
+Write-ExitCode 'WP03_VERIFY_WEBAPP_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'Web App read-back failed.' }
+
+Write-Host '=== CONTAINER IMAGE ==='
+& az webapp config container show --name $WebAppName --resource-group $ResourceGroup --output json
+Write-ExitCode 'WP03_VERIFY_CONTAINER_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'Container configuration read-back failed.' }
+
+Write-Host '=== NON-SECRET DEPLOYMENT SETTINGS ==='
+& az webapp config appsettings list --name $WebAppName --resource-group $ResourceGroup --query "[?name=='WEBSITES_ENABLE_APP_SERVICE_STORAGE' || name=='WEBSITES_PORT'].{name:name,value:value}" --output json
+Write-ExitCode 'WP03_VERIFY_SETTINGS_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'Deployment-settings read-back failed.' }
+
+Write-Host '=== OWNED RESOURCE INVENTORY ==='
+& az resource list --resource-group $ResourceGroup --query "[].{name:name,type:type,location:location,kind:kind,sku:sku.name}" --output json
+Write-ExitCode 'WP03_VERIFY_RESOURCE_INVENTORY_EXIT_CODE'
+if ($LASTEXITCODE -ne 0) { throw 'Resource inventory read-back failed.' }
+
+Write-Host 'WP03_VERIFY_BOUNDARY=No secrets, SQLite initialization, provider automation, or public-health claims are validated by WP03.'


### PR DESCRIPTION
Implements the literal WP03 automation contract with exactly four new PowerShell scripts: GHCR publish/digest/public-manifest validation, West Central US Linux F1 deployment, read-only verification, and ownership-tag-guarded cleanup.\n\nEmpirical execution used public GHCR image digest sha256:51889b708ce5ab251bb8174e94c56bf8ddae06a716f169d2d912de05c09d2c65 and a Free F1 app-service plan. SQLite initialization, secrets, provider behavior, and public health are deferred to WP04–WP06.\n\nMerge is not authorized by this authority.